### PR TITLE
fix: password login when OpenID is configured with password auth

### DIFF
--- a/packages/sync-server/src/account-db.js
+++ b/packages/sync-server/src/account-db.js
@@ -64,11 +64,9 @@ export function getLoginMethod(req) {
     (req.body || { loginMethod: null }).loginMethod &&
     config.get('allowedLoginMethods').includes(req.body.loginMethod)
   ) {
-    const accountDb = getAccountDb();
-    const row = accountDb.first('SELECT method FROM auth WHERE method = ?', [
-      req.body.loginMethod,
-    ]);
-    if (row) return req.body.loginMethod;
+    // Handlers validate their own readiness (e.g. loginWithPassword
+    // returns 'invalid-password' with no hash set), so no DB row is needed here.
+    return req.body.loginMethod;
   }
 
   //BY-PASS ANY OTHER CONFIGURATION TO ENSURE HEADER AUTH

--- a/packages/sync-server/src/app-account.test.js
+++ b/packages/sync-server/src/app-account.test.js
@@ -4,6 +4,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { getAccountDb, getLoginMethod, getServerPrefs } from './account-db';
 import { bootstrapPassword } from './accounts/password';
 import { handlers as app, authRateLimiter } from './app-account';
+import { config } from './load-config';
 
 const ADMIN_ROLE = 'ADMIN';
 const BASIC_ROLE = 'BASIC';
@@ -206,16 +207,48 @@ describe('getLoginMethod()', () => {
     expect(getLoginMethod(req)).toBe('password');
   });
 
-  it('ignores a client-requested method that is not in DB', () => {
+  it('honors a client-requested allowed method even when it has no auth row', () => {
     insertAuthRow('openid', 1);
     const req = { body: { loginMethod: 'password' } };
-    expect(getLoginMethod(req)).toBe('openid');
+    expect(getLoginMethod(req)).toBe('password');
   });
 
   it('falls back to config default when auth table is empty and no req', () => {
     // auth table is empty — getActiveLoginMethod() returns undefined
     // config default for loginMethod is 'password'
     expect(getLoginMethod(undefined)).toBe('password');
+  });
+
+  describe('with header auth configured', () => {
+    const originalLoginMethod = config.get('loginMethod');
+    const originalAllowedMethods = config.get('allowedLoginMethods');
+
+    beforeEach(() => {
+      config.set('loginMethod', 'header');
+      config.set('allowedLoginMethods', ['header', 'password']);
+    });
+
+    afterEach(() => {
+      config.set('loginMethod', originalLoginMethod);
+      config.set('allowedLoginMethods', originalAllowedMethods);
+    });
+
+    it('still allows an explicit password login as a documented fallback', () => {
+      insertAuthRow('password', 1);
+      const req = { body: { loginMethod: 'password' } };
+      expect(getLoginMethod(req)).toBe('password');
+    });
+
+    it('falls back to header auth when no explicit method is requested', () => {
+      insertAuthRow('password', 1);
+      expect(getLoginMethod(undefined)).toBe('header');
+    });
+
+    it('falls back to header auth when the requested method is not allowed', () => {
+      insertAuthRow('password', 1);
+      const req = { body: { loginMethod: 'openid' } };
+      expect(getLoginMethod(req)).toBe('header');
+    });
   });
 });
 
@@ -250,6 +283,17 @@ describe('/login', () => {
     const res = await request(app)
       .post('/login')
       .send({ loginMethod: 'password', password: 'wrongpassword' });
+
+    expect(res.statusCode).toEqual(400);
+    expect(res.body).toHaveProperty('reason', 'invalid-password');
+  });
+
+  it('routes an explicit password login to the password handler when OpenID is the only configured method', async () => {
+    insertAuthRow('openid', 1);
+
+    const res = await request(app)
+      .post('/login')
+      .send({ loginMethod: 'password', password: 'whatever' });
 
     expect(res.statusCode).toEqual(400);
     expect(res.body).toHaveProperty('reason', 'invalid-password');

--- a/upcoming-release-notes/fix-password-login-with-openid-configured.md
+++ b/upcoming-release-notes/fix-password-login-with-openid-configured.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [yash-garg]
+---
+
+Fix password login failing with "Invalid redirect URL" when OpenID is also configured


### PR DESCRIPTION
## Description

Password login via the Node.js API fails with `Invalid redirect URL` on servers where OpenID is configured through environment variables, even though password auth is still allowed.

`getLoginMethod()` only honored an explicitly requested login method (e.g. `loginMethod: 'password'`) if a matching row already existed in the `auth` table. Servers bootstrapped via `ACTUAL_OPENID_*` env vars never create a password row, so the request silently fell through to the OpenID redirect flow instead.

Fix: honor the requested method whenever it's allowed by config, and let each handler validate its own readiness (password login now correctly reports `invalid-password` instead of redirecting to OpenID). The explicit-method check still runs before the header-auth fallback, so the [documented header-auth behavior](https://actualbudget.org/docs/advanced/http-header-auth/) — "the normal password authentication will still work as a fallback" — keeps working for API clients behind an SSO proxy (Authelia/Authentik).

This change was drafted with the help of Claude, which I reviewed and tested.

## Related issue(s)

Fixes #7241

## Testing

- Added regression tests in `packages/sync-server/src/app-account.test.js` covering:
  - Explicit password login on an OpenID-only server.
  - Explicit password login still works as a fallback when header auth is configured.
  - Header auth still applies when no explicit method is requested, or the requested one isn't allowed.
- `yarn workspace @actual-app/sync-server run test` — all tests pass.
- Manually reproduced the bug on a fresh server with only `ACTUAL_OPENID_*` env vars set: before the fix, `POST /account/login` with `loginMethod: 'password'` returned `Invalid redirect URL`; after the fix it returns `invalid-password` (or a valid token, once a password is set).

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed
