### PR TITLE
Add actual-budget-mcp to Community Projects

### DIFF
--- a/packages/docs/docs/community-repos.md
+++ b/packages/docs/docs/community-repos.md
@@ -63,10 +63,9 @@ Actual currently has official support for migrating budgets from YNAB4 and nYNAB
 - **Actual Budget iOS Widget** - https://github.com/TaylorJns/Actual-Budget-iOS-Widget
   - _An iOS widget to display your Actual Budget category balances for the current month. Requires your Actual server to be accessible via HTTPS, and the **Local REST API** community project to be installed._
 - **Actual Bench** - https://github.com/x-rous/actual-bench
-
-* **actual-budget-mcp** - https://github.com/henfrydls/actual-budget-mcp
-  - _Connect Actual to Claude and other AI assistants. Ask about your budget in plain language, get spending analysis and projections, and create or edit transactions. Deletes wait for your confirmation, and an optional read only mode hides the write tools entirely._
   - _Admin and workbench companion for Actual Budget. Bulk-edit data, manage, merge and diagnose rules, 12-month budget view, snapshot inspection, and ActualQL queries - all changes staged until you save._
+- **actual-budget-mcp** - https://github.com/henfrydls/actual-budget-mcp
+  - _Connect Actual to Claude and other AI assistants. Ask about your budget in plain language, get spending analysis and projections, and create, edit, or delete transactions. Deletions wait for your confirmation, and an optional read-only mode hides the write tools entirely._
 
 ## Others
 

--- a/packages/docs/docs/community-repos.md
+++ b/packages/docs/docs/community-repos.md
@@ -63,8 +63,9 @@ Actual currently has official support for migrating budgets from YNAB4 and nYNAB
 - **Actual Budget iOS Widget** - https://github.com/TaylorJns/Actual-Budget-iOS-Widget
   - _An iOS widget to display your Actual Budget category balances for the current month. Requires your Actual server to be accessible via HTTPS, and the **Local REST API** community project to be installed._
 - **Actual Bench** - https://github.com/x-rous/actual-bench
+
 * **actual-budget-mcp** - https://github.com/henfrydls/actual-budget-mcp
-   - *Connect Actual to Claude and other AI assistants. Ask about your budget in plain language, get spending analysis and projections, and create or edit transactions. Deletes wait for your confirmation, and an optional read only mode hides the write tools entirely.*
+  - _Connect Actual to Claude and other AI assistants. Ask about your budget in plain language, get spending analysis and projections, and create or edit transactions. Deletes wait for your confirmation, and an optional read only mode hides the write tools entirely._
   - _Admin and workbench companion for Actual Budget. Bulk-edit data, manage, merge and diagnose rules, 12-month budget view, snapshot inspection, and ActualQL queries - all changes staged until you save._
 
 ## Others

--- a/packages/docs/docs/community-repos.md
+++ b/packages/docs/docs/community-repos.md
@@ -63,6 +63,8 @@ Actual currently has official support for migrating budgets from YNAB4 and nYNAB
 - **Actual Budget iOS Widget** - https://github.com/TaylorJns/Actual-Budget-iOS-Widget
   - _An iOS widget to display your Actual Budget category balances for the current month. Requires your Actual server to be accessible via HTTPS, and the **Local REST API** community project to be installed._
 - **Actual Bench** - https://github.com/x-rous/actual-bench
+* **actual-budget-mcp** - https://github.com/henfrydls/actual-budget-mcp
+   - *Connect Actual to Claude and other AI assistants. Ask about your budget in plain language, get spending analysis and projections, and create or edit transactions. Deletes wait for your confirmation, and an optional read only mode hides the write tools entirely.*
   - _Admin and workbench companion for Actual Budget. Bulk-edit data, manage, merge and diagnose rules, 12-month budget view, snapshot inspection, and ActualQL queries - all changes staged until you save._
 
 ## Others


### PR DESCRIPTION
## Description

Adds `actual-budget-mcp` to the Community Projects page, under "Various utilities to enhance Actual's functionality".

It is an MCP server, so Claude and other AI assistants can talk to an Actual server: questions about the budget in plain language, spending analysis and projections, and creating or editing transactions. Deletes preview what they would remove and wait for a confirmation before running, and there is an opt-in read only mode that hides the write tools from the model entirely. MIT, published on npm and as a container image, and the README has a demo.

I raised it in #documentation on Discord first, as the page instructs, and opened this in case a PR saves a maintainer the typing. Note the old `actualbudget/docs` repo is archived, so this goes against `packages/docs` here.

Disclosure per the AI usage policy: the wording of this entry and of this description was drafted with Claude and then reviewed and edited by me. The change itself is two lines of documentation.

## Related issue(s)

None.

## Testing

Checked that the entry matches the format of the surrounding items in that section (bold name, link, indented italic description) and that it renders in the docs preview build.

## Checklist

- [ ] Release notes added — not applicable, this is a docs-only change and `check-release-notes` passes
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed