### PR TITLE
[AI] Keep net worth stable across transfer dates

### DIFF
--- a/packages/desktop-client/e2e/page-models/account-page.ts
+++ b/packages/desktop-client/e2e/page-models/account-page.ts
@@ -275,7 +275,7 @@ export class AccountPage {
       await notesCell.click();
       const notesInput = notesCell.getByRole('combobox');
       await this.selectInputText(notesInput);
-      await notesInput.pressSequentially(transaction.notes);
+      await notesInput.fill(transaction.notes);
       await this.page.keyboard.press('Tab');
     }
 

--- a/packages/desktop-client/src/components/reports/spreadsheets/net-worth-spreadsheet.test.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/net-worth-spreadsheet.test.ts
@@ -266,6 +266,36 @@ describe('net worth transfers', () => {
     expect(report.graphData.data.at(-1)).toMatchObject({ checking: 100_000 });
   });
 
+  it('keeps a transfer neutral when it spans the entire report range', async () => {
+    const report = await runReport({
+      accounts,
+      accountQueryResults: [90_000, [], 0, []],
+      linkedTransfers: [
+        {
+          id: 'checking-transfer',
+          account: 'checking',
+          amount: -10_000,
+          date: '2026-06-30',
+          transfer_id: 'savings-transfer',
+        },
+        {
+          id: 'savings-transfer',
+          account: 'savings',
+          amount: 10_000,
+          date: '2026-09-01',
+          transfer_id: 'checking-transfer',
+        },
+      ],
+      start: '2026-08',
+      end: '2026-08',
+      earliestTransactionDate: '2026-06-30',
+    });
+
+    expect(report.graphData.data.map(point => point.y)).toEqual([
+      100_000, 100_000,
+    ]);
+  });
+
   it.each([
     {
       interval: 'Daily',

--- a/packages/desktop-client/src/components/reports/spreadsheets/net-worth-spreadsheet.test.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/net-worth-spreadsheet.test.ts
@@ -1,0 +1,346 @@
+import {
+  clearServer,
+  initServer,
+} from '@actual-app/core/platform/client/connection';
+import type { AccountEntity } from '@actual-app/core/types/models';
+import { enUS } from 'date-fns/locale';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { createSpreadsheet } from './net-worth-spreadsheet';
+
+vi.mock(
+  '@actual-app/core/platform/client/connection',
+  () => import('#mocks/connection'),
+);
+
+type SpreadsheetData = Parameters<
+  Parameters<ReturnType<typeof createSpreadsheet>>[1]
+>[0];
+
+type LinkedTransfer = {
+  id: string;
+  account: string;
+  amount: number;
+  date: string;
+  transfer_id: string;
+};
+
+type AccountQueryResult = number | Array<{ date: string; amount: number }>;
+
+const accounts = [
+  createAccount('checking', 'Checking'),
+  createAccount('savings', 'Savings'),
+] satisfies AccountEntity[];
+
+function createAccount(id: string, name: string): AccountEntity {
+  return {
+    id,
+    name,
+    offbudget: 0,
+    closed: 0,
+    sort_order: 0,
+    last_reconciled: null,
+    tombstone: 0,
+    account_group_id: null,
+    account_id: null,
+    bank: null,
+    bankName: null,
+    bankId: null,
+    mask: null,
+    official_name: null,
+    balance_current: null,
+    balance_available: null,
+    balance_limit: null,
+    account_sync_source: null,
+    last_sync: null,
+    bank_sync_status: null,
+  };
+}
+
+async function runReport({
+  accounts,
+  accountQueryResults,
+  linkedTransfers = [],
+  start = '2026-07',
+  end = '2026-08',
+  interval = 'Monthly',
+  earliestTransactionDate = '2026-07-01',
+}: {
+  accounts: AccountEntity[];
+  accountQueryResults: AccountQueryResult[];
+  linkedTransfers?: LinkedTransfer[];
+  start?: string;
+  end?: string;
+  interval?: string;
+  earliestTransactionDate?: string;
+}) {
+  const remainingAccountResults = [...accountQueryResults];
+
+  initServer({
+    'make-filters-from-conditions': async () => ({ filters: [] }),
+    'get-earliest-transaction': async () => ({
+      date: earliestTransactionDate,
+    }),
+    query: async query => {
+      if (query.selectExpressions.includes('transfer_id')) {
+        const transferFilter = query.filterExpressions.find(
+          expression => 'transfer_id' in expression,
+        );
+        const accountIds = getOneOfValues(transferFilter?.account);
+        const transactionIds = getOneOfValues(transferFilter?.id);
+        const endDate = getUpperBound(transferFilter?.date);
+
+        return {
+          data: linkedTransfers.filter(
+            leg =>
+              (accountIds.length === 0 || accountIds.includes(leg.account)) &&
+              (transactionIds.length === 0 ||
+                transactionIds.includes(leg.id)) &&
+              (!endDate || leg.date <= endDate),
+          ),
+          dependencies: [],
+        };
+      }
+
+      const data = remainingAccountResults.shift();
+      if (data === undefined) {
+        throw new Error('Unexpected account query');
+      }
+      return { data, dependencies: [] };
+    },
+  });
+
+  let report: SpreadsheetData | undefined;
+  const spreadsheet = createSpreadsheet(
+    start,
+    end,
+    accounts,
+    [],
+    'and',
+    enUS,
+    interval,
+    '0',
+    value => String(value),
+  );
+
+  // The net worth factory does not use its spreadsheet dependency.
+  await spreadsheet(undefined as never, data => {
+    report = data;
+  });
+
+  if (!report) {
+    throw new Error('Spreadsheet did not produce report data');
+  }
+  return report;
+}
+
+function getOneOfValues(value: unknown) {
+  if (
+    typeof value === 'object' &&
+    value !== null &&
+    '$oneof' in value &&
+    Array.isArray(value.$oneof)
+  ) {
+    return value.$oneof.filter(item => typeof item === 'string');
+  }
+  return [];
+}
+
+function getUpperBound(value: unknown) {
+  if (
+    typeof value === 'object' &&
+    value !== null &&
+    '$lte' in value &&
+    typeof value.$lte === 'string'
+  ) {
+    return value.$lte;
+  }
+  return null;
+}
+
+afterEach(async () => {
+  await clearServer();
+});
+
+describe('net worth transfers', () => {
+  it('keeps a linked transfer neutral when its two legs cross months', async () => {
+    const report = await runReport({
+      accounts,
+      accountQueryResults: [
+        100_000,
+        [{ date: '2026-07', amount: -10_000 }],
+        0,
+        [{ date: '2026-08', amount: 10_000 }],
+      ],
+      linkedTransfers: [
+        {
+          id: 'checking-transfer',
+          account: 'checking',
+          amount: -10_000,
+          date: '2026-07-31',
+          transfer_id: 'savings-transfer',
+        },
+        {
+          id: 'savings-transfer',
+          account: 'savings',
+          amount: 10_000,
+          date: '2026-08-01',
+          transfer_id: 'checking-transfer',
+        },
+      ],
+    });
+
+    expect(report.graphData.data.map(point => point.y)).toEqual([
+      100_000, 100_000,
+    ]);
+  });
+
+  it('preserves a real expense as a net worth loss', async () => {
+    const report = await runReport({
+      accounts: [accounts[0]],
+      accountQueryResults: [100_000, [{ date: '2026-07', amount: -10_000 }]],
+    });
+
+    expect(report.graphData.data.map(point => point.y)).toEqual([
+      90_000, 90_000,
+    ]);
+  });
+
+  it('preserves a transfer out of the selected account set as a loss', async () => {
+    const report = await runReport({
+      accounts: [accounts[0]],
+      accountQueryResults: [100_000, [{ date: '2026-07', amount: -10_000 }]],
+      linkedTransfers: [
+        {
+          id: 'checking-transfer',
+          account: 'checking',
+          amount: -10_000,
+          date: '2026-07-31',
+          transfer_id: 'savings-transfer',
+        },
+        {
+          id: 'savings-transfer',
+          account: 'savings',
+          amount: 10_000,
+          date: '2026-08-01',
+          transfer_id: 'checking-transfer',
+        },
+      ],
+    });
+
+    expect(report.graphData.data.map(point => point.y)).toEqual([
+      90_000, 90_000,
+    ]);
+  });
+
+  it('keeps funds in the source account until a later counterpart arrives', async () => {
+    const report = await runReport({
+      accounts,
+      accountQueryResults: [
+        100_000,
+        [{ date: '2026-08', amount: -10_000 }],
+        0,
+        [],
+      ],
+      linkedTransfers: [
+        {
+          id: 'checking-transfer',
+          account: 'checking',
+          amount: -10_000,
+          date: '2026-08-31',
+          transfer_id: 'savings-transfer',
+        },
+        {
+          id: 'savings-transfer',
+          account: 'savings',
+          amount: 10_000,
+          date: '2026-09-01',
+          transfer_id: 'checking-transfer',
+        },
+      ],
+    });
+
+    expect(report.graphData.data.map(point => point.y)).toEqual([
+      100_000, 100_000,
+    ]);
+    expect(report.graphData.data.at(-1)).toMatchObject({ checking: 100_000 });
+  });
+
+  it.each([
+    {
+      interval: 'Daily',
+      start: '2016-07',
+      end: '2016-07',
+      earliestTransactionDate: '2016-07-30',
+      earlierDate: '2016-07-30',
+      laterDate: '2016-07-31',
+      earlierBalanceDate: '2016-07-30',
+      laterBalanceDate: '2016-07-31',
+    },
+    {
+      interval: 'Weekly',
+      start: '2016-07',
+      end: '2016-07',
+      earliestTransactionDate: '2016-07-30',
+      earlierDate: '2016-07-30',
+      laterDate: '2016-07-31',
+      earlierBalanceDate: '2016-07-30',
+      laterBalanceDate: '2016-07-31',
+    },
+    {
+      interval: 'Yearly',
+      start: '2016-01',
+      end: '2017-01',
+      earliestTransactionDate: '2016-12-31',
+      earlierDate: '2016-12-31',
+      laterDate: '2017-01-01',
+      earlierBalanceDate: '2016',
+      laterBalanceDate: '2017',
+    },
+  ])(
+    'keeps a linked transfer neutral across $interval intervals',
+    async ({
+      interval,
+      start,
+      end,
+      earliestTransactionDate,
+      earlierDate,
+      laterDate,
+      earlierBalanceDate,
+      laterBalanceDate,
+    }) => {
+      const report = await runReport({
+        accounts,
+        accountQueryResults: [
+          100_000,
+          [{ date: earlierBalanceDate, amount: -10_000 }],
+          0,
+          [{ date: laterBalanceDate, amount: 10_000 }],
+        ],
+        linkedTransfers: [
+          {
+            id: 'checking-transfer',
+            account: 'checking',
+            amount: -10_000,
+            date: earlierDate,
+            transfer_id: 'savings-transfer',
+          },
+          {
+            id: 'savings-transfer',
+            account: 'savings',
+            amount: 10_000,
+            date: laterDate,
+            transfer_id: 'checking-transfer',
+          },
+        ],
+        start,
+        end,
+        interval,
+        earliestTransactionDate,
+      });
+
+      const totals = report.graphData.data.map(point => point.y);
+      expect(totals).toEqual(totals.map(() => 100_000));
+    },
+  );
+});

--- a/packages/desktop-client/src/components/reports/spreadsheets/net-worth-spreadsheet.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/net-worth-spreadsheet.ts
@@ -238,7 +238,8 @@ export function createSpreadsheet(
       allTransferLegs = [...transferLegs, ...counterpartLegs];
     }
 
-    // Keep in-transit funds in the source account until the linked leg arrives.
+    // Prevent paired internal transfers from changing net worth between their
+    // two posting dates.
     alignInternalTransferDates(data, allTransferLegs, {
       startDate,
       endDate,

--- a/packages/desktop-client/src/components/reports/spreadsheets/net-worth-spreadsheet.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/net-worth-spreadsheet.ts
@@ -4,6 +4,7 @@ import { q } from '@actual-app/core/shared/query';
 import type {
   AccountEntity,
   RuleConditionEntity,
+  TransactionEntity,
 } from '@actual-app/core/types/models';
 import * as d from 'date-fns';
 import type { Locale } from 'date-fns';
@@ -17,6 +18,27 @@ import { aqlQuery } from '#queries/aqlQuery';
 type Balance = {
   date: string;
   amount: number;
+};
+
+type AccountBalanceData = {
+  id: string;
+  name: string;
+  balances: Record<string, Balance>;
+  starting: number;
+};
+
+type TransferLeg = Pick<
+  TransactionEntity,
+  'id' | 'account' | 'amount' | 'date'
+> & {
+  transfer_id: string;
+};
+
+type IntervalRange = {
+  startDate: string;
+  endDate: string;
+  interval: string;
+  firstDayOfWeekIdx: string;
 };
 
 export function createSpreadsheet(
@@ -94,7 +116,24 @@ export function createSpreadsheet(
       }
     }
 
-    const data = await Promise.all(
+    const accountIds = accounts.map(account => account.id);
+    const transferLegsPromise =
+      accountIds.length === 0
+        ? Promise.resolve<TransferLeg[]>([])
+        : aqlQuery(
+            q('transactions')
+              .filter({
+                [conditionsOpKey]: filters,
+              })
+              .filter({
+                account: { $oneof: accountIds },
+                transfer_id: { $ne: null },
+                date: { $lte: endDate },
+              })
+              .select(['id', 'account', 'amount', 'date', 'transfer_id']),
+          ).then(({ data }: { data: TransferLeg[] }) => data);
+
+    const accountDataPromise = Promise.all(
       accounts.map(async acct => {
         const [starting, balances]: [number, Balance[]] = await Promise.all([
           aqlQuery(
@@ -168,6 +207,44 @@ export function createSpreadsheet(
         };
       }),
     );
+    const [data, transferLegs] = await Promise.all([
+      accountDataPromise,
+      transferLegsPromise,
+    ]);
+
+    const loadedTransferIds = new Set(transferLegs.map(leg => leg.id));
+    const missingCounterpartIds = [
+      ...new Set(
+        transferLegs
+          .map(leg => leg.transfer_id)
+          .filter(id => !loadedTransferIds.has(id)),
+      ),
+    ];
+
+    let allTransferLegs = transferLegs;
+    if (missingCounterpartIds.length > 0) {
+      const counterpartLegs: TransferLeg[] = await aqlQuery(
+        q('transactions')
+          .filter({
+            [conditionsOpKey]: filters,
+          })
+          .filter({
+            id: { $oneof: missingCounterpartIds },
+            account: { $oneof: accountIds },
+            transfer_id: { $ne: null },
+          })
+          .select(['id', 'account', 'amount', 'date', 'transfer_id']),
+      ).then(({ data }: { data: TransferLeg[] }) => data);
+      allTransferLegs = [...transferLegs, ...counterpartLegs];
+    }
+
+    // Keep in-transit funds in the source account until the linked leg arrives.
+    alignInternalTransferDates(data, allTransferLegs, {
+      startDate,
+      endDate,
+      interval,
+      firstDayOfWeekIdx,
+    });
 
     setData(
       recalculate(
@@ -183,13 +260,106 @@ export function createSpreadsheet(
   };
 }
 
+function alignInternalTransferDates(
+  data: AccountBalanceData[],
+  transferLegs: TransferLeg[],
+  range: IntervalRange,
+) {
+  const accountsById = new Map(data.map(account => [account.id, account]));
+  const transfersById = new Map(transferLegs.map(leg => [leg.id, leg]));
+  const processed = new Set<string>();
+
+  transferLegs.forEach(leg => {
+    if (processed.has(leg.id)) {
+      return;
+    }
+
+    const counterpart = transfersById.get(leg.transfer_id);
+    if (
+      !counterpart ||
+      counterpart.transfer_id !== leg.id ||
+      counterpart.account === leg.account ||
+      counterpart.amount + leg.amount !== 0 ||
+      !accountsById.has(leg.account) ||
+      !accountsById.has(counterpart.account)
+    ) {
+      return;
+    }
+
+    processed.add(leg.id);
+    processed.add(counterpart.id);
+
+    if (leg.date === counterpart.date) {
+      return;
+    }
+
+    const [earlier, later] =
+      leg.date < counterpart.date ? [leg, counterpart] : [counterpart, leg];
+
+    const account = accountsById.get(earlier.account);
+    if (account) {
+      moveTransferLeg(account, earlier, later.date, range);
+    }
+  });
+}
+
+function moveTransferLeg(
+  account: AccountBalanceData,
+  leg: TransferLeg,
+  laterDate: string,
+  range: IntervalRange,
+) {
+  const { startDate, endDate, interval, firstDayOfWeekIdx } = range;
+  if (laterDate < startDate) {
+    return;
+  }
+
+  if (leg.date < startDate) {
+    account.starting -= leg.amount;
+  } else {
+    if (leg.date > endDate) {
+      return;
+    }
+    const originalKey = getIntervalKey(leg.date, interval, firstDayOfWeekIdx);
+    const originalBalance = account.balances[originalKey];
+    if (!originalBalance) {
+      return;
+    }
+    originalBalance.amount -= leg.amount;
+  }
+
+  if (laterDate > endDate) {
+    return;
+  }
+
+  const intervalKey = getIntervalKey(laterDate, interval, firstDayOfWeekIdx);
+  const balance = account.balances[intervalKey];
+  if (balance) {
+    balance.amount += leg.amount;
+  } else {
+    account.balances[intervalKey] = { date: intervalKey, amount: leg.amount };
+  }
+}
+
+function getIntervalKey(
+  date: string,
+  interval: string,
+  firstDayOfWeekIdx: string,
+) {
+  if (interval === 'Daily') {
+    return date;
+  }
+  if (interval === 'Weekly') {
+    return monthUtils.weekFromDate(date, firstDayOfWeekIdx);
+  }
+  if (interval === 'Yearly') {
+    return date.slice(0, 4);
+  }
+  return monthUtils.getMonth(date);
+}
+
 function recalculate(
-  data: Array<{
-    id: string;
-    name: string;
-    balances: Record<string, Balance>;
-    starting: number;
-  }>,
+  data: AccountBalanceData[],
   startDate: string,
   endDate: string,
   locale: Locale,

--- a/upcoming-release-notes/fix-cross-month-net-worth-transfers.md
+++ b/upcoming-release-notes/fix-cross-month-net-worth-transfers.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [sambai-dev]
+---
+
+Keep net worth reports stable while linked transfers cross reporting intervals


### PR DESCRIPTION
## Description

If the two sides of an internal transfer were dated in different reporting periods, the net worth report counted one side before the other. This made net worth appear to rise or fall even though no money had entered or left the selected accounts.

This updates the report calculation so a linked transfer stays neutral when both accounts are included. For reporting purposes, the earlier side is held until its counterpart appears. Ordinary expenses and transfers involving an account outside the report are unchanged.

I used OpenAI Codex to help implement and review this change. I reviewed the final diff and regression coverage.

## Related issue(s)

Fixes #8633.

## Testing

- Added eight regression tests covering daily, weekly, monthly, and yearly reports, including transfers that begin before or finish after the visible range.
- Confirmed that ordinary expenses and transfers outside the selected account set still affect net worth normally.
- Reproduced the issue with the budget attached to #8633. The current release showed 8,000 in July and 4,000 in August, while the PR preview shows 4,000 in both months.
- Ran `yarn workspace @actual-app/web test net-worth-spreadsheet.test.ts`: 8 tests passed.
- Ran the monorepo typecheck and targeted formatting and lint checks on the changed files.
- All GitHub CI checks passed, including unit tests, functional and visual E2E tests, and platform builds.

## Checklist

- [x] Release notes added
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 42 | 13.6 MB → 13.6 MB (+3.23 kB) | +0.02%
loot-core | 1 | 4.64 MB | 0%
api | 2 | 3.85 MB | 0%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
42 | 13.6 MB → 13.6 MB (+3.23 kB) | +0.02%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/reports/spreadsheets/net-worth-spreadsheet.ts` | 📈 +3.23 kB (+57.48%) | 5.62 kB → 8.85 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/ReportRouter.js | 1.43 MB → 1.43 MB (+3.23 kB) | +0.22%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.58 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/DateSelect.js | 2.37 MB | 0%
static/js/FormulaEditor.js | 766.35 kB | 0%
static/js/ManageRules.js | 71.66 kB | 0%
static/js/NotesTagFormatter.js | 25.94 kB | 0%
static/js/PayeeRuleCountLabel.js | 12.81 kB | 0%
static/js/ScheduleEditForm.js | 75.41 kB | 0%
static/js/SchedulesTable.js | 171.25 kB | 0%
static/js/TourHost.js | 169.22 kB | 0%
static/js/TourProvider.js | 1.54 kB | 0%
static/js/TransactionEdit.js | 221.38 kB | 0%
static/js/TransactionList.js | 166.98 kB | 0%
static/js/Value.js | 1.79 MB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/ca.js | 170.64 kB | 0%
static/js/client.js | 452.05 kB | 0%
static/js/columns.js | 673.28 kB | 0%
static/js/de.js | 185 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/en.js | 245.91 kB | 0%
static/js/es.js | 164.81 kB | 0%
static/js/fr.js | 179.04 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 151.67 kB | 0%
static/js/months.js | 574.72 kB | 0%
static/js/narrow.js | 290.52 kB | 0%
static/js/nb-NO.js | 135.46 kB | 0%
static/js/nl.js | 151.78 kB | 0%
static/js/pl.js | 136.39 kB | 0%
static/js/pt-BR.js | 178.2 kB | 0%
static/js/ru.js | 209.6 kB | 0%
static/js/theme.js | 31.1 kB | 0%
static/js/uk.js | 201.42 kB | 0%
static/js/useFormatList.js | 10.22 kB | 0%
static/js/useLocalPref.js | 97.2 kB | 0%
static/js/useReducedMotion.js | 594 B | 0%
static/js/wide.js | 274.04 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 106.8 kB | 0%
static/js/zh-Hant.js | 130.92 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.64 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.CokRHpI5.js | 4.64 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.85 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.85 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.16 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->