### PR TITLE
Monte carlo linked account feedback

### DIFF
--- a/packages/desktop-client/src/components/reports/reports/monte-carlo/MonteCarloPotConfiguration.tsx
+++ b/packages/desktop-client/src/components/reports/reports/monte-carlo/MonteCarloPotConfiguration.tsx
@@ -76,7 +76,12 @@ export function MonteCarloPotConfiguration({
   // A linked account that has since been closed or deleted isn't in the
   // open-accounts list; keep it represented so the stored link doesn't
   // display as a blank selection
-  const openAccounts = accounts.filter(account => account.closed === 0);
+  const openAccounts = accounts
+    .filter(account => account.closed === 0)
+    // Budgeted accounts first, then off-budget, each keeping the user's
+    // sidebar drag order (the query already sorts by sort_order) - the
+    // same order the sidebar shows
+    .sort((accountA, accountB) => accountA.offbudget - accountB.offbudget);
   const linkedAccount = accounts.find(account => account.id === pot.accountId);
   const missingLinkedOptions: Array<[string, string]> =
     pot.accountId != null &&
@@ -137,7 +142,10 @@ export function MonteCarloPotConfiguration({
         >
           <Input
             // Uncontrolled on purpose: committing on blur keeps typing
-            // snappy since every config change re-runs the simulation
+            // snappy since every config change re-runs the simulation.
+            // The key remounts it when the linked account changes, so an
+            // auto-filled name actually shows up
+            key={pot.accountId ?? 'manual'}
             defaultValue={pot.name}
             placeholder={t('Pot {{number}}', { number: potNumber })}
             onUpdate={newName => {
@@ -177,9 +185,25 @@ export function MonteCarloPotConfiguration({
         >
           <Select
             value={pot.accountId ?? ''}
-            onChange={value =>
-              onPotChange({ accountId: value === '' ? null : value })
-            }
+            onChange={value => {
+              const newAccountId = value === '' ? null : value;
+              const newAccount = accounts.find(
+                account => account.id === newAccountId,
+              );
+              const previousAccount = accounts.find(
+                account => account.id === pot.accountId,
+              );
+              // Default the pot's name to the account's, but only when
+              // the current name isn't the user's own: empty, or still
+              // the auto-filled name of the previously linked account
+              const shouldFillName =
+                newAccount != null &&
+                (pot.name === '' || pot.name === previousAccount?.name);
+              onPotChange({
+                accountId: newAccountId,
+                ...(shouldFillName && { name: newAccount.name }),
+              });
+            }}
             options={[
               ['', t('None')],
               ...missingLinkedOptions,

--- a/upcoming-release-notes/monte-carlo-linked-account-polish.md
+++ b/upcoming-release-notes/monte-carlo-linked-account-polish.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [MikesGlitch]
+---
+
+Name Monte Carlo pots after their linked account automatically, and list accounts in the same order as the sidebar


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

AI helped with this.

Addresses these two:

- [x] Consistent dropdown ordering
  - In the pots section, sort the linked accounts dropdown to match the sidebar account order
- [x] Smarter default pot names
  - For pots with linked accounts, default to the linked account's name instead of generic "Pot 1", "Pot 2", etc.

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

<!-- If AI tools wrote a significant part of this change, please disclose it here and name the tool you used. See https://actualbudget.org/docs/contributing/ai-usage-policy -->

## Related issue(s)


https://github.com/actualbudget/actual/issues/8571#issuecomment-5495411254

<!-- e.g. Fixes #123, Relates to #456 -->

## Testing

Tested on web

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 42 | 13.52 MB → 13.52 MB (+471 B) | +0.00%
loot-core | 1 | 4.64 MB | 0%
api | 2 | 3.85 MB | 0%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
42 | 13.52 MB → 13.52 MB (+471 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/reports/reports/monte-carlo/MonteCarloPotConfiguration.tsx` | 📈 +471 B (+3.59%) | 12.83 kB → 13.29 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/ReportRouter.js | 1.44 MB → 1.44 MB (+471 B) | +0.03%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.58 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/DateSelect.js | 2.37 MB | 0%
static/js/FormulaEditor.js | 766.35 kB | 0%
static/js/ManageRules.js | 71.66 kB | 0%
static/js/NotesTagFormatter.js | 25.94 kB | 0%
static/js/PayeeRuleCountLabel.js | 12.81 kB | 0%
static/js/ScheduleEditForm.js | 75.41 kB | 0%
static/js/SchedulesTable.js | 171.25 kB | 0%
static/js/TourHost.js | 169.22 kB | 0%
static/js/TourProvider.js | 1.54 kB | 0%
static/js/TransactionEdit.js | 221.38 kB | 0%
static/js/TransactionList.js | 79.22 kB | 0%
static/js/Value.js | 1.79 MB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/ca.js | 170.64 kB | 0%
static/js/client.js | 452.05 kB | 0%
static/js/columns.js | 673.28 kB | 0%
static/js/de.js | 185.95 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/en.js | 245.91 kB | 0%
static/js/es.js | 164.81 kB | 0%
static/js/fr.js | 179.04 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 151.67 kB | 0%
static/js/months.js | 574.72 kB | 0%
static/js/narrow.js | 290.52 kB | 0%
static/js/nb-NO.js | 135.46 kB | 0%
static/js/nl.js | 151.78 kB | 0%
static/js/pl.js | 136.39 kB | 0%
static/js/pt-BR.js | 178.2 kB | 0%
static/js/ru.js | 209.6 kB | 0%
static/js/theme.js | 31.1 kB | 0%
static/js/uk.js | 201.42 kB | 0%
static/js/useFormatList.js | 10.22 kB | 0%
static/js/useLocalPref.js | 97.2 kB | 0%
static/js/useReducedMotion.js | 594 B | 0%
static/js/wide.js | 274.04 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 106.8 kB | 0%
static/js/zh-Hant.js | 130.92 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.64 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.CokRHpI5.js | 4.64 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.85 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.85 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.16 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->