### PR TITLE
[WIP] docs(sync-server): explain npm allow-scripts warnings on global install

### DIFF
--- a/packages/sync-server/README.md
+++ b/packages/sync-server/README.md
@@ -20,6 +20,38 @@ npm install --location=global @actual-app/sync-server
 
 After installing, you can execute actual-server commands directly in your terminal.
 
+> **npm 11+: `allow-scripts` warnings during install**
+>
+> The install above prints warnings like:
+>
+> ```
+> npm warn allow-scripts 2 packages have install scripts not yet covered by allowScripts:
+> npm warn allow-scripts   bcrypt@6.0.0 (install: node-gyp-build)
+> npm warn allow-scripts   better-sqlite3@12.11.1 (install: prebuild-install || node-gyp rebuild --release)
+> ```
+>
+> These are expected. `bcrypt` and `better-sqlite3` are native modules, and their install
+> scripts must run for the server to work.
+>
+> The `npm approve-scripts` command that the warning suggests cannot record an approval
+> for a global install, because there is no project `package.json` for it to write to
+> (see [npm/cli#9457](https://github.com/npm/cli/issues/9457)). Approve them through your
+> npm config instead:
+>
+> ```ini
+> ; ~/.npmrc
+> allow-scripts = bcrypt, better-sqlite3
+> ```
+>
+> or per-install:
+>
+> ```bash
+> npm install --location=global @actual-app/sync-server --allow-scripts=bcrypt,better-sqlite3
+> ```
+>
+> From npm v12, dependency install scripts are opt-in by default. Without one of the
+> above, the native modules will not build and the server will fail to start.
+
 **Usage**
 
 ```bash

--- a/packages/sync-server/README.md
+++ b/packages/sync-server/README.md
@@ -20,18 +20,19 @@ npm install --location=global @actual-app/sync-server
 
 After installing, you can execute actual-server commands directly in your terminal.
 
-> **npm 11+: `allow-scripts` warnings during install**
+> **npm 11.16+: `allow-scripts` warnings during install**
 >
 > The install above prints warnings like:
 >
-> ```
+> ```text
 > npm warn allow-scripts 2 packages have install scripts not yet covered by allowScripts:
 > npm warn allow-scripts   bcrypt@6.0.0 (install: node-gyp-build)
 > npm warn allow-scripts   better-sqlite3@12.11.1 (install: prebuild-install || node-gyp rebuild --release)
 > ```
 >
-> These are expected. `bcrypt` and `better-sqlite3` are native modules, and their install
-> scripts must run for the server to work.
+> These are expected. `argon2`, `bcrypt` and `better-sqlite3` are native modules, and
+> their install scripts must run for the server to work. The exact list in the warning
+> depends on the release you install.
 >
 > The `npm approve-scripts` command that the warning suggests cannot record an approval
 > for a global install, because there is no project `package.json` for it to write to
@@ -40,13 +41,13 @@ After installing, you can execute actual-server commands directly in your termin
 >
 > ```ini
 > ; ~/.npmrc
-> allow-scripts = bcrypt, better-sqlite3
+> allow-scripts=argon2,bcrypt,better-sqlite3
 > ```
 >
 > or per-install:
 >
 > ```bash
-> npm install --location=global @actual-app/sync-server --allow-scripts=bcrypt,better-sqlite3
+> npm install --location=global @actual-app/sync-server --allow-scripts=argon2,bcrypt,better-sqlite3
 > ```
 >
 > From npm v12, dependency install scripts are opt-in by default. Without one of the

--- a/upcoming-release-notes/document-sync-server-allow-scripts.md
+++ b/upcoming-release-notes/document-sync-server-allow-scripts.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [Rijul202]
+---
+
+Document the npm 11+ `allow-scripts` warnings shown when installing `@actual-app/sync-server` globally, and how to approve the native module install scripts.

--- a/upcoming-release-notes/document-sync-server-allow-scripts.md
+++ b/upcoming-release-notes/document-sync-server-allow-scripts.md
@@ -3,4 +3,4 @@ category: Maintenance
 authors: [Rijul202]
 ---
 
-Document the npm 11+ `allow-scripts` warnings shown when installing `@actual-app/sync-server` globally, and how to approve the native module install scripts.
+Document the npm 11.16+ `allow-scripts` warnings shown when installing `@actual-app/sync-server` globally, and how to approve the native module install scripts.


### PR DESCRIPTION
Closes #8584.

### Background

The issue suggested adding an `allowScripts` field to `packages/sync-server/package.json`. That won't have any effect, for two reasons:

- `allowScripts` is a **consumer-side** policy field. npm reads it from the root project's `package.json`, not from a dependency's. A published package can't declare it on behalf of whoever installs it.
- For global installs specifically — which is what the issue reports — the `package.json` layer is skipped entirely when `npm.global` is true. See [npm/cli#9457](https://github.com/npm/cli/issues/9457), where the `npm approve-scripts` command the warning suggests was confirmed to hard-error with `EGLOBAL` on global installs. npm fixed the misleading message in [npm/cli#9469](https://github.com/npm/cli/pull/9469) by pointing at `--allow-scripts` instead.

So there is no publisher-side change that suppresses these warnings. The remedy is on the installing machine (`~/.npmrc` or the `--allow-scripts` flag).

### Change

Adds a note to the sync-server README next to the global install command, covering:

- the warnings are expected — `bcrypt` and `better-sqlite3` are native modules whose install scripts must run
- why `npm approve-scripts` doesn't work here
- the two working remedies (`~/.npmrc` entry, or `--allow-scripts=` per install)
- a heads-up that npm v12 makes dependency install scripts opt-in by default, at which point these modules won't build and the server won't start without one of the above

Documentation only; no code or dependency changes.

### Note

Happy to move this to the hosting docs instead if that's the better home — I couldn't tell where those live now that `actualbudget/docs` is archived, so I put it next to the install command it applies to.
