### PR TITLE
[WIP] [AI] Make the budget page scroll as one page with a sticky titlebar

### DIFF
--- a/packages/desktop-client/e2e/page-models/budget-page.ts
+++ b/packages/desktop-client/e2e/page-models/budget-page.ts
@@ -10,7 +10,7 @@ export class BudgetPage {
   readonly budgetTableTotals: Locator;
   readonly selectedMonthButton: Locator;
   readonly nextMonthButton: Locator;
-  readonly budgetTableScrollContainer: Locator;
+  readonly pageScrollContainer: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -20,25 +20,23 @@ export class BudgetPage {
     this.budgetTableTotals = this.budgetTable.getByTestId('budget-totals');
     this.selectedMonthButton = page.getByTestId('selected-budget-month');
     this.nextMonthButton = page.getByTitle('Next month');
-    this.budgetTableScrollContainer = page.getByTestId(
-      'budget-table-scroll-container',
-    );
+    this.pageScrollContainer = page.getByTestId('page-scroll-container');
   }
 
   async getScrollTop() {
-    return this.budgetTableScrollContainer.evaluate(el => el.scrollTop);
+    return this.pageScrollContainer.evaluate(el => el.scrollTop);
   }
 
   async scrollToBottom() {
-    await this.budgetTableScrollContainer.evaluate(el => {
+    await this.pageScrollContainer.evaluate(el => {
       el.scrollTop = el.scrollHeight;
     });
   }
 
   /**
    * Wait for the budget page to finish loading. The budget-table is
-   * inside AutoSizer which returns null until layout provides width/
-   * height, so it only appears after the page has fully mounted.
+   * inside AutoSizer which returns null until layout provides a width,
+   * so it only appears after the page has fully mounted.
    */
   async waitFor(...options: Parameters<Locator['waitFor']>) {
     await this.budgetTable.waitFor(...options);
@@ -186,10 +184,10 @@ export class BudgetPage {
     // position is not changed before the click handler captures it.
     const clicked = await this.page.evaluate(() => {
       const container = document.querySelector(
-        '[data-testid="budget-table-scroll-container"]',
+        '[data-testid="page-scroll-container"]',
       );
       if (!container) {
-        throw new Error('Budget scroll container not found');
+        throw new Error('Page scroll container not found');
       }
       const containerRect = container.getBoundingClientRect();
       const cells = container.querySelectorAll<HTMLElement>(

--- a/packages/desktop-client/src/components/FinancesApp.tsx
+++ b/packages/desktop-client/src/components/FinancesApp.tsx
@@ -227,6 +227,7 @@ export function FinancesApp() {
               <MobilePageHeaderProvider>
                 <View
                   ref={scrollableRef}
+                  data-testid="page-scroll-container"
                   style={{
                     flex: 1,
                     overflow: 'auto',
@@ -236,10 +237,9 @@ export function FinancesApp() {
                   <Titlebar
                     style={{
                       WebkitAppRegion: 'drag',
-                      position: 'absolute',
+                      position: 'sticky',
                       top: 0,
-                      left: 0,
-                      right: 0,
+                      backgroundColor: theme.pageBackground,
                       zIndex: 1000,
                     }}
                   />

--- a/packages/desktop-client/src/components/budget/BudgetPageHeader.tsx
+++ b/packages/desktop-client/src/components/budget/BudgetPageHeader.tsx
@@ -7,7 +7,6 @@ import { View } from '@actual-app/components/view';
 import { useGlobalPref } from '#hooks/useGlobalPref';
 
 import { MonthPicker } from './MonthPicker';
-import { getScrollbarWidth } from './util';
 
 type BudgetPageHeaderProps = {
   startMonth: string;
@@ -32,7 +31,7 @@ export const BudgetPageHeader = memo<BudgetPageHeaderProps>(
       >
         <View
           style={{
-            marginRight: 5 + getScrollbarWidth() - offsetMultipleMonths,
+            marginRight: 5 - offsetMultipleMonths,
           }}
         >
           <MonthPicker

--- a/packages/desktop-client/src/components/budget/BudgetTable.tsx
+++ b/packages/desktop-client/src/components/budget/BudgetTable.tsx
@@ -1,8 +1,6 @@
-import React, { useLayoutEffect, useMemo, useRef, useState } from 'react';
+import React, { useLayoutEffect, useMemo, useState } from 'react';
 import type { KeyboardEvent } from 'react';
 
-import { styles } from '@actual-app/components/styles';
-import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 import { q } from '@actual-app/core/shared/query';
 import type {
@@ -15,18 +13,14 @@ import { SchedulesProvider } from '#hooks/useCachedSchedules';
 import { useCategories } from '#hooks/useCategories';
 import { useGlobalPref } from '#hooks/useGlobalPref';
 import { useLocalPref } from '#hooks/useLocalPref';
+import { useScrollableRef } from '#hooks/useScrollListener';
 
 import { BudgetCategories } from './BudgetCategories';
 import { BudgetSummaries } from './BudgetSummaries';
 import { BudgetTotals } from './BudgetTotals';
 import { MonthsProvider } from './MonthsContext';
 import type { MonthBounds } from './MonthsContext';
-import {
-  findSortDown,
-  findSortUp,
-  getScrollbarWidth,
-  separateGroups,
-} from './util';
+import { findSortDown, findSortUp, separateGroups } from './util';
 
 type BudgetTableProps = {
   type: string;
@@ -90,17 +84,17 @@ export function BudgetTable(props: BudgetTableProps) {
     null,
   );
 
-  const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const scrollableRef = useScrollableRef();
 
   useLayoutEffect(() => {
     const savedScrollPosition = sessionStorage.getItem(
       'budget-scroll-position',
     );
-    if (savedScrollPosition != null && scrollContainerRef.current) {
-      scrollContainerRef.current.scrollTop = Number(savedScrollPosition);
+    if (savedScrollPosition != null && scrollableRef.current) {
+      scrollableRef.current.scrollTop = Number(savedScrollPosition);
       sessionStorage.removeItem('budget-scroll-position');
     }
-  }, []);
+  }, [scrollableRef]);
 
   const onEditMonth = (id: string, month: string) => {
     setEditing(id ? { id, cell: month } : null);
@@ -234,10 +228,10 @@ export function BudgetTable(props: BudgetTableProps) {
   };
 
   const _onShowActivity = (id: string, month?: string) => {
-    if (scrollContainerRef.current) {
+    if (scrollableRef.current) {
       sessionStorage.setItem(
         'budget-scroll-position',
-        String(scrollContainerRef.current.scrollTop),
+        String(scrollableRef.current.scrollTop),
       );
     }
     onShowActivity(id, month);
@@ -246,21 +240,7 @@ export function BudgetTable(props: BudgetTableProps) {
   const schedulesQuery = useMemo(() => q('schedules').select('*'), []);
 
   return (
-    <View
-      data-testid="budget-table"
-      style={{
-        flex: 1,
-        ...(styles.lightScrollbar && {
-          '& ::-webkit-scrollbar': {
-            backgroundColor: 'transparent',
-          },
-          '& ::-webkit-scrollbar-thumb:vertical': {
-            backgroundColor: theme.pageTextSubdued,
-            // changed from tableHeaderBackground. pageTextSubdued is always visible on pageBackground
-          },
-        }),
-      }}
-    >
+    <View data-testid="budget-table" style={{ flex: 1 }}>
       <View
         style={{
           flexDirection: 'row',
@@ -269,7 +249,7 @@ export function BudgetTable(props: BudgetTableProps) {
           // This is necessary to align with the table because the
           // table has this padding to allow the shadow to show
           paddingLeft: 5,
-          paddingRight: 5 + getScrollbarWidth(),
+          paddingRight: 5,
         }}
       >
         <View style={{ width: 200 + 100 * categoryExpandedState }} />
@@ -295,41 +275,31 @@ export function BudgetTable(props: BudgetTableProps) {
           collapseAllCategories={collapseAllCategories}
         />
         <View
-          ref={scrollContainerRef}
-          data-testid="budget-table-scroll-container"
           style={{
-            overflowY: 'scroll',
-            overflowAnchor: 'none',
-            flex: 1,
+            flexShrink: 0,
             paddingLeft: 5,
             paddingRight: 5,
           }}
+          onKeyDown={onKeyDown}
         >
-          <View
-            style={{
-              flexShrink: 0,
-            }}
-            onKeyDown={onKeyDown}
-          >
-            <SchedulesProvider query={schedulesQuery}>
-              <BudgetCategories
-                categoryGroups={categoryGroups}
-                editingCell={editing}
-                onEditMonth={onEditMonth}
-                onEditName={onEditName}
-                onSaveCategory={onSaveCategory}
-                onSaveGroup={onSaveGroup}
-                onDeleteCategory={onDeleteCategory}
-                onDeleteGroup={onDeleteGroup}
-                onReorderCategory={_onReorderCategory}
-                onReorderGroup={_onReorderGroup}
-                onBudgetAction={onBudgetAction}
-                onShowActivity={_onShowActivity}
-                onApplyBudgetTemplatesInGroup={onApplyBudgetTemplatesInGroup}
-                onSortCategories={onSortCategories}
-              />
-            </SchedulesProvider>
-          </View>
+          <SchedulesProvider query={schedulesQuery}>
+            <BudgetCategories
+              categoryGroups={categoryGroups}
+              editingCell={editing}
+              onEditMonth={onEditMonth}
+              onEditName={onEditName}
+              onSaveCategory={onSaveCategory}
+              onSaveGroup={onSaveGroup}
+              onDeleteCategory={onDeleteCategory}
+              onDeleteGroup={onDeleteGroup}
+              onReorderCategory={_onReorderCategory}
+              onReorderGroup={_onReorderGroup}
+              onBudgetAction={onBudgetAction}
+              onShowActivity={_onShowActivity}
+              onApplyBudgetTemplatesInGroup={onApplyBudgetTemplatesInGroup}
+              onSortCategories={onSortCategories}
+            />
+          </SchedulesProvider>
         </View>
       </MonthsProvider>
     </View>

--- a/packages/desktop-client/src/components/budget/BudgetTotals.tsx
+++ b/packages/desktop-client/src/components/budget/BudgetTotals.tsx
@@ -17,7 +17,6 @@ import { View } from '@actual-app/components/view';
 import { useGlobalPref } from '#hooks/useGlobalPref';
 
 import { RenderMonths } from './RenderMonths';
-import { getScrollbarWidth } from './util';
 
 import { useBudgetComponents } from '.';
 
@@ -68,7 +67,7 @@ export const BudgetTotals = memo(function BudgetTotals({
         flexShrink: 0,
         boxShadow: styles.cardShadow,
         marginLeft: 5,
-        marginRight: 5 + getScrollbarWidth(),
+        marginRight: 5,
         borderRadius: '4px 4px 0 0',
         borderBottom: '1px solid ' + theme.tableBorder,
         '& .hover-visible': {

--- a/packages/desktop-client/src/components/budget/DynamicBudgetTable.tsx
+++ b/packages/desktop-client/src/components/budget/DynamicBudgetTable.tsx
@@ -36,13 +36,11 @@ function getNumPossibleMonths(width: number, categoryWidth: number) {
 
 type DynamicBudgetTableProps = {
   width: number;
-  height: number;
 } & AutoSizingBudgetTableProps;
 
 const DynamicBudgetTable = ({
   type,
   width,
-  height,
   prewarmStartMonth,
   startMonth,
   maxMonths = 3,
@@ -142,9 +140,8 @@ const DynamicBudgetTable = ({
     <View
       style={{
         width,
-        height,
         alignItems: 'center',
-        opacity: width <= 0 || height <= 0 ? 0 : 1,
+        opacity: width <= 0 ? 0 : 1,
       }}
     >
       <View style={{ width: '100%', maxWidth }}>
@@ -183,12 +180,12 @@ type AutoSizingBudgetTableProps = Omit<
 export const AutoSizingBudgetTable = (props: AutoSizingBudgetTableProps) => {
   return (
     <AutoSizer
-      renderProp={({ width = 0, height = 0 }) => {
-        if (width === 0 || height === 0) {
+      renderProp={({ width = 0 }) => {
+        if (width === 0) {
           return null;
         }
 
-        return <DynamicBudgetTable width={width} height={height} {...props} />;
+        return <DynamicBudgetTable width={width} {...props} />;
       }}
     />
   );

--- a/packages/desktop-client/src/components/budget/index.tsx
+++ b/packages/desktop-client/src/components/budget/index.tsx
@@ -242,18 +242,11 @@ export function Budget() {
 
   return (
     <SheetNameProvider name={monthUtils.sheetForMonth(startMonth)}>
-      {/*
-        In a previous iteration, the wrapper needs `overflow: hidden` for
-        some reason. Without it at certain dimensions the width/height
-        that autosizer gives us is slightly wrong, causing scrollbars to
-        appear. We might not need it anymore?
-      */}
       <View
         style={{
           ...styles.page,
           paddingLeft: 8,
           paddingRight: 8,
-          overflow: 'hidden',
         }}
       >
         <View style={{ flex: 1 }}>{table}</View>

--- a/packages/desktop-client/src/components/budget/util.ts
+++ b/packages/desktop-client/src/components/budget/util.ts
@@ -1,5 +1,4 @@
 // @ts-strict-ignore
-import { styles } from '@actual-app/components/styles';
 import type { CSSProperties } from '@actual-app/components/styles';
 import { theme } from '@actual-app/components/theme';
 import { send } from '@actual-app/core/platform/client/connection';
@@ -172,10 +171,6 @@ export function findSortUp<T extends { id: string }>(
       return { targetId: null };
     }
   }
-}
-
-export function getScrollbarWidth() {
-  return Math.max(styles.scrollbarWidth - 2, 0);
 }
 
 export async function prewarmMonth(

--- a/packages/desktop-client/src/components/tour/steps.tsx
+++ b/packages/desktop-client/src/components/tour/steps.tsx
@@ -56,7 +56,6 @@ function getBudgetTourSteps({ navigate, budgetType }: TourStepDeps): Step[] {
     {
       id: 'budget-table',
       target: '[data-testid="budget-table"]',
-      scrollTarget: '[data-testid="budget-table-scroll-container"]',
       placement: 'center',
       before: async () => {
         if (window.location.pathname !== '/budget') {

--- a/packages/desktop-client/src/hooks/useScrollListener.tsx
+++ b/packages/desktop-client/src/hooks/useScrollListener.tsx
@@ -27,6 +27,7 @@ type RegisterScrollListener = (
 
 type IScrollContext = {
   registerScrollListener: RegisterScrollListener;
+  scrollableRef: RefObject<Element | null>;
 };
 
 const ScrollContext = createContext<IScrollContext | undefined>(undefined);
@@ -195,7 +196,7 @@ export function ScrollProvider<T extends Element>({
   );
 
   return (
-    <ScrollContext.Provider value={{ registerScrollListener }}>
+    <ScrollContext.Provider value={{ registerScrollListener, scrollableRef }}>
       {children}
     </ScrollContext.Provider>
   );
@@ -218,4 +219,17 @@ export function useScrollListener(listener: ScrollListener) {
   useEffect(() => {
     return registerScrollListener(listener);
   }, [listener, registerScrollListener]);
+}
+
+/**
+ * A hook to access the ref of the app's page-level scroll container
+ * (the element that owns the scrollbar for the routed page's content).
+ */
+export function useScrollableRef() {
+  const context = useContext(ScrollContext);
+  if (!context) {
+    throw new Error('useScrollableRef must be used within a ScrollProvider');
+  }
+
+  return context.scrollableRef;
 }

--- a/upcoming-release-notes/budget-page-scroll.md
+++ b/upcoming-release-notes/budget-page-scroll.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [dezman]
+---
+
+Make the budget page scroll as a single page (month picker, summary, and category table together) instead of using a separate inner scrollbar, with a sticky titlebar


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

<!-- If AI tools wrote a significant part of this change, please disclose it here and name the tool you used. See https://actualbudget.org/docs/contributing/ai-usage-policy -->

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

## Checklist

- [ ] Release notes added (see link above)
- [ ] No obvious regressions in affected areas
- [ ] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 42 | 13.6 MB → 13.6 MB (-491 B) | -0.00%
loot-core | 1 | 4.64 MB | 0%
api | 2 | 3.85 MB | 0%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
42 | 13.6 MB → 13.6 MB (-491 B) | -0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/hooks/useScrollListener.tsx` | 📈 +237 B (+5.37%) | 4.31 kB → 4.54 kB
`src/components/FinancesApp.tsx` | 📈 +58 B (+0.25%) | 22.73 kB → 22.78 kB
`src/components/budget/BudgetTotals.tsx` | 📉 -22 B (-0.29%) | 7.41 kB → 7.39 kB
`src/components/budget/index.tsx` | 📉 -24 B (-0.35%) | 6.69 kB → 6.66 kB
`src/components/tour/steps.tsx` | 📉 -68 B (-0.98%) | 6.81 kB → 6.74 kB
`src/components/budget/BudgetPageHeader.tsx` | 📉 -22 B (-1.16%) | 1.85 kB → 1.83 kB
`src/components/budget/DynamicBudgetTable.tsx` | 📉 -73 B (-2.10%) | 3.39 kB → 3.32 kB
`src/components/budget/util.ts` | 📉 -81 B (-2.45%) | 3.23 kB → 3.15 kB
`src/components/budget/BudgetTable.tsx` | 📉 -496 B (-7.93%) | 6.11 kB → 5.62 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/Value.js | 1.79 MB → 1.79 MB (+156 B) | +0.01%
static/js/index.js | 1.58 MB → 1.58 MB (+58 B) | +0.00%

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/wide.js | 274.04 kB → 273.42 kB (-637 B) | -0.23%
static/js/TourHost.js | 169.22 kB → 169.15 kB (-68 B) | -0.04%

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/DateSelect.js | 2.37 MB | 0%
static/js/FormulaEditor.js | 766.35 kB | 0%
static/js/ManageRules.js | 71.66 kB | 0%
static/js/NotesTagFormatter.js | 25.94 kB | 0%
static/js/PayeeRuleCountLabel.js | 12.81 kB | 0%
static/js/ReportRouter.js | 1.43 MB | 0%
static/js/ScheduleEditForm.js | 75.41 kB | 0%
static/js/SchedulesTable.js | 171.25 kB | 0%
static/js/TourProvider.js | 1.54 kB | 0%
static/js/TransactionEdit.js | 221.38 kB | 0%
static/js/TransactionList.js | 166.98 kB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/ca.js | 170.64 kB | 0%
static/js/client.js | 452.05 kB | 0%
static/js/columns.js | 673.28 kB | 0%
static/js/de.js | 185 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/en.js | 245.91 kB | 0%
static/js/es.js | 164.81 kB | 0%
static/js/fr.js | 179.04 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 151.67 kB | 0%
static/js/months.js | 574.72 kB | 0%
static/js/narrow.js | 290.52 kB | 0%
static/js/nb-NO.js | 135.46 kB | 0%
static/js/nl.js | 151.78 kB | 0%
static/js/pl.js | 136.39 kB | 0%
static/js/pt-BR.js | 178.2 kB | 0%
static/js/ru.js | 209.6 kB | 0%
static/js/theme.js | 31.1 kB | 0%
static/js/uk.js | 201.42 kB | 0%
static/js/useFormatList.js | 10.22 kB | 0%
static/js/useLocalPref.js | 97.2 kB | 0%
static/js/useReducedMotion.js | 594 B | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 106.8 kB | 0%
static/js/zh-Hant.js | 130.92 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.64 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.CokRHpI5.js | 4.64 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.85 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.85 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.16 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->