### PR TITLE
[WIP] [AI] Add formula support to schedule amounts

### DIFF
--- a/packages/desktop-client/e2e/page-models/schedule-edit-modal.ts
+++ b/packages/desktop-client/e2e/page-models/schedule-edit-modal.ts
@@ -43,7 +43,9 @@ export class ScheduleEditModal {
     this.cancelButton = locator.getByRole('button', { name: 'Cancel' });
   }
 
-  async selectAmountOp(op: string) {
+  async selectAmountOp(
+    op: 'is exactly' | 'is approximately' | 'is between' | 'is formula',
+  ) {
     await this.amountOpButton.click();
 
     // The popover is rendered outside of the modal locator

--- a/packages/desktop-client/e2e/page-models/schedule-edit-modal.ts
+++ b/packages/desktop-client/e2e/page-models/schedule-edit-modal.ts
@@ -15,6 +15,9 @@ export class ScheduleEditModal {
   readonly payeeInput: Locator;
   readonly accountInput: Locator;
   readonly amountInput: Locator;
+  readonly amountOpButton: Locator;
+  readonly formulaEditor: Locator;
+  readonly formulaPreview: Locator;
   readonly addButton: Locator;
   readonly saveButton: Locator;
   readonly cancelButton: Locator;
@@ -30,9 +33,24 @@ export class ScheduleEditModal {
     this.payeeInput = locator.getByRole('textbox', { name: 'Payee' });
     this.accountInput = locator.getByRole('textbox', { name: 'Account' });
     this.amountInput = locator.getByLabel('Amount');
+    this.amountOpButton = locator.getByRole('button', {
+      name: /^is (exactly|approximately|between|formula)$/,
+    });
+    this.formulaEditor = locator.locator('.cm-content');
+    this.formulaPreview = locator.getByText(/Evaluates to/).first();
     this.addButton = locator.getByRole('button', { name: 'Add' });
     this.saveButton = locator.getByRole('button', { name: 'Save' });
     this.cancelButton = locator.getByRole('button', { name: 'Cancel' });
+  }
+
+  async selectAmountOp(op: string) {
+    await this.amountOpButton.click();
+
+    // The popover is rendered outside of the modal locator
+    await this.page
+      .locator('[data-popover]')
+      .getByRole('button', { name: op, exact: true })
+      .click();
   }
 
   async fill(data: ScheduleEntry) {

--- a/packages/desktop-client/e2e/schedules.test.ts
+++ b/packages/desktop-client/e2e/schedules.test.ts
@@ -272,4 +272,57 @@ test.describe('Schedules', () => {
     await expect(menu).toBeVisible();
     await expect(menu.getByRole('button', { name: 'Complete' })).toBeVisible();
   });
+
+  test('creates a schedule with a formula amount', async () => {
+    const settingsPage = await navigation.goToSettingsPage();
+    await settingsPage.enableExperimentalFeature(
+      'Excel formula mode (Formula cards, Rule formulas & Schedule amounts)',
+    );
+    await navigation.goToSchedulesPage();
+
+    const scheduleEditModal = await schedulesPage.addNewSchedule();
+    await scheduleEditModal.fill({
+      payee: 'Home Depot',
+      account: 'HSBC',
+    });
+
+    // Switch the amount to a formula
+    await scheduleEditModal.selectAmountOp('is formula');
+
+    await scheduleEditModal.formulaEditor.waitFor({ state: 'visible' });
+    await scheduleEditModal.formulaEditor.click();
+    await scheduleEditModal.formulaEditor.pressSequentially('-DAY(date)*100');
+
+    // The live preview evaluates the formula for the next occurrence
+    await expect(scheduleEditModal.formulaPreview).toBeVisible();
+    await expect(scheduleEditModal.formulaPreview).toHaveText(
+      /Evaluates to .* on .*/,
+    );
+
+    // The preview line reserves its space: the date row must not move when
+    // the formula (and thus the preview text) changes.
+    const dateRowBefore = await scheduleEditModal.locator
+      .getByText('Upcoming dates')
+      .boundingBox();
+    await scheduleEditModal.formulaEditor.click();
+    await scheduleEditModal.formulaEditor.press('End');
+    await scheduleEditModal.formulaEditor.pressSequentially('/2');
+    await expect(scheduleEditModal.formulaPreview).toHaveText(
+      /Evaluates to .* on .*/,
+    );
+    const dateRowAfter = await scheduleEditModal.locator
+      .getByText('Upcoming dates')
+      .boundingBox();
+    expect(dateRowAfter?.y).toBe(dateRowBefore?.y);
+
+    // Restore the intended formula before saving
+    await scheduleEditModal.formulaEditor.press('Backspace');
+    await scheduleEditModal.formulaEditor.press('Backspace');
+
+    await scheduleEditModal.add();
+
+    const schedule = schedulesPage.getNthSchedule(2);
+    await expect(schedule.payee).toHaveText('Home Depot');
+    await expect(schedule.amount).toHaveText('ƒ=-DAY(date)*100');
+  });
 });

--- a/packages/desktop-client/e2e/schedules.test.ts
+++ b/packages/desktop-client/e2e/schedules.test.ts
@@ -313,6 +313,8 @@ test.describe('Schedules', () => {
     const dateRowAfter = await scheduleEditModal.locator
       .getByText('Upcoming dates')
       .boundingBox();
+    expect(dateRowBefore).not.toBeNull();
+    expect(dateRowAfter).not.toBeNull();
     expect(dateRowAfter?.y).toBe(dateRowBefore?.y);
 
     // Restore the intended formula before saving

--- a/packages/desktop-client/src/components/accounts/Balance.tsx
+++ b/packages/desktop-client/src/components/accounts/Balance.tsx
@@ -65,6 +65,7 @@ export function SelectedBalance({
   account,
 }: SelectedBalanceProps) {
   const { t } = useTranslation();
+  const format = useFormat();
 
   const name = `selected-balance-${[...selectedItems].join('-')}`;
 
@@ -114,7 +115,10 @@ export function SelectedBalance({
         isExactBalance = false;
       }
 
-      const amount = getScheduledAmount(schedule._amount, false, { date });
+      const amount = getScheduledAmount(schedule._amount, false, {
+        date,
+        decimalPlaces: format.currency.decimalPlaces,
+      });
 
       if (!account || account.id === schedule._account) {
         scheduleBalance += amount;

--- a/packages/desktop-client/src/components/accounts/Balance.tsx
+++ b/packages/desktop-client/src/components/accounts/Balance.tsx
@@ -100,7 +100,7 @@ export function SelectedBalance({
 
   for (const id of [...selectedItems].filter(isPreviewId)) {
     // Preview IDs are in the format `preview/<schedule_id>/<date>`
-    const scheduleId = id.slice(8).split('/')[0];
+    const [, scheduleId, date] = id.split('/');
     const schedule = schedules.find(s => s.id === scheduleId);
     if (schedule) {
       // If a schedule is `between X and Y` then we calculate the average
@@ -108,10 +108,18 @@ export function SelectedBalance({
         isExactBalance = false;
       }
 
+      // Formula amounts are evaluated per occurrence date; the balance is
+      // only an estimate because BALANCE_OF can't be resolved here.
+      if (schedule._amountOp === 'formula') {
+        isExactBalance = false;
+      }
+
+      const amount = getScheduledAmount(schedule._amount, false, { date });
+
       if (!account || account.id === schedule._account) {
-        scheduleBalance += getScheduledAmount(schedule._amount);
+        scheduleBalance += amount;
       } else {
-        scheduleBalance -= getScheduledAmount(schedule._amount);
+        scheduleBalance -= amount;
       }
     }
   }

--- a/packages/desktop-client/src/components/formula/FormulaEditor.tsx
+++ b/packages/desktop-client/src/components/formula/FormulaEditor.tsx
@@ -23,8 +23,7 @@ import type {
   MonthYearFormat,
 } from './codeMirror-excelLanguage';
 import { budgetQueryDimensions } from './formulaCatalog';
-
-type FormulaMode = 'transaction' | 'query';
+import type { FormulaMode } from './formulaCatalog';
 
 type FormulaEditorProps = {
   value: string;

--- a/packages/desktop-client/src/components/formula/codeMirror-excelLanguage.tsx
+++ b/packages/desktop-client/src/components/formula/codeMirror-excelLanguage.tsx
@@ -55,6 +55,7 @@ import {
   getFunctionSignatureCompletionSection,
   getNamedVariableCompletions,
   getRuleFieldCompletions,
+  getScheduleFieldCompletions,
   sortFormulaCompletions,
 } from './formulaCatalog';
 import type { FormulaFunctionDef, FormulaMode } from './formulaCatalog';
@@ -661,6 +662,7 @@ export function excelFormulaAutocomplete(
           ...queryCompletions,
           ...functionCompletions,
           ...(mode === 'transaction' ? getRuleFieldCompletions() : []),
+          ...(mode === 'schedule' ? getScheduleFieldCompletions() : []),
         ];
 
         const contextualSuggestions: Completion[] = activeFunctionContext
@@ -739,9 +741,14 @@ export function excelFormulaHover(mode: FormulaMode): Extension {
       } satisfies Tooltip;
     }
 
-    // Transaction fields
-    if (mode === 'transaction') {
-      const field = getRuleFieldCompletions().find(f => f.label === w);
+    // Transaction/schedule fields
+    if (mode === 'transaction' || mode === 'schedule') {
+      const fields =
+        mode === 'transaction'
+          ? getRuleFieldCompletions()
+          : getScheduleFieldCompletions();
+      // Field lookups are case-insensitive, matching the function lookup.
+      const field = fields.find(f => f.label === w.toLowerCase());
       if (field) {
         return {
           pos: word.from,

--- a/packages/desktop-client/src/components/formula/formulaBadgeRanges.ts
+++ b/packages/desktop-client/src/components/formula/formulaBadgeRanges.ts
@@ -3,8 +3,7 @@ import { HyperFormula } from 'hyperformula';
 import { bootstrapHyperFormula } from '#util/bootstrapHyperFormula';
 
 import { budgetQueryDimensions } from './formulaCatalog';
-
-type FormulaMode = 'transaction' | 'query';
+import type { FormulaMode } from './formulaCatalog';
 
 export type FormulaBadgeVariant =
   | 'named-expression'
@@ -93,6 +92,12 @@ const transactionNamedExpressionBadges: Record<string, string> = {
   reconciled: 'reconciled',
   balance: 'balance',
   parent_amount: 'parent_amount',
+};
+
+// Schedule formulas only know about their own occurrence date.
+const scheduleNamedExpressionBadges: Record<string, string> = {
+  today: 'today',
+  date: 'date',
 };
 
 const queryNameFunctions = new Set([
@@ -534,6 +539,7 @@ function getNamedExpressionBadges({
 }) {
   return {
     ...(mode === 'transaction' ? transactionNamedExpressionBadges : {}),
+    ...(mode === 'schedule' ? scheduleNamedExpressionBadges : {}),
     ...Object.fromEntries(
       Object.keys(variables ?? {}).map(name => [name, name]),
     ),

--- a/packages/desktop-client/src/components/formula/formulaCatalog.ts
+++ b/packages/desktop-client/src/components/formula/formulaCatalog.ts
@@ -1277,7 +1277,11 @@ export function getFormulaFunctionsByMode(): Record<FormulaMode, string[]> {
       functionsByMode[mode].push(name);
     }
     // Schedule formulas expose the same functions as transaction formulas.
-    if (func.modes.includes('transaction')) {
+    // Guard against duplicates if an entry ever declares both modes.
+    if (
+      func.modes.includes('transaction') &&
+      !func.modes.includes('schedule')
+    ) {
       functionsByMode.schedule.push(name);
     }
   }

--- a/packages/desktop-client/src/components/formula/formulaCatalog.ts
+++ b/packages/desktop-client/src/components/formula/formulaCatalog.ts
@@ -1,7 +1,7 @@
 import type { Completion } from '@codemirror/autocomplete';
 import { t } from 'i18next';
 
-export type FormulaMode = 'query' | 'transaction';
+export type FormulaMode = 'query' | 'transaction' | 'schedule';
 
 export type FormulaFunctionCategory =
   | 'math'
@@ -97,6 +97,10 @@ function getRuleFieldCompletionSection(): string {
   return `💰 ${t('Transaction Fields')}`;
 }
 
+function getScheduleFieldCompletionSection(): string {
+  return `💰 ${t('Schedule Fields')}`;
+}
+
 function getFormulaCompletionSectionOrder(): Record<string, number> {
   const categoryConfig = getFormulaFunctionCategoryConfig();
 
@@ -112,6 +116,7 @@ function getFormulaCompletionSectionOrder(): Record<string, number> {
     [getBudgetDimensionCompletionSection()]: 6,
     [getBudgetCategoryCompletionSection()]: 7,
     [getRuleFieldCompletionSection()]: 8,
+    [getScheduleFieldCompletionSection()]: 8,
   };
 }
 
@@ -1264,11 +1269,16 @@ export function getFormulaFunctionsByMode(): Record<FormulaMode, string[]> {
   const functionsByMode: Record<FormulaMode, string[]> = {
     query: [],
     transaction: [],
+    schedule: [],
   };
 
   for (const [name, func] of Object.entries(getFormulaFunctionCatalog())) {
     for (const mode of func.modes) {
       functionsByMode[mode].push(name);
+    }
+    // Schedule formulas expose the same functions as transaction formulas.
+    if (func.modes.includes('transaction')) {
+      functionsByMode.schedule.push(name);
     }
   }
 
@@ -1279,9 +1289,13 @@ export function getFormulaFunctionsForMode(
   mode: FormulaMode,
 ): Record<string, FormulaFunctionDef> {
   const catalog = getFormulaFunctionCatalog();
+  // Schedule formulas expose the same functions as transaction formulas.
+  const lookupMode = mode === 'schedule' ? 'transaction' : mode;
 
   return Object.fromEntries(
-    Object.entries(catalog).filter(([, func]) => func.modes.includes(mode)),
+    Object.entries(catalog).filter(([, func]) =>
+      func.modes.includes(lookupMode),
+    ),
   );
 }
 
@@ -1291,8 +1305,10 @@ export function getFormulaFunctionByName(
 ): FormulaFunctionDef | undefined {
   const upperName = name.toUpperCase();
   const func = getFormulaFunctionCatalog()[upperName];
+  // Schedule formulas expose the same functions as transaction formulas.
+  const lookupMode = mode === 'schedule' ? 'transaction' : mode;
 
-  if (!func || (mode && !func.modes.includes(mode))) {
+  if (!func || (lookupMode && !func.modes.includes(lookupMode))) {
     return undefined;
   }
 
@@ -1454,6 +1470,34 @@ export function getRuleFieldCompletions(): Completion[] {
       boost: 5,
       info: t(
         'The amount of the parent transaction in cents in split transactions.\n\nExample: =(parent_amount / 100) * .05',
+      ),
+    },
+  ];
+}
+
+// Schedule formulas are evaluated against each occurrence, which only knows
+// its own date — `date` and `today` are the only available variables. Amounts
+// written as numbers in the formula are in currency units (e.g. `=100` means
+// 100 currency units); `BALANCE_OF` returns cents, so divide by 100 or use
+// `INTEGER_TO_AMOUNT` when combining it with other amounts.
+export function getScheduleFieldCompletions(): Completion[] {
+  return [
+    {
+      label: 'date',
+      type: 'variable',
+      section: getScheduleFieldCompletionSection(),
+      boost: 5,
+      info: t(
+        'The date of the schedule occurrence. Use with date functions.\n\nExample: =IF(MONTH(date) = 1, 150, 100)',
+      ),
+    },
+    {
+      label: 'today',
+      type: 'variable',
+      section: getScheduleFieldCompletionSection(),
+      boost: 5,
+      info: t(
+        "Today's date. Use with date functions.\n\nExample: =IF(date = today, 100, 200)",
       ),
     },
   ];

--- a/packages/desktop-client/src/components/mobile/schedules/MobileSchedulesPage.tsx
+++ b/packages/desktop-client/src/components/mobile/schedules/MobileSchedulesPage.tsx
@@ -57,14 +57,19 @@ export function MobileSchedulesPage() {
     ? schedules.filter(schedule => {
         const payee = payees.find(p => schedule._payee === p.id);
         const account = accounts.find(a => schedule._account === a.id);
+        const isFormula =
+          schedule._amountOp === 'formula' &&
+          typeof schedule._amount === 'string';
         const amount = getScheduledAmount(schedule._amount);
         const amountStr =
-          (schedule._amountOp === 'isapprox' ||
-          schedule._amountOp === 'isbetween'
-            ? '~'
-            : '') +
-          (amount > 0 ? '+' : '') +
-          format(Math.abs(amount || 0), 'financial');
+          isFormula && typeof schedule._amount === 'string'
+            ? schedule._amount
+            : (schedule._amountOp === 'isapprox' ||
+              schedule._amountOp === 'isbetween'
+                ? '~'
+                : '') +
+              (amount > 0 ? '+' : '') +
+              format(Math.abs(amount || 0), 'financial');
         const dateStr = schedule.next_date
           ? monthUtilFormat(schedule.next_date, dateFormat)
           : null;

--- a/packages/desktop-client/src/components/mobile/schedules/SchedulesListItem.tsx
+++ b/packages/desktop-client/src/components/mobile/schedules/SchedulesListItem.tsx
@@ -36,13 +36,17 @@ export function SchedulesListItem({
   const format = useFormat();
   const dateFormat = useDateFormat() || 'MM/dd/yyyy';
 
+  const isFormula =
+    schedule._amountOp === 'formula' && typeof schedule._amount === 'string';
   const amount = getScheduledAmount(schedule._amount);
   const amountStr =
-    (schedule._amountOp === 'isapprox' || schedule._amountOp === 'isbetween'
-      ? '~'
-      : '') +
-    (amount > 0 ? '+' : '') +
-    format(Math.abs(amount || 0), 'financial');
+    isFormula && typeof schedule._amount === 'string'
+      ? schedule._amount
+      : (schedule._amountOp === 'isapprox' || schedule._amountOp === 'isbetween'
+          ? '~'
+          : '') +
+        (amount > 0 ? '+' : '') +
+        format(Math.abs(amount || 0), 'financial');
 
   return (
     <ActionableGridListItem

--- a/packages/desktop-client/src/components/rules/Value.tsx
+++ b/packages/desktop-client/src/components/rules/Value.tsx
@@ -98,6 +98,10 @@ export function Value<T>({
         case 'amount':
         case 'amount-inflow':
         case 'amount-outflow':
+          // Formula amount conditions store the formula string
+          if (typeof value === 'string') {
+            return value;
+          }
           return format(value, 'financial');
         case 'date':
           if (value) {

--- a/packages/desktop-client/src/components/schedules/ScheduleEditForm.tsx
+++ b/packages/desktop-client/src/components/schedules/ScheduleEditForm.tsx
@@ -1,5 +1,5 @@
 // @ts-strict-ignore
-import React from 'react';
+import React, { lazy, Suspense, useEffect, useMemo, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 
 import { Button } from '@actual-app/components/button';
@@ -15,6 +15,7 @@ import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 import * as monthUtils from '@actual-app/core/shared/months';
 import { UPCOMING_LENGTH_PRESET_OPTIONS } from '@actual-app/core/shared/schedules';
+import { amountToInteger } from '@actual-app/core/shared/util';
 import type {
   RecurConfig,
   ScheduleEntity,
@@ -31,14 +32,22 @@ import { SimpleTransactionsTable } from '#components/transactions/SimpleTransact
 import { AmountInput, BetweenAmountInput } from '#components/util/AmountInput';
 import { GenericInput } from '#components/util/GenericInput';
 import { useDateFormat } from '#hooks/useDateFormat';
+import { useFeatureFlag } from '#hooks/useFeatureFlag';
+import { useFormat } from '#hooks/useFormat';
 import { useLocale } from '#hooks/useLocale';
 import { SelectedProvider } from '#hooks/useSelected';
 import type { Actions } from '#hooks/useSelected';
 
+const FormulaEditor = lazy(() =>
+  import('#components/formula/FormulaEditor').then(module => ({
+    default: module.FormulaEditor,
+  })),
+);
+
 export type ScheduleFormFields = {
   payee: null | string;
   account: null | string;
-  amount: null | number | { num1: number; num2: number };
+  amount: null | number | { num1: number; num2: number } | string;
   amountOp: null | string;
   date: null | string | RecurConfig;
   posts_transaction: boolean;
@@ -55,12 +64,12 @@ export type ScheduleEditFormDispatch =
   | {
       type: 'set-field';
       field: 'amountOp';
-      value: 'is' | 'isbetween' | 'isapprox';
+      value: 'is' | 'isbetween' | 'isapprox' | 'formula';
     }
   | {
       type: 'set-field';
       field: 'amount';
-      value: number | { num1: number; num2: number };
+      value: number | { num1: number; num2: number } | string;
     }
   | {
       type: 'set-field';
@@ -121,6 +130,126 @@ export function ScheduleEditForm({
   const { t } = useTranslation();
   const dateFormat = useDateFormat() || 'MM/dd/yyyy';
   const { isNarrowWidth } = useResponsive();
+  const format = useFormat();
+  const formulaModeEnabled = useFeatureFlag('formulaMode');
+  // Make sure that we don't hide the formula option if formulaMode has been
+  // disabled after the schedule was created with a formula amount.
+  const showFormulaOp = formulaModeEnabled || fields.amountOp === 'formula';
+  const isFormula = fields.amountOp === 'formula';
+
+  const previewDate =
+    upcomingDates?.[0] ?? schedule?.next_date ?? monthUtils.currentDay();
+  const previewDates = useMemo(() => {
+    const dates = previewDate ? [previewDate, ...(upcomingDates ?? [])] : [];
+    return dates.filter((date, index, all) => all.indexOf(date) === index);
+  }, [previewDate, upcomingDates]);
+
+  const formulaHasBalanceOf =
+    isFormula &&
+    typeof fields.amount === 'string' &&
+    /BALANCE_OF\s*\(/i.test(fields.amount);
+
+  // Live per-occurrence preview, evaluated in the browser. BALANCE_OF
+  // resolves to 0 here (balances are prefetched server-side), so formulas
+  // that use it show a hint instead of a misleading amount.
+  const [formulaPreviews, setFormulaPreviews] = useState<
+    Map<string, { ok: number } | { error: string; soft: boolean }>
+  >(new Map());
+
+  useEffect(() => {
+    if (!isFormula || typeof fields.amount !== 'string') {
+      setFormulaPreviews(new Map());
+      return;
+    }
+    const formula = fields.amount;
+    if (!formula.startsWith('=') || formula.replace(/^=/, '').trim() === '') {
+      setFormulaPreviews(new Map());
+      return;
+    }
+
+    let cancelled = false;
+    void import('@actual-app/core/shared/formulas/evaluate').then(
+      ({ evaluateFormula, FormulaEvaluationError }) => {
+        if (cancelled) {
+          return;
+        }
+        const next = new Map<
+          string,
+          { ok: number } | { error: string; soft: boolean }
+        >();
+        for (const date of previewDates) {
+          try {
+            const result = evaluateFormula(formula, {
+              date,
+              today: monthUtils.currentDay(),
+            });
+            if (typeof result !== 'number') {
+              next.set(date, {
+                error: t('Formula did not evaluate to a number'),
+                soft: true,
+              });
+            } else {
+              next.set(date, {
+                ok: amountToInteger(result, format.currency.decimalPlaces),
+              });
+            }
+          } catch (e) {
+            if (
+              e instanceof FormulaEvaluationError &&
+              e.formulaErrorType === 'ERROR'
+            ) {
+              next.set(date, {
+                error: t('Not a valid formula'),
+                soft: true,
+              });
+            } else {
+              next.set(date, {
+                error: e instanceof Error ? e.message : String(e),
+                soft: false,
+              });
+            }
+          }
+        }
+        setFormulaPreviews(next);
+      },
+    );
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    isFormula,
+    fields.amount,
+    previewDates,
+    format.currency.decimalPlaces,
+    t,
+  ]);
+
+  function renderFormulaPreview(date: string) {
+    const preview = formulaPreviews.get(date);
+    if (!preview) {
+      return null;
+    }
+    if ('error' in preview) {
+      return (
+        <Text
+          style={{
+            fontSize: 12,
+            color: preview.soft ? theme.pageTextLight : theme.errorText,
+          }}
+        >
+          {preview.error}
+        </Text>
+      );
+    }
+    return (
+      <Text style={{ fontSize: 12, color: theme.pageTextLight }}>
+        <Trans>
+          Evaluates to {{ amount: format(preview.ok, 'financial') }} on{' '}
+          {{ date: monthUtils.format(date, dateFormat, locale) }}
+        </Trans>
+      </Text>
+    );
+  }
 
   return (
     <>
@@ -183,12 +312,18 @@ export function ScheduleEditForm({
             <SpaceBetween style={{ marginBottom: 3, alignItems: 'center' }}>
               <FormLabel
                 title={t('Amount')}
-                htmlFor="amount-field"
+                htmlFor={isFormula ? undefined : 'amount-field'}
                 style={{ margin: 0, flex: 1 }}
               />
               <OpSelect
-                ops={['isapprox', 'is', 'isbetween']}
-                value={fields.amountOp as 'isapprox' | 'is' | 'isbetween'}
+                ops={
+                  showFormulaOp
+                    ? ['isapprox', 'is', 'isbetween', 'formula']
+                    : ['isapprox', 'is', 'isbetween']
+                }
+                value={
+                  fields.amountOp as 'isapprox' | 'is' | 'isbetween' | 'formula'
+                }
                 formatOp={op => {
                   switch (op) {
                     case 'is':
@@ -197,6 +332,8 @@ export function ScheduleEditForm({
                       return t('is approximately');
                     case 'isbetween':
                       return t('is between');
+                    case 'formula':
+                      return t('is formula');
                     default:
                       throw new Error('Invalid op for select: ' + op);
                   }
@@ -215,7 +352,63 @@ export function ScheduleEditForm({
                 }
               />
             </SpaceBetween>
-            {fields.amountOp === 'isbetween' ? (
+            {isFormula ? (
+              <>
+                <View
+                  style={{
+                    flex: 1,
+                    border: `1px solid ${theme.formInputBorder}`,
+                    borderRadius: 4,
+                    overflow: 'visible',
+                    backgroundColor: theme.tableBackground,
+                  }}
+                >
+                  <Suspense fallback={<div style={{ height: 32 }} />}>
+                    <FormulaEditor
+                      value={
+                        typeof fields.amount === 'string' ? fields.amount : ''
+                      }
+                      onChange={value =>
+                        dispatch({
+                          type: 'set-field',
+                          field: 'amount',
+                          value: value.replace(/[\r\n]+/g, ' '),
+                        })
+                      }
+                      mode="schedule"
+                      singleLine
+                      showLineNumbers={false}
+                    />
+                  </Suspense>
+                </View>
+                {/* The preview line reserves its space so the other fields
+                    don't move around as the formula is edited. */}
+                <View
+                  style={{
+                    marginTop: 3,
+                    minHeight: 17,
+                    flexDirection: 'column',
+                    gap: 2,
+                  }}
+                >
+                  {previewDate && renderFormulaPreview(previewDate)}
+                  {previewDates.length > 1 &&
+                    upcomingDates
+                      ?.slice(1)
+                      .map(date => (
+                        <View key={date}>{renderFormulaPreview(date)}</View>
+                      ))}
+                  {formulaHasBalanceOf && (
+                    <Text style={{ fontSize: 12, color: theme.pageTextLight }}>
+                      <Trans>
+                        BALANCE_OF resolves to 0 in this preview; the actual
+                        value is fetched when the transaction is posted.
+                      </Trans>
+                    </Text>
+                  )}
+                </View>
+              </>
+            ) : fields.amountOp === 'isbetween' ? (
               <BetweenAmountInput
                 // @ts-expect-error fix me
                 defaultValue={fields.amount}

--- a/packages/desktop-client/src/components/schedules/ScheduleEditForm.tsx
+++ b/packages/desktop-client/src/components/schedules/ScheduleEditForm.tsx
@@ -168,53 +168,58 @@ export function ScheduleEditForm({
     }
 
     let cancelled = false;
-    void import('@actual-app/core/shared/formulas/evaluate').then(
-      ({ evaluateFormula, FormulaEvaluationError }) => {
-        if (cancelled) {
-          return;
-        }
-        const next = new Map<
-          string,
-          { ok: number } | { error: string; soft: boolean }
-        >();
-        for (const date of previewDates) {
-          try {
-            const result = evaluateFormula(formula, {
-              date,
-              today: monthUtils.currentDay(),
-            });
-            if (typeof result !== 'number') {
-              next.set(date, {
-                error: t('Formula did not evaluate to a number'),
-                soft: true,
+    // Debounce so rapid typing doesn't build and destroy a HyperFormula
+    // engine for every keystroke.
+    const timer = setTimeout(() => {
+      void import('@actual-app/core/shared/formulas/evaluate').then(
+        ({ evaluateFormula, FormulaEvaluationError }) => {
+          if (cancelled) {
+            return;
+          }
+          const next = new Map<
+            string,
+            { ok: number } | { error: string; soft: boolean }
+          >();
+          for (const date of previewDates) {
+            try {
+              const result = evaluateFormula(formula, {
+                date,
+                today: monthUtils.currentDay(),
               });
-            } else {
-              next.set(date, {
-                ok: amountToInteger(result, format.currency.decimalPlaces),
-              });
-            }
-          } catch (e) {
-            if (
-              e instanceof FormulaEvaluationError &&
-              e.formulaErrorType === 'ERROR'
-            ) {
-              next.set(date, {
-                error: t('Not a valid formula'),
-                soft: true,
-              });
-            } else {
-              next.set(date, {
-                error: e instanceof Error ? e.message : String(e),
-                soft: false,
-              });
+              if (typeof result !== 'number') {
+                next.set(date, {
+                  error: t('Formula did not evaluate to a number'),
+                  soft: true,
+                });
+              } else {
+                next.set(date, {
+                  ok: amountToInteger(result, format.currency.decimalPlaces),
+                });
+              }
+            } catch (e) {
+              if (
+                e instanceof FormulaEvaluationError &&
+                e.formulaErrorType === 'ERROR'
+              ) {
+                next.set(date, {
+                  error: t('Not a valid formula'),
+                  soft: true,
+                });
+              } else {
+                next.set(date, {
+                  error: e instanceof Error ? e.message : String(e),
+                  soft: false,
+                });
+              }
             }
           }
-        }
-        setFormulaPreviews(next);
-      },
-    );
+          setFormulaPreviews(next);
+        },
+      );
+    }, 200);
     return () => {
       cancelled = true;
+      clearTimeout(timer);
     };
   }, [
     isFormula,
@@ -312,6 +317,7 @@ export function ScheduleEditForm({
             <SpaceBetween style={{ marginBottom: 3, alignItems: 'center' }}>
               <FormLabel
                 title={t('Amount')}
+                id="amount-label"
                 htmlFor={isFormula ? undefined : 'amount-field'}
                 style={{ margin: 0, flex: 1 }}
               />
@@ -355,6 +361,9 @@ export function ScheduleEditForm({
             {isFormula ? (
               <>
                 <View
+                  id="amount-field"
+                  role="group"
+                  aria-labelledby="amount-label"
                   style={{
                     flex: 1,
                     border: `1px solid ${theme.formInputBorder}`,

--- a/packages/desktop-client/src/components/schedules/SchedulesTable.tsx
+++ b/packages/desktop-client/src/components/schedules/SchedulesTable.tsx
@@ -77,16 +77,19 @@ export function ScheduleAmountCell({
   const currencyAmount = format(Math.abs(num || 0), 'financial');
   const isApprox = op === 'isapprox';
   const isBetween = op === 'isbetween';
+  const isFormula = op === 'formula';
   let cellText = '';
   if (isApprox) {
     cellText = t('Approximately {{currencyAmount}}', {
       currencyAmount,
     });
-  } else if (isBetween && typeof amount != 'number') {
+  } else if (isBetween && typeof amount === 'object' && amount != null) {
     cellText = t('{{currency1}} to {{currency2}}', {
       currency1: format(Math.abs(amount.num1 || 0), 'financial'),
       currency2: format(Math.abs(amount.num2 || 0), 'financial'),
     });
+  } else if (isFormula && typeof amount === 'string') {
+    cellText = amount;
   } else {
     cellText = currencyAmount;
   }
@@ -128,6 +131,19 @@ export function ScheduleAmountCell({
           ±
         </View>
       )}
+      {isFormula && (
+        <View
+          style={{
+            textAlign: 'left',
+            color: theme.pageTextSubdued,
+            lineHeight: '1em',
+            marginRight: 10,
+          }}
+          title={cellText}
+        >
+          ƒ
+        </View>
+      )}
       <FinancialText
         style={{
           flex: 1,
@@ -139,7 +155,11 @@ export function ScheduleAmountCell({
         title={cellText}
       >
         <PrivacyFilter>
-          {num > 0 ? `+${currencyAmount}` : `${currencyAmount}`}
+          {isFormula
+            ? cellText
+            : num > 0
+              ? `+${currencyAmount}`
+              : `${currencyAmount}`}
         </PrivacyFilter>
       </FinancialText>
     </Cell>
@@ -325,15 +345,26 @@ export function SchedulesTable({
     return schedules.filter(schedule => {
       const payee = payees.find(p => schedule._payee === p.id);
       const account = accounts.find(a => schedule._account === a.id);
-      const amount = getScheduledAmount(schedule._amount);
-      let amountStr = '';
-      if (schedule._amountOp === 'isbetween') {
-        amountStr = '±';
-      } else if (schedule._amountOp === 'isapprox') {
-        amountStr = '~';
-      }
-      amountStr +=
-        (amount > 0 ? '+' : '') + format(Math.abs(amount || 0), 'financial');
+      const isFormula =
+        schedule._amountOp === 'formula' &&
+        typeof schedule._amount === 'string';
+      const amountStr =
+        isFormula && typeof schedule._amount === 'string'
+          ? schedule._amount
+          : (() => {
+              const amount = getScheduledAmount(schedule._amount);
+              let str = '';
+              if (schedule._amountOp === 'isbetween') {
+                str = '±';
+              } else if (schedule._amountOp === 'isapprox') {
+                str = '~';
+              }
+              return (
+                str +
+                (amount > 0 ? '+' : '') +
+                format(Math.abs(amount || 0), 'financial')
+              );
+            })();
       const dateStr = schedule.next_date
         ? monthUtilFormat(schedule.next_date, dateFormat)
         : null;

--- a/packages/desktop-client/src/components/schedules/schedule-edit-utils.ts
+++ b/packages/desktop-client/src/components/schedules/schedule-edit-utils.ts
@@ -11,6 +11,7 @@ import type { ScheduleFormFields } from './ScheduleEditForm';
 export function updateScheduleConditions(
   schedule: Partial<ScheduleEntity>,
   fields: ScheduleFormFields,
+  { forMatchSearch = false }: { forMatchSearch?: boolean } = {},
 ): { error?: string; conditions?: RuleConditionEntity[] } {
   const conds = extractScheduleConds(schedule._conditions);
 
@@ -38,8 +39,20 @@ export function updateScheduleConditions(
     return { error: t('Date is required'), conditions: [] };
   }
 
+  const isFormula = fields.amountOp === 'formula';
+
   if (fields.amount == null) {
     return { error: t('A valid amount is required'), conditions: [] };
+  }
+
+  // The match search only needs conditions the DB can evaluate; a formula
+  // amount is skipped by the query layer anyway, so an incomplete formula
+  // should not block the search. Save-time validation below stays strict.
+  if (isFormula && !forMatchSearch) {
+    const formula = typeof fields.amount === 'string' ? fields.amount : '';
+    if (!formula.startsWith('=') || formula.replace(/^=/, '').trim() === '') {
+      return { error: t('Formula must start with ='), conditions: [] };
+    }
   }
 
   return {
@@ -49,11 +62,18 @@ export function updateScheduleConditions(
       updateCond(conds.date, 'isapprox', 'date', fields.date),
       // We don't use `updateCond` for amount because we want to
       // overwrite it completely
-      {
-        op: (fields.amountOp || 'isapprox') as RuleConditionOp,
-        field: 'amount',
-        value: fields.amount,
-      },
+      isFormula && typeof fields.amount === 'string'
+        ? {
+            op: 'formula',
+            field: 'amount',
+            value: fields.amount,
+            type: 'string',
+          }
+        : {
+            op: (fields.amountOp || 'isapprox') as RuleConditionOp,
+            field: 'amount',
+            value: fields.amount,
+          },
     ].filter((val): val is RuleConditionEntity => val != null),
   };
 }

--- a/packages/desktop-client/src/components/settings/Experimental.tsx
+++ b/packages/desktop-client/src/components/settings/Experimental.tsx
@@ -194,7 +194,10 @@ export function ExperimentalFeatures() {
               flag="formulaMode"
               feedbackLink="https://github.com/actualbudget/actual/issues/5949"
             >
-              <Trans>Excel formula mode (Formula cards & Rule formulas)</Trans>
+              <Trans>
+                Excel formula mode (Formula cards, Rule formulas & Schedule
+                amounts)
+              </Trans>
             </FeatureToggle>
             <FeatureToggle
               flag="currency"

--- a/packages/desktop-client/src/hooks/usePreviewTransactions.ts
+++ b/packages/desktop-client/src/hooks/usePreviewTransactions.ts
@@ -11,6 +11,7 @@ import type {
 } from '@actual-app/core/types/models';
 
 import { useCachedSchedules } from './useCachedSchedules';
+import { useFormat } from './useFormat';
 import { useSyncedPref } from './useSyncedPref';
 import { calculateRunningBalancesBottomUp } from './useTransactions';
 
@@ -72,6 +73,7 @@ export function usePreviewTransactions({
   const [error, setError] = useState<Error | undefined>(undefined);
 
   const [upcomingLength] = useSyncedPref('upcomingScheduledTransactionLength');
+  const format = useFormat();
 
   const scheduleTransactions = useMemo(() => {
     if (isSchedulesLoading) {
@@ -83,8 +85,16 @@ export function usePreviewTransactions({
       statuses,
       upcomingLength,
       filter,
+      format.currency.decimalPlaces,
     );
-  }, [filter, isSchedulesLoading, schedules, statuses, upcomingLength]);
+  }, [
+    filter,
+    isSchedulesLoading,
+    schedules,
+    statuses,
+    upcomingLength,
+    format.currency.decimalPlaces,
+  ]);
 
   useEffect(() => {
     let isUnmounted = false;

--- a/packages/desktop-client/src/hooks/useScheduleEdit.ts
+++ b/packages/desktop-client/src/hooks/useScheduleEdit.ts
@@ -401,25 +401,36 @@ export function useScheduleEdit({
 
       void send('make-filters-from-conditions', {
         conditions,
-      }).then(({ filters }) => {
-        if (current) {
-          const live = liveQuery<TransactionEntity>(
-            q('transactions')
-              .filter({ $and: filters })
-              .select('*')
-              .options({ splits: 'all' }),
-            {
-              onData: data =>
-                dispatch({
-                  type: 'set-transactions',
-                  transactions: data,
-                  transactionId,
-                }),
-            },
-          );
-          unsubscribe = live.unsubscribe;
-        }
-      });
+      })
+        .then(({ filters }) => {
+          if (current) {
+            const live = liveQuery<TransactionEntity>(
+              q('transactions')
+                .filter({ $and: filters })
+                .select('*')
+                .options({ splits: 'all' }),
+              {
+                onData: data =>
+                  dispatch({
+                    type: 'set-transactions',
+                    transactions: data,
+                    transactionId,
+                  }),
+              },
+            );
+            unsubscribe = live.unsubscribe;
+          }
+        })
+        .catch(error => {
+          // A failed filter request must not leave stale results silently;
+          // surface it through the same error path as validation failures.
+          if (current) {
+            dispatch({
+              type: 'form-error',
+              error: error instanceof Error ? error.message : String(error),
+            });
+          }
+        });
     }
 
     return () => {

--- a/packages/desktop-client/src/hooks/useScheduleEdit.ts
+++ b/packages/desktop-client/src/hooks/useScheduleEdit.ts
@@ -42,12 +42,12 @@ type ScheduleEditAction =
   | {
       type: 'set-field';
       field: 'amountOp';
-      value: 'is' | 'isbetween' | 'isapprox';
+      value: 'is' | 'isbetween' | 'isapprox' | 'formula';
     }
   | {
       type: 'set-field';
       field: 'amount';
-      value: number | { num1: number; num2: number };
+      value: number | { num1: number; num2: number } | string;
     }
   | {
       type: 'set-field';
@@ -130,13 +130,23 @@ function createScheduleEditReducer(useGetScheduledAmount: boolean = false) {
         };
 
         // If we are changing the amount operator either to or
-        // away from the `isbetween` operator, the amount value is
-        // different and we need to convert it
+        // away from the `isbetween` or `formula` operator, the amount
+        // value is different and we need to convert it
         if (
           action.field === 'amountOp' &&
           action.value !== state.fields.amountOp
         ) {
-          if (action.value === 'isbetween') {
+          if (action.value === 'formula') {
+            // Keep any existing formula; start with `=` otherwise
+            fields.amount =
+              typeof state.fields.amount === 'string'
+                ? state.fields.amount
+                : '=';
+          } else if (state.fields.amountOp === 'formula') {
+            // Switching away from a formula resets the amount
+            fields.amount =
+              action.value === 'isbetween' ? { num1: 0, num2: 0 } : 0;
+          } else if (action.value === 'isbetween') {
             // We need a range if switching to `isbetween`
             if (useGetScheduledAmount) {
               const num = getScheduledAmount(state.fields.amount);
@@ -156,7 +166,9 @@ function createScheduleEditReducer(useGetScheduledAmount: boolean = false) {
               fields.amount =
                 typeof state.fields.amount === 'number'
                   ? state.fields.amount
-                  : state.fields.amount?.num1;
+                  : typeof state.fields.amount === 'object'
+                    ? (state.fields.amount?.num1 ?? 0)
+                    : 0;
             }
           }
         }
@@ -362,7 +374,12 @@ export function useScheduleEdit({
     let unsubscribe: (() => void) | undefined;
 
     if (state.schedule && state.transactionsMode === 'matched') {
-      const updated = updateScheduleConditions(state.schedule, state.fields);
+      // The match search cannot evaluate formula amounts (the DB layer skips
+      // them), so an incomplete formula must not block the search or clear
+      // unrelated form errors.
+      const updated = updateScheduleConditions(state.schedule, state.fields, {
+        forMatchSearch: true,
+      });
 
       if ('error' in updated) {
         dispatch({ type: 'form-error', error: updated.error });

--- a/packages/desktop-client/src/util/rule.ts
+++ b/packages/desktop-client/src/util/rule.ts
@@ -90,6 +90,8 @@ export function friendlyOp(op, type?) {
       return t('is approx');
     case 'isbetween':
       return t('is between');
+    case 'formula':
+      return t('is formula');
     case 'contains':
       return t('contains');
     case 'hasTags':

--- a/packages/docs/docs/experimental/formulas.md
+++ b/packages/docs/docs/experimental/formulas.md
@@ -395,7 +395,17 @@ When a rule runs, Actual converts the formula result to the field type:
 
 Number fields receive the result in dollars and store it in cents — see [Cents in, dollars out](#available-variables) above.
 
-## Schedule amounts
+## Schedule amounts — dynamic amounts for scheduled transactions
+
+> **What this PR adds vs [#8591](https://github.com/actualbudget/actual/pull/8591) (BALANCE_OF in Formula reports):**
+> [#8591](https://github.com/actualbudget/actual/pull/8591) made `BALANCE_OF` work inside **Reports → Formula cards**, where it returns the account's **current** balance in **display units** (dollars) for dashboard widgets.
+> This PR makes `BALANCE_OF` work inside **Schedules → Amount is formula**, where it returns the balance **as of each occurrence's date** in **cents**, so every future posting can be a different amount (e.g. declining loan interest). They are complementary — different modes, different cutoffs, no overlap.
+
+| Feature                                                                     | Where                             | `BALANCE_OF` returns                                         | Date context                                      | Typical use                                                      |
+| --------------------------------------------------------------------------- | --------------------------------- | ------------------------------------------------------------ | ------------------------------------------------- | ---------------------------------------------------------------- |
+| Rule formulas                                                               | Rules → Set field                 | cents, cutoff = transaction's `date`/`sort_order`            | `date` = transaction date                         | `=PPMT(0.05/12, DATEDIF("2024-01-01",date,"M")+1, 360, -300000)` |
+| **Schedule formulas (this PR)**                                             | **Schedules → Amount is formula** | **cents, cutoff = occurrence's date (fresh per occurrence)** | `date` = occurrence date, re-evaluated each month | `=-ABS(INTEGER_TO_AMOUNT(BALANCE_OF("Home Loan")))*0.0715/12`    |
+| Report formulas ([#8591](https://github.com/actualbudget/actual/pull/8591)) | Reports → Formula card            | dollars, current balance now                                 | no transaction date                               | `=BALANCE_OF("Checking")`                                        |
 
 Schedule formulas compute the amount of a scheduled transaction from its occurrence date (and, with `BALANCE_OF`, from the balances of other accounts). This is useful for amounts that vary over time, such as:
 
@@ -403,6 +413,15 @@ Schedule formulas compute the amount of a scheduled transaction from its occurre
 - Loan principal tracking: `=-BALANCE_OF("Home Loan") / 100 / 12`
 - Costs that repeat several times in a month:
   `=-50 * (INT((EOMONTH(date,1) - (EOMONTH(date,0)+1) - MOD(5 - WEEKDAY(EOMONTH(date,0)+1, 2) + 7, 7)) / 7) + 1)`
+
+### Home-loan interest example (real-world)
+
+Single off-budget `Home Loan` account (balance = principal, negative). Two schedules:
+
+- **`Home loan interest (auto)`** on the **4th**, into the loan account: `=-ABS(INTEGER_TO_AMOUNT(BALANCE_OF("9baa9eb2-…")))*0.0715/12` — interest for the month, re-computed from the live balance. Use the **account ID** (not name) so renames don't silently return `0`.
+- **`Home loan EMI`** on the **5th**, fixed `−₹111,854` transfer from HDFC.
+
+Principal is implicit `EMI − interest` and falls each month as `BALANCE_OF` declines — no edits needed. Each occurrence fetches a fresh balance as of the 4th, so April vs May postings differ automatically. Budget goal templates (`schedule` lines) also re-evaluate per occurrence for correct monthly targets.
 
 ### Where to find the formula toggle
 

--- a/packages/docs/docs/experimental/formulas.md
+++ b/packages/docs/docs/experimental/formulas.md
@@ -394,3 +394,37 @@ When a rule runs, Actual converts the formula result to the field type:
 - **string fields**: converted with `String(...)`
 
 Number fields receive the result in dollars and store it in cents — see [Cents in, dollars out](#available-variables) above.
+
+## Schedule amounts
+
+Schedule formulas compute the amount of a scheduled transaction from its occurrence date (and, with `BALANCE_OF`, from the balances of other accounts). This is useful for amounts that vary over time, such as:
+
+- Credit-card statement balance payments: `=INTEGER_TO_AMOUNT(BALANCE_OF("Credit Card"))`
+- Loan principal tracking: `=-BALANCE_OF("Home Loan") / 100 / 12`
+- Costs that repeat several times in a month:
+  `=-50 * (INT((EOMONTH(date,1) - (EOMONTH(date,0)+1) - MOD(5 - WEEKDAY(EOMONTH(date,0)+1, 2) + 7, 7)) / 7) + 1)`
+
+### Where to find the formula toggle
+
+In **More -> Schedules**, edit or create a schedule and change the **Amount** operator to **is formula**. A formula editor with autocomplete and hover help replaces the amount input, and a live preview shows what the next occurrences evaluate to.
+
+### Available variables
+
+Schedule formulas evaluate with the occurrence's own date:
+
+- `date` — The date of the schedule occurrence
+- `today` — Today's date
+
+### Units
+
+Numbers written directly in the formula are in **currency units**: `=100` means 100 currency units (for example $100.00). The result is rounded to the currency's decimal places.
+
+`BALANCE_OF("…")` returns an amount in **cents** (minor units), like in rule formulas. To use it as an amount, divide by 100 or wrap it in `INTEGER_TO_AMOUNT()`:
+
+```text
+=INTEGER_TO_AMOUNT(BALANCE_OF("Credit Card"))
+```
+
+:::note
+The schedule editor's preview resolves `BALANCE_OF` to 0 because balances are only fetched when the transaction is posted. The posted transaction always uses the balance as of the scheduled date, and each occurrence is evaluated with its own date.
+:::

--- a/packages/docs/docs/experimental/formulas.md
+++ b/packages/docs/docs/experimental/formulas.md
@@ -426,5 +426,5 @@ Numbers written directly in the formula are in **currency units**: `=100` means 
 ```
 
 :::note
-The schedule editor's preview resolves `BALANCE_OF` to 0 because balances are only fetched when the transaction is posted. The posted transaction always uses the balance as of the scheduled date, and each occurrence is evaluated with its own date.
+The schedule editor's preview resolves `BALANCE_OF` to 0 because balances are only fetched when the transaction is posted. The posted transaction always uses the balance as of the scheduled date, and each occurrence is evaluated with its own date. If a formula fails to evaluate (for example, because it references an account that was deleted), the transaction is not posted.
 :::

--- a/packages/docs/docs/schedules.md
+++ b/packages/docs/docs/schedules.md
@@ -91,6 +91,8 @@ Next to the amount field, you can select if the amount is the exact number, an a
 
 If you choose _is approximately_, the amount will be treated as an estimate, and Actual will match transactions that are plus/minus 7.5% of the amount entered. This means that if you enter $100, Actual will match transactions that are between $92.50 and $107.50.
 
+If you enable the experimental Excel formula mode, you can also choose _is formula_ and enter an Excel-style formula that is evaluated against each occurrence's date. This is useful for amounts that vary over time, such as credit-card balance payments. See [Excel formula mode - Schedule amounts](./experimental/formulas.md#schedule-amounts) for details.
+
 Enable the **Automatically add transaction** checkbox if you want the schedule to automatically enter the transaction into your account register.
 This means that the transaction will be automatically entered into the account register on all scheduled dates without requiring manual approval.
 

--- a/packages/loot-core/src/server/api-models.ts
+++ b/packages/loot-core/src/server/api-models.ts
@@ -221,7 +221,7 @@ export const budgetModel = {
   },
 };
 
-export type AmountOPType = 'is' | 'isapprox' | 'isbetween';
+export type AmountOPType = 'is' | 'isapprox' | 'isbetween' | 'formula';
 
 export type APIScheduleEntity = Pick<
   ScheduleEntity,
@@ -233,7 +233,7 @@ export type APIScheduleEntity = Pick<
   payee?: ScheduleEntity['_payee']; // Optional will default to null
   account?: ScheduleEntity['_account']; // Optional will default to null
   amount?: ScheduleEntity['_amount']; // Provide only 1 number except if the Amount
-  amountOp: AmountOPType; // 'is' | 'isapprox' | 'isbetween'
+  amountOp: AmountOPType; // 'is' | 'isapprox' | 'isbetween' | 'formula'
   date: ScheduleEntity['_date']; // mandatory field in creating a schedule Mandatory field in creation
 };
 
@@ -249,7 +249,11 @@ export const scheduleModel = {
       payee: schedule._payee,
       account: schedule._account,
       amount: schedule._amount,
-      amountOp: schedule._amountOp as 'is' | 'isapprox' | 'isbetween', // e.g. 'isapprox', 'is', etc.
+      amountOp: schedule._amountOp as
+        | 'is'
+        | 'isapprox'
+        | 'isbetween'
+        | 'formula', // e.g. 'isapprox', 'is', etc.
       date: schedule._date,
     };
   },
@@ -274,7 +278,12 @@ export const scheduleModel = {
         { op: 'is', field: 'payee', value: String(schedule.payee) },
         { op: 'is', field: 'account', value: String(schedule.account) },
         { op: 'isapprox', field: 'date', value: schedule.date },
-        { op: schedule.amountOp, field: 'amount', value: amount },
+        {
+          op: schedule.amountOp,
+          field: 'amount',
+          value: amount,
+          type: schedule.amountOp === 'formula' ? 'string' : 'number',
+        },
       ],
       _actions: [], // empty array, as you requested
     };

--- a/packages/loot-core/src/server/budget/schedule-template.test.ts
+++ b/packages/loot-core/src/server/budget/schedule-template.test.ts
@@ -725,7 +725,7 @@ describe('runSchedule', () => {
     expect(result.to_budget).toBe(0);
   });
 
-  it('budgets a constant-formula expense schedule for the same amount as a static one', async () => {
+  it('budgets a constant-formula expense schedule at the formula value', async () => {
     const template_lines = [
       {
         type: 'schedule',

--- a/packages/loot-core/src/server/budget/schedule-template.test.ts
+++ b/packages/loot-core/src/server/budget/schedule-template.test.ts
@@ -1,8 +1,9 @@
 import * as db from '#server/db';
 import { Rule } from '#server/rules';
 import { getRuleForSchedule } from '#server/schedules/app';
+import { prefetchBalanceOfForTransaction } from '#server/transactions/transaction-rules';
 import type { Currency } from '#shared/currencies';
-import type { CategoryEntity } from '#types/models';
+import type { CategoryEntity, RuleConditionEntity } from '#types/models';
 
 import { isTrackingBudget } from './actions';
 import { runSchedule } from './schedule-template';
@@ -14,6 +15,15 @@ vi.mock('#server/schedules/app', async () => {
   return {
     ...actualModule,
     getRuleForSchedule: vi.fn(),
+  };
+});
+vi.mock('#server/transactions/transaction-rules', async () => {
+  const actualModule = await vi.importActual(
+    '#server/transactions/transaction-rules',
+  );
+  return {
+    ...actualModule,
+    prefetchBalanceOfForTransaction: vi.fn(),
   };
 });
 
@@ -31,18 +41,42 @@ const defaultCategory = { id: '1', name: 'Test Category' } as CategoryEntity;
 type RuleSpec = {
   id?: string;
   start: string;
-  amount: number;
   frequency: 'monthly' | 'yearly' | 'weekly' | 'daily';
   interval?: number;
-};
+  patterns?: Array<{ type: 'day'; value: number }>;
+} & (
+  | { amountOp?: 'is' | 'isapprox'; amount: number }
+  | { amountOp: 'isbetween'; amount: { num1: number; num2: number } }
+  | { amountOp: 'formula'; amount: string }
+);
 
-function makeRule({
-  id = 'r',
-  start,
-  amount,
-  frequency,
-  interval = 1,
-}: RuleSpec): Rule {
+function makeAmountCondition(spec: RuleSpec): RuleConditionEntity {
+  if (spec.amountOp === 'formula') {
+    return {
+      op: 'formula',
+      field: 'amount',
+      value: spec.amount,
+      type: 'string',
+    };
+  }
+  if (spec.amountOp === 'isbetween') {
+    return {
+      op: 'isbetween',
+      field: 'amount',
+      value: spec.amount,
+      type: 'number',
+    };
+  }
+  return {
+    op: spec.amountOp ?? 'is',
+    field: 'amount',
+    value: spec.amount,
+    type: 'number',
+  };
+}
+
+function makeRule(spec: RuleSpec): Rule {
+  const { id = 'r', start, frequency, interval = 1, patterns = [] } = spec;
   return new Rule({
     id,
     stage: 'pre',
@@ -55,7 +89,7 @@ function makeRule({
           start,
           interval,
           frequency,
-          patterns: [],
+          patterns,
           skipWeekend: false,
           weekendSolveMode: 'before',
           endMode: 'never',
@@ -64,7 +98,7 @@ function makeRule({
         },
         type: 'date',
       },
-      { op: 'is', field: 'amount', value: amount, type: 'number' },
+      makeAmountCondition(spec),
     ],
     actions: [],
   });
@@ -103,6 +137,7 @@ describe('runSchedule', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(db.getAccounts).mockResolvedValue([]);
+    vi.mocked(prefetchBalanceOfForTransaction).mockResolvedValue(new Map());
   });
 
   it('should return correct budget when recurring schedule set', async () => {
@@ -688,5 +723,185 @@ describe('runSchedule', () => {
       defaultCurrency,
     );
     expect(result.to_budget).toBe(0);
+  });
+
+  it('budgets a constant-formula expense schedule for the same amount as a static one', async () => {
+    const template_lines = [
+      {
+        type: 'schedule',
+        name: 'FormulaSchedule',
+        directive: 'template',
+        priority: 0,
+      } as const,
+    ];
+
+    mockSingleSchedule({
+      start: '2024-08-01',
+      amount: '=-100',
+      amountOp: 'formula',
+      frequency: 'monthly',
+    });
+
+    const result = await runSchedule(
+      template_lines,
+      '2024-08-01',
+      0,
+      0,
+      0,
+      0,
+      [],
+      defaultCategory,
+      defaultCurrency,
+    );
+
+    expect(result.errors).toHaveLength(0);
+    expect(result.to_budget).toBe(10000);
+  });
+
+  it('reevaluates a monthly formula schedule against each budget month independently', async () => {
+    const daysOfMonthFormula =
+      '=-DATEDIF(EOMONTH(date,-1) ,EOMONTH(date,0), "D")';
+
+    const template_lines = [
+      {
+        type: 'schedule',
+        name: 'daysOfMonth',
+        directive: 'template',
+        priority: 0,
+      } as const,
+    ];
+
+    // June run
+    mockSingleSchedule({
+      start: '2026-06-15',
+      amount: daysOfMonthFormula,
+      amountOp: 'formula',
+      frequency: 'monthly',
+    });
+    const june = await runSchedule(
+      template_lines,
+      '2026-06',
+      0,
+      0,
+      0,
+      0,
+      [],
+      defaultCategory,
+      defaultCurrency,
+    );
+
+    // July run
+    mockSingleSchedule({
+      start: '2026-06-15',
+      amount: daysOfMonthFormula,
+      amountOp: 'formula',
+      frequency: 'monthly',
+    });
+    const july = await runSchedule(
+      template_lines,
+      '2026-07',
+      0,
+      0,
+      0,
+      0,
+      [],
+      defaultCategory,
+      defaultCurrency,
+    );
+
+    expect(june.errors).toHaveLength(0);
+    expect(july.errors).toHaveLength(0);
+
+    expect(Math.abs(june.to_budget)).toBe(3000);
+    expect(Math.abs(july.to_budget)).toBe(3100);
+  });
+
+  it('budgets a date-dependent formula expense schedule per occurrence', async () => {
+    // Daily schedule where we spend the $DAY amount of dollars: 1+2+...+31
+    // for August.
+    const template_lines = [
+      {
+        type: 'schedule',
+        name: 'DailyFormula',
+        directive: 'template',
+        priority: 0,
+      } as const,
+    ];
+    mockSingleSchedule({
+      start: '2024-08-01',
+      amount: '=-DAY(date)',
+      amountOp: 'formula',
+      frequency: 'daily',
+    });
+
+    const result = await runSchedule(
+      template_lines,
+      '2024-08-01',
+      0,
+      0,
+      0,
+      0,
+      [],
+      defaultCategory,
+      defaultCurrency,
+    );
+
+    expect(result.errors).toHaveLength(0);
+    // Sum of 1..31 = 496 dollars -> 49600 cents
+    expect(result.to_budget).toBe(49600);
+  });
+
+  it('reevaluates BALANCE_OF with a fresh prefetch for each occurrence date', async () => {
+    // Two occurrences per month; the savings balance changes mid-month. A
+    // stale single-date prefetch would use the same balance for both
+    // occurrences; the correct target sums each occurrence's own balance.
+    const template_lines = [
+      {
+        type: 'schedule',
+        name: 'BalanceFormula',
+        directive: 'template',
+        priority: 0,
+      } as const,
+    ];
+    mockSingleSchedule({
+      start: '2024-07-01',
+      amount: '=-BALANCE_OF("Savings")/100',
+      amountOp: 'formula',
+      frequency: 'monthly',
+      patterns: [
+        { type: 'day', value: 1 },
+        { type: 'day', value: 15 },
+      ],
+    });
+
+    vi.mocked(prefetchBalanceOfForTransaction).mockImplementation(
+      async trans => {
+        const date = trans.date ?? '0000-00-00';
+        return new Map([['Savings', date >= '2024-07-15' ? 70000 : 50000]]);
+      },
+    );
+
+    const result = await runSchedule(
+      template_lines,
+      '2024-07',
+      0,
+      0,
+      0,
+      0,
+      [],
+      defaultCategory,
+      defaultCurrency,
+    );
+
+    expect(result.errors).toHaveLength(0);
+    // 50000 (Jul 1) + 70000 (Jul 15) = 120000 cents
+    expect(result.to_budget).toBe(120000);
+
+    // Each occurrence was prefetched with its own date.
+    const prefetchedDates = vi
+      .mocked(prefetchBalanceOfForTransaction)
+      .mock.calls.map(call => call[0].date);
+    expect(prefetchedDates).toContain('2024-07-01');
+    expect(prefetchedDates).toContain('2024-07-15');
   });
 });

--- a/packages/loot-core/src/server/budget/schedule-template.ts
+++ b/packages/loot-core/src/server/budget/schedule-template.ts
@@ -61,6 +61,7 @@ async function createScheduleList(
     const { date: dateConditions, amount: amountCondition } =
       extractScheduleConds(conditions);
     const isFormulaAmount =
+      amountCondition != null &&
       amountCondition.op === 'formula' &&
       typeof amountCondition.value === 'string';
 
@@ -73,7 +74,8 @@ async function createScheduleList(
       date: string | null,
       balanceOfPrefetched?: Map<string, number>,
     ): number => {
-      let value = getScheduledAmount(amountCondition.value, false, {
+      // A deleted amount condition resolves to 0, like getScheduledAmount.
+      let value = getScheduledAmount(amountCondition?.value ?? null, false, {
         date: date ?? undefined,
         decimalPlaces: currency.decimalPlaces,
         ...(isFormulaAmount ? { balanceOfPrefetch: balanceOfPrefetched } : {}),
@@ -121,12 +123,16 @@ async function createScheduleList(
 
     // Use each occurrence's date so "balance as of this moment" matches that
     // scheduled date; id/sort_order are unset so we don't exclude a
-    // non-existent transaction from the balance query.
+    // non-existent transaction from the balance query. The seed amount only
+    // matters for non-formula schedules; formula amounts are evaluated
+    // against the occurrence's own balance prefetch, so BALANCE_OF reflects
+    // the balance as of that occurrence.
     const computeOccurrenceTarget = async (
       date: string | null,
+      seedAmount: number = 0,
     ): Promise<number> => {
       const occurrenceContext: TransactionEntity = {
-        amount: 0,
+        amount: seedAmount,
         category: category.id,
         subtransactions: [],
         ...(date ? { date } : {}),
@@ -138,9 +144,9 @@ async function createScheduleList(
         accountsMap,
         formulaStrings,
       );
-      // Formula amounts are evaluated against the occurrence's own balance
-      // prefetch, so BALANCE_OF reflects the balance as of that occurrence.
-      const amount = computeScheduleAmount(date, balanceOfPrefetched);
+      const amount = isFormulaAmount
+        ? computeScheduleAmount(date, balanceOfPrefetched)
+        : seedAmount;
       const { amount: postRuleAmount, subtransactions } = rule.execActions({
         ...occurrenceContext,
         amount,
@@ -160,41 +166,12 @@ async function createScheduleList(
       );
     };
 
-    let target: number;
-    if (isFormulaAmount) {
-      target = await computeOccurrenceTarget(next_date_string);
-    } else {
-      const scheduleRuleContext: TransactionEntity = {
-        amount: computeScheduleAmount(next_date_string),
-        category: category.id,
-        subtransactions: [],
-        ...(next_date_string ? { date: next_date_string } : {}),
-        id: null,
-        sort_order: null,
-      } as TransactionEntity;
-
-      const balanceOfPrefetched = await prefetchBalanceOfForTransaction(
-        scheduleRuleContext,
-        accountsMap,
-        formulaStrings,
-      );
-
-      const { amount: postRuleAmount, subtransactions } = rule.execActions({
-        ...scheduleRuleContext,
-        _balanceOfPrefetched: balanceOfPrefetched,
-      });
-      const categorySubtransactions = subtransactions?.filter(
-        t => t.category === category.id,
-      );
-
-      // Unless the current category is relevant to the schedule, target the
-      // post-rule amount.
-      target =
-        sign *
-        (categorySubtransactions?.length
-          ? categorySubtransactions.reduce((acc, t) => acc + t.amount, 0)
-          : (postRuleAmount ?? scheduleRuleContext.amount));
-    }
+    const target = isFormulaAmount
+      ? await computeOccurrenceTarget(next_date_string)
+      : await computeOccurrenceTarget(
+          next_date_string,
+          computeScheduleAmount(next_date_string),
+        );
 
     const target_interval = dateConditions.value.interval
       ? dateConditions.value.interval

--- a/packages/loot-core/src/server/budget/schedule-template.ts
+++ b/packages/loot-core/src/server/budget/schedule-template.ts
@@ -10,6 +10,7 @@ import {
   extractScheduleConds,
   getDateWithSkippedWeekend,
   getNextDate,
+  getScheduledAmount,
 } from '#shared/schedules';
 import { amountToInteger } from '#shared/util';
 import type { CategoryEntity, TransactionEntity } from '#types/models';
@@ -59,32 +60,47 @@ async function createScheduleList(
     const conditions = rule.serialize().conditions;
     const { date: dateConditions, amount: amountCondition } =
       extractScheduleConds(conditions);
-    let scheduleAmount =
-      amountCondition.op === 'isbetween'
-        ? Math.round(amountCondition.value.num1 + amountCondition.value.num2) /
-          2
-        : amountCondition.value;
-    // Apply adjustment percentage if specified
-    if (template.adjustment !== undefined && template.adjustmentType) {
-      switch (template.adjustmentType) {
-        case 'percent': {
-          const adjustmentFactor = 1 + template.adjustment / 100;
-          scheduleAmount = scheduleAmount * adjustmentFactor;
-          break;
-        }
-        case 'fixed': {
-          const sign = scheduleAmount < 0 ? -1 : 1;
-          scheduleAmount +=
-            sign * amountToInteger(template.adjustment, currency.decimalPlaces);
-          break;
-        }
+    const isFormulaAmount =
+      amountCondition.op === 'formula' &&
+      typeof amountCondition.value === 'string';
 
-        default:
-        //no valid adjustment was found
+    // Formula numbers are major units (e.g. `=100` means 100 currency
+    // units), so the result is converted to integer minor units using the
+    // schedule currency's decimal places. BALANCE_OF returns cents, so it
+    // must be divided by 100 (or wrapped in INTEGER_TO_AMOUNT) inside the
+    // formula, matching rule-formula semantics.
+    const computeScheduleAmount = (
+      date: string | null,
+      balanceOfPrefetched?: Map<string, number>,
+    ): number => {
+      let value = getScheduledAmount(amountCondition.value, false, {
+        date: date ?? undefined,
+        decimalPlaces: currency.decimalPlaces,
+        ...(isFormulaAmount ? { balanceOfPrefetch: balanceOfPrefetched } : {}),
+      });
+      // Apply adjustment percentage if specified
+      if (template.adjustment !== undefined && template.adjustmentType) {
+        switch (template.adjustmentType) {
+          case 'percent': {
+            const adjustmentFactor = 1 + template.adjustment / 100;
+            value = value * adjustmentFactor;
+            break;
+          }
+          case 'fixed': {
+            const sign = value < 0 ? -1 : 1;
+            value +=
+              sign *
+              amountToInteger(template.adjustment, currency.decimalPlaces);
+            break;
+          }
+
+          default:
+          //no valid adjustment was found
+        }
       }
-    }
 
-    scheduleAmount = Math.round(scheduleAmount);
+      return Math.round(value);
+    };
 
     const next_date_string = getNextDate(
       dateConditions,
@@ -94,42 +110,91 @@ async function createScheduleList(
     // Schedule templates call rule.execActions() on the rule attached to each
     // schedule, so we prefetch balances and pass _balanceOfPrefetched here too.
     // Without that, BALANCE_OF would behave wrong or always look empty for
-    // schedule rules.
-    const formulaStrings = collectFormulasFromActions(rule.actions);
+    // schedule rules. A formula amount condition also evaluates BALANCE_OF,
+    // so its formula is prefetched alongside the actions' formulas.
+    const formulaStrings = [
+      ...collectFormulasFromActions(rule.actions),
+      ...(isFormulaAmount ? [amountCondition.value] : []),
+    ];
 
-    // Use the schedule's next occurrence date so "balance as of this moment"
-    // matches the scheduled date; id/sort_order are unset so we don't exclude a
-    // non-existent transaction from the balance query.
-    const scheduleRuleContext: TransactionEntity = {
-      amount: scheduleAmount,
-      category: category.id,
-      subtransactions: [],
-      ...(next_date_string ? { date: next_date_string } : {}),
-      id: null,
-      sort_order: null,
-    } as TransactionEntity;
-
-    const balanceOfPrefetched = await prefetchBalanceOfForTransaction(
-      scheduleRuleContext,
-      accountsMap,
-      formulaStrings,
-    );
-
-    const { amount: postRuleAmount, subtransactions } = rule.execActions({
-      ...scheduleRuleContext,
-      _balanceOfPrefetched: balanceOfPrefetched,
-    });
-    const categorySubtransactions = subtransactions?.filter(
-      t => t.category === category.id,
-    );
-
-    // Unless the current category is relevant to the schedule, target the post-rule amount.
     const sign = category.is_income ? 1 : -1;
-    const target =
-      sign *
-      (categorySubtransactions?.length
-        ? categorySubtransactions.reduce((acc, t) => acc + t.amount, 0)
-        : (postRuleAmount ?? scheduleAmount));
+
+    // Use each occurrence's date so "balance as of this moment" matches that
+    // scheduled date; id/sort_order are unset so we don't exclude a
+    // non-existent transaction from the balance query.
+    const computeOccurrenceTarget = async (
+      date: string | null,
+    ): Promise<number> => {
+      const occurrenceContext: TransactionEntity = {
+        amount: 0,
+        category: category.id,
+        subtransactions: [],
+        ...(date ? { date } : {}),
+        id: null,
+        sort_order: null,
+      } as TransactionEntity;
+      const balanceOfPrefetched = await prefetchBalanceOfForTransaction(
+        occurrenceContext,
+        accountsMap,
+        formulaStrings,
+      );
+      // Formula amounts are evaluated against the occurrence's own balance
+      // prefetch, so BALANCE_OF reflects the balance as of that occurrence.
+      const amount = computeScheduleAmount(date, balanceOfPrefetched);
+      const { amount: postRuleAmount, subtransactions } = rule.execActions({
+        ...occurrenceContext,
+        amount,
+        _balanceOfPrefetched: balanceOfPrefetched,
+      });
+      const categorySubtransactions = subtransactions?.filter(
+        t => t.category === category.id,
+      );
+
+      // Unless the current category is relevant to the schedule, target the
+      // post-rule amount.
+      return (
+        sign *
+        (categorySubtransactions?.length
+          ? categorySubtransactions.reduce((acc, t) => acc + t.amount, 0)
+          : (postRuleAmount ?? amount))
+      );
+    };
+
+    let target: number;
+    if (isFormulaAmount) {
+      target = await computeOccurrenceTarget(next_date_string);
+    } else {
+      const scheduleRuleContext: TransactionEntity = {
+        amount: computeScheduleAmount(next_date_string),
+        category: category.id,
+        subtransactions: [],
+        ...(next_date_string ? { date: next_date_string } : {}),
+        id: null,
+        sort_order: null,
+      } as TransactionEntity;
+
+      const balanceOfPrefetched = await prefetchBalanceOfForTransaction(
+        scheduleRuleContext,
+        accountsMap,
+        formulaStrings,
+      );
+
+      const { amount: postRuleAmount, subtransactions } = rule.execActions({
+        ...scheduleRuleContext,
+        _balanceOfPrefetched: balanceOfPrefetched,
+      });
+      const categorySubtransactions = subtransactions?.filter(
+        t => t.category === category.id,
+      );
+
+      // Unless the current category is relevant to the schedule, target the
+      // post-rule amount.
+      target =
+        sign *
+        (categorySubtransactions?.length
+          ? categorySubtransactions.reduce((acc, t) => acc + t.amount, 0)
+          : (postRuleAmount ?? scheduleRuleContext.amount));
+    }
 
     const target_interval = dateConditions.value.interval
       ? dateConditions.value.interval
@@ -181,7 +246,13 @@ async function createScheduleList(
               )
             : nextBaseDate;
           while (nextDate < nextMonth) {
-            monthlyTarget += -target;
+            // Formula amounts are re-evaluated per occurrence date with a
+            // fresh BALANCE_OF prefetch, so date- and balance-dependent
+            // formulas produce the correct per-occurrence target.
+            const occurrenceTarget = isFormulaAmount
+              ? await computeOccurrenceTarget(nextDate)
+              : target;
+            monthlyTarget += -occurrenceTarget;
             const currentDate = nextBaseDate;
             const oneDayLater = monthUtils.addDays(nextBaseDate, 1);
             nextBaseDate = getNextDate(

--- a/packages/loot-core/src/server/rules/action.ts
+++ b/packages/loot-core/src/server/rules/action.ts
@@ -1,28 +1,15 @@
 // @ts-strict-ignore
 import * as dateFns from 'date-fns';
 import * as Handlebars from 'handlebars';
-import { HyperFormula } from 'hyperformula';
-import enUS from 'hyperformula/i18n/languages/enUS';
 
 import { logger } from '#platform/server/log';
 import type { TransactionForRules } from '#server/transactions/transaction-rules';
-import {
-  CustomFunctionsPlugin,
-  customFunctionsTranslations,
-} from '#shared/formulas/customFunctions';
+import { evaluateFormula } from '#shared/formulas/evaluate';
 import { currentDay, format, parseDate } from '#shared/months';
 import { FIELD_TYPES } from '#shared/rules';
 import { amountToInteger } from '#shared/util';
 
 import { assert } from './rule-utils';
-
-if (!HyperFormula.getRegisteredLanguagesCodes().includes('enUS')) {
-  HyperFormula.registerLanguage('enUS', enUS);
-}
-HyperFormula.registerFunctionPlugin(
-  CustomFunctionsPlugin,
-  customFunctionsTranslations,
-);
 
 const ACTION_OPS = [
   'set',
@@ -295,66 +282,18 @@ export class Action {
     formula: string,
     transaction: Partial<TransactionForRules>,
   ): unknown {
-    let hfInstance: ReturnType<typeof HyperFormula.buildEmpty> | null = null;
-
-    if (!formula || !formula.startsWith('=')) {
-      throw new Error('Formula must start with =');
-    }
+    const { _balanceOfPrefetched, ...rest } = transaction;
+    const namedExpressions = {
+      ...rest,
+      today: currentDay(),
+      account_name: transaction._account_name || '',
+      category_name: transaction._category_name || '',
+    };
 
     try {
-      hfInstance = HyperFormula.buildEmpty({
-        licenseKey: 'gpl-v3',
-        language: 'enUS',
-        dateFormats: ['DD/MM/YYYY', 'YYYY-MM-DD', 'YYYY/MM/DD'],
-        context: {
-          balanceOfPrefetch: transaction['_balanceOfPrefetched'] ?? new Map(),
-        },
+      const cellValue = evaluateFormula(formula, namedExpressions, {
+        balanceOfPrefetch: _balanceOfPrefetched ?? new Map(),
       });
-
-      const sheetName = hfInstance.addSheet('Sheet1');
-      const sheetId = hfInstance.getSheetId(sheetName);
-
-      if (sheetId === undefined) {
-        throw new Error('Failed to create sheet');
-      }
-
-      const fieldValues: Partial<TransactionForRules> & {
-        today: string;
-        account_name: string;
-        category_name: string;
-      } = {
-        ...transaction,
-        today: currentDay(),
-        account_name: transaction._account_name || '',
-        category_name: transaction._category_name || '',
-      };
-
-      for (const key of Object.keys(fieldValues)) {
-        if (key === '_balanceOfPrefetched') {
-          continue;
-        }
-        let cellValue: string | number | boolean;
-        if (
-          fieldValues[key] === undefined ||
-          fieldValues[key] === null ||
-          typeof fieldValues[key] === 'object'
-        ) {
-          cellValue = '';
-        } else {
-          cellValue = fieldValues[key];
-        }
-        hfInstance.addNamedExpression(key, cellValue);
-      }
-      hfInstance.setCellContents({ sheet: sheetId, col: 0, row: 0 }, [
-        [formula],
-      ]);
-
-      const cellAddress = { sheet: sheetId, col: 0, row: 0 };
-      const cellValue = hfInstance.getCellValue(cellAddress);
-
-      if (cellValue && typeof cellValue === 'object' && 'type' in cellValue) {
-        throw new Error(`Formula error: ${cellValue.message}`);
-      }
 
       if (typeof cellValue === 'number') {
         return amountToInteger(Math.round(cellValue * 100) / 100);
@@ -364,12 +303,6 @@ export class Action {
     } catch (err) {
       logger.error('Formula execution error:', err);
       throw err;
-    } finally {
-      try {
-        hfInstance?.destroy();
-      } catch (err) {
-        logger.error('Error destroying HyperFormula instance:', err);
-      }
     }
   }
 

--- a/packages/loot-core/src/server/rules/action.ts
+++ b/packages/loot-core/src/server/rules/action.ts
@@ -4,6 +4,7 @@ import * as Handlebars from 'handlebars';
 
 import { logger } from '#platform/server/log';
 import type { TransactionForRules } from '#server/transactions/transaction-rules';
+import { getCachedFormulaPreferences } from '#shared/formulas/customFunctions';
 import { evaluateFormula } from '#shared/formulas/evaluate';
 import { currentDay, format, parseDate } from '#shared/months';
 import { FIELD_TYPES } from '#shared/rules';
@@ -296,7 +297,14 @@ export class Action {
       });
 
       if (typeof cellValue === 'number') {
-        return amountToInteger(Math.round(cellValue * 100) / 100);
+        // Use the app currency's decimal places so formula results scale the
+        // same way as schedule amounts (getScheduledAmount), matching for
+        // zero- and non-two-decimal currencies. Falls back to 2 decimal
+        // places when the formula preferences have not been loaded yet.
+        return amountToInteger(
+          Math.round(cellValue * 100) / 100,
+          getCachedFormulaPreferences()?.currency.decimalPlaces ?? 2,
+        );
       }
 
       return cellValue;

--- a/packages/loot-core/src/server/rules/condition.ts
+++ b/packages/loot-core/src/server/rules/condition.ts
@@ -2,6 +2,7 @@
 import * as dateFns from 'date-fns';
 
 import { logger } from '#platform/server/log';
+import { getCachedFormulaPreferences } from '#shared/formulas/customFunctions';
 import { evaluateFormula } from '#shared/formulas/evaluate';
 import {
   addDays,
@@ -351,7 +352,12 @@ export class Condition {
           if (typeof result !== 'number') {
             return false;
           }
-          const number = amountToInteger(Math.round(result * 100) / 100);
+          // Use the app currency's decimal places so the formula condition
+          // matches amounts posted for zero- and non-two-decimal currencies.
+          const number = amountToInteger(
+            Math.round(result * 100) / 100,
+            getCachedFormulaPreferences()?.currency.decimalPlaces ?? 2,
+          );
           const threshold = getApproxNumberThreshold(number);
           return (
             fieldValue >= number - threshold && fieldValue <= number + threshold

--- a/packages/loot-core/src/server/rules/condition.ts
+++ b/packages/loot-core/src/server/rules/condition.ts
@@ -2,8 +2,10 @@
 import * as dateFns from 'date-fns';
 
 import { logger } from '#platform/server/log';
+import { evaluateFormula } from '#shared/formulas/evaluate';
 import {
   addDays,
+  currentDay,
   isAfter,
   isBefore,
   monthFromDate,
@@ -18,6 +20,7 @@ import {
   sortNumbers,
 } from '#shared/rules';
 import { extractTagsForFilter } from '#shared/tags';
+import { amountToInteger } from '#shared/util';
 
 import {
   assert,
@@ -142,9 +145,18 @@ export const CONDITION_TYPES = {
     },
   },
   number: {
-    ops: ['is', 'isapprox', 'isbetween', 'gt', 'gte', 'lt', 'lte'],
+    ops: ['is', 'isapprox', 'isbetween', 'gt', 'gte', 'lt', 'lte', 'formula'],
     nullable: false,
     parse(op, value, fieldName) {
+      if (op === 'formula') {
+        assert(
+          typeof value === 'string' && value.startsWith('='),
+          'number-format',
+          `Formula value must be a string starting with "=" (field: ${fieldName})`,
+        );
+        return { type: 'formula', value };
+      }
+
       const parsed =
         typeof value === 'number'
           ? { type: 'literal', value }
@@ -320,6 +332,35 @@ export class Condition {
           return fieldValue === number;
         }
         return fieldValue === this.value;
+
+      case 'formula': {
+        // A formula condition is matched against the field value using the
+        // same approximate semantics as `isapprox`. It can only be evaluated
+        // in-memory (SQLite can't run formulas), so the DB layer skips it.
+        try {
+          const result = evaluateFormula(
+            this.value.value,
+            {
+              date: object.date ?? currentDay(),
+              today: currentDay(),
+            },
+            {
+              balanceOfPrefetch: object._balanceOfPrefetched ?? new Map(),
+            },
+          );
+          if (typeof result !== 'number') {
+            return false;
+          }
+          const number = amountToInteger(Math.round(result * 100) / 100);
+          const threshold = getApproxNumberThreshold(number);
+          return (
+            fieldValue >= number - threshold && fieldValue <= number + threshold
+          );
+        } catch (err) {
+          logger.warn('Formula condition evaluation error:', err);
+          return false;
+        }
+      }
 
       case 'isNot':
         return fieldValue !== this.value;

--- a/packages/loot-core/src/server/rules/formula-action.test.ts
+++ b/packages/loot-core/src/server/rules/formula-action.test.ts
@@ -28,6 +28,37 @@ describe('Formula-based rule actions', () => {
     expect(result).toBe(30000);
   });
 
+  it('should scale formula results with the currency decimal places', () => {
+    const action = new Action('set', 'amount', null, {});
+    const transaction: Partial<TransactionForRules> = { amount: 500 };
+
+    // JPY has 0 decimal places: =100 means 100 yen
+    setCachedUserPreferences({
+      currency: getCurrency('JPY'),
+      numberFormat: 'comma-dot',
+      decimalPlaces: 0,
+      thousandsSeparator: ',',
+      decimalSeparator: '.',
+      locale: 'en-US',
+      currencySymbolPosition: 'before',
+      currencySpaceBetweenAmountAndSymbol: false,
+    });
+    expect(action.executeFormulaSync('=100', transaction)).toBe(100);
+
+    // A 3-decimal currency: =100 means 100.000 minor units
+    setCachedUserPreferences({
+      currency: { ...getCurrency('USD'), decimalPlaces: 3 },
+      numberFormat: 'comma-dot',
+      decimalPlaces: 3,
+      thousandsSeparator: ',',
+      decimalSeparator: '.',
+      locale: 'en-US',
+      currencySymbolPosition: 'before',
+      currencySpaceBetweenAmountAndSymbol: false,
+    });
+    expect(action.executeFormulaSync('=100', transaction)).toBe(100000);
+  });
+
   it('should use transaction field variables', () => {
     const action = new Action('set', 'notes', null, {});
     const transaction = { amount: 5000 };

--- a/packages/loot-core/src/server/rules/index.test.ts
+++ b/packages/loot-core/src/server/rules/index.test.ts
@@ -1,4 +1,7 @@
 // @ts-strict-ignore
+import { getCurrency } from '#shared/currencies';
+import { setCachedUserPreferences } from '#shared/formulas/customFunctions';
+
 import {
   Action,
   Condition,
@@ -104,6 +107,38 @@ describe('Condition', () => {
     cond = new Condition('formula', 'amount', '=1 +', null);
     expect(cond.eval({ amount: 0, date: '2020-08-10' })).toBe(false);
     warnSpy.mockRestore();
+  });
+
+  test('formula conditions scale with the currency decimal places', () => {
+    const prefs = (
+      decimalPlaces: number,
+      currency = getCurrency('USD'),
+    ): Parameters<typeof setCachedUserPreferences>[0] => ({
+      currency: { ...currency, decimalPlaces },
+      numberFormat: 'comma-dot',
+      decimalPlaces,
+      thousandsSeparator: ',',
+      decimalSeparator: '.',
+      locale: 'en-US',
+      currencySymbolPosition: 'before',
+      currencySpaceBetweenAmountAndSymbol: false,
+    });
+
+    try {
+      // JPY: 0 decimal places, so =100 matches amount 100
+      setCachedUserPreferences(prefs(0, getCurrency('JPY')));
+      let cond = new Condition('formula', 'amount', '=100', null);
+      expect(cond.eval({ amount: 100, date: '2020-08-10' })).toBe(true);
+      expect(cond.eval({ amount: 10000, date: '2020-08-10' })).toBe(false);
+
+      // 3-decimal currency: =100 matches amount 100000
+      setCachedUserPreferences(prefs(3));
+      cond = new Condition('formula', 'amount', '=100', null);
+      expect(cond.eval({ amount: 100000, date: '2020-08-10' })).toBe(true);
+      expect(cond.eval({ amount: 10000, date: '2020-08-10' })).toBe(false);
+    } finally {
+      setCachedUserPreferences(prefs(2));
+    }
   });
 
   test('date restricts operators for each type', () => {

--- a/packages/loot-core/src/server/rules/index.test.ts
+++ b/packages/loot-core/src/server/rules/index.test.ts
@@ -68,6 +68,44 @@ describe('Condition', () => {
     spy.mockRestore();
   });
 
+  test('formula conditions require a formula value', () => {
+    expect(() => new Condition('formula', 'amount', 100, null)).toThrow(
+      'Formula value must be a string starting with "="',
+    );
+    expect(() => new Condition('formula', 'amount', '100', null)).toThrow(
+      'Formula value must be a string starting with "="',
+    );
+    expect(
+      () => new Condition('formula', 'amount', '=100', null),
+    ).not.toThrow();
+  });
+
+  test('formula conditions evaluate against the field value approximately', () => {
+    // =100 major units -> 10000 minor units
+    let cond = new Condition('formula', 'amount', '=100', null);
+    expect(cond.eval({ amount: 10000, date: '2020-08-10' })).toBe(true);
+    expect(cond.eval({ amount: 10001, date: '2020-08-10' })).toBe(true);
+    expect(cond.eval({ amount: 20000, date: '2020-08-10' })).toBe(false);
+
+    // Date-dependent formulas use the transaction's own date
+    cond = new Condition('formula', 'amount', '=DAY(date) * 100', null);
+    expect(cond.eval({ amount: 150000, date: '2020-08-15' })).toBe(true);
+    expect(cond.eval({ amount: 10000, date: '2020-08-15' })).toBe(false);
+  });
+
+  test('formula conditions never match non-numeric or invalid formulas', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => null);
+    let cond = new Condition('formula', 'amount', '="hello"', null);
+    expect(cond.eval({ amount: 0, date: '2020-08-10' })).toBe(false);
+
+    cond = new Condition('formula', 'amount', '=NOT_A_FUNCTION()', null);
+    expect(cond.eval({ amount: 0, date: '2020-08-10' })).toBe(false);
+
+    cond = new Condition('formula', 'amount', '=1 +', null);
+    expect(cond.eval({ amount: 0, date: '2020-08-10' })).toBe(false);
+    warnSpy.mockRestore();
+  });
+
   test('date restricts operators for each type', () => {
     expect(() => {
       new Condition('isapprox', 'date', '2020-08', null);

--- a/packages/loot-core/src/server/rules/rule-utils.ts
+++ b/packages/loot-core/src/server/rules/rule-utils.ts
@@ -33,6 +33,7 @@ const OP_SCORES: Record<RuleConditionEntity['op'], number> = {
   hasAnyTag: 0,
   onBudget: 0,
   offBudget: 0,
+  formula: 0,
 };
 
 function computeScore(rule: Rule): number {

--- a/packages/loot-core/src/server/schedules/app.test.ts
+++ b/packages/loot-core/src/server/schedules/app.test.ts
@@ -1010,5 +1010,198 @@ describe('schedule app', () => {
         await schedulesApp.stopServices();
       }
     });
+
+    it('createSchedule mirrors a formula amount into a `set amount` action', async () => {
+      const id = await createSchedule({
+        conditions: [
+          { op: 'is', field: 'date', value: '2024-08-01' },
+          {
+            op: 'formula',
+            field: 'amount',
+            value: '=-DAY(date) * 100',
+            type: 'string',
+          },
+        ],
+      });
+
+      const { data: ruleId } = await aqlQuery(
+        q('schedules').filter({ id }).calculate('rule'),
+      );
+      const ruleRow = await db.first<Pick<db.DbRule, 'actions'>>(
+        'SELECT actions FROM rules WHERE id = ?',
+        [ruleId],
+      );
+
+      const actions = JSON.parse(ruleRow.actions);
+      // Posting runs the rule's actions, so the formula must be mirrored into
+      // a `set amount` action for per-transaction re-evaluation.
+      expect(actions).toContainEqual({
+        op: 'set',
+        field: 'amount',
+        value: 0,
+        options: { formula: '=-DAY(date) * 100' },
+      });
+    });
+
+    it('updateSchedule mirrors a formula amount into existing `set amount` actions', async () => {
+      const id = await createSchedule({
+        conditions: [
+          { op: 'is', field: 'date', value: '2024-08-01' },
+          { op: 'is', field: 'amount', value: -6000 },
+        ],
+      });
+
+      const { data: ruleId } = await aqlQuery(
+        q('schedules').filter({ id }).calculate('rule'),
+      );
+      const ruleRow = await db.first<Pick<db.DbRule, 'actions'>>(
+        'SELECT actions FROM rules WHERE id = ?',
+        [ruleId],
+      );
+      await updateRule({
+        id: ruleId,
+        actions: [
+          { op: 'set', field: 'amount', value: -6000 },
+          ...JSON.parse(ruleRow.actions),
+        ],
+      });
+
+      // Switch the amount to a formula.
+      await updateSchedule({
+        schedule: { id },
+        conditions: [
+          { op: 'is', field: 'date', value: '2024-08-01' },
+          {
+            op: 'formula',
+            field: 'amount',
+            value: '=-DAY(date) * 100',
+            type: 'string',
+          },
+        ],
+      });
+
+      let ruleAfter = await db.first<Pick<db.DbRule, 'actions'>>(
+        'SELECT actions FROM rules WHERE id = ?',
+        [ruleId],
+      );
+      expect(JSON.parse(ruleAfter.actions)).toContainEqual({
+        op: 'set',
+        field: 'amount',
+        value: 0,
+        options: { formula: '=-DAY(date) * 100' },
+        type: 'number',
+      });
+
+      // Switching back to a fixed amount clears the stale formula.
+      await updateSchedule({
+        schedule: { id },
+        conditions: [
+          { op: 'is', field: 'date', value: '2024-08-01' },
+          { op: 'is', field: 'amount', value: -8000 },
+        ],
+      });
+
+      ruleAfter = await db.first<Pick<db.DbRule, 'actions'>>(
+        'SELECT actions FROM rules WHERE id = ?',
+        [ruleId],
+      );
+      expect(JSON.parse(ruleAfter.actions)).toContainEqual({
+        op: 'set',
+        field: 'amount',
+        value: -8000,
+        type: 'number',
+      });
+    });
+
+    it('posts a date-dependent formula schedule with the occurrence date', async () => {
+      MockDate.set(new Date(2016, 11, 31, 12));
+      schedulesApp.startServices();
+
+      try {
+        const accountId = await db.insertAccount({
+          name: 'Checking',
+          offbudget: 0,
+          closed: 0,
+        });
+
+        // DAY(2016-12-31) = 31 -> -31 * 100 major units = -310000 cents
+        const id = await createSchedule({
+          schedule: { posts_transaction: true },
+          conditions: [
+            { op: 'is', field: 'account', value: accountId },
+            {
+              op: 'formula',
+              field: 'amount',
+              value: '=-DAY(date) * 100',
+              type: 'string',
+            },
+            { op: 'is', field: 'date', value: '2016-12-31' },
+          ],
+        });
+
+        await advanceSchedulesService(true);
+
+        const { data: transactions } = await aqlQuery(
+          q('transactions').filter({ schedule: id }).select(['amount']),
+        );
+        expect(transactions.map(({ amount }) => amount)).toEqual([-310000]);
+      } finally {
+        MockDate.reset();
+        await schedulesApp.stopServices();
+      }
+    });
+
+    it('posts a BALANCE_OF formula schedule using the balance as of the scheduled date', async () => {
+      MockDate.set(new Date(2016, 11, 31, 12));
+      schedulesApp.startServices();
+
+      try {
+        const savingsId = await db.insertAccount({
+          name: 'Savings',
+          offbudget: 0,
+          closed: 0,
+        });
+        const checkingId = await db.insertAccount({
+          name: 'Checking',
+          offbudget: 0,
+          closed: 0,
+        });
+
+        // The savings balance at the scheduled date (2016-12-31) is $500.
+        // BALANCE_OF returns cents, so the formula divides by 100 to stay in
+        // the formula's major-unit convention.
+        await db.insertTransaction({
+          id: 'savings-deposit',
+          amount: 50000,
+          date: '2016-12-30',
+          account: savingsId,
+          cleared: true,
+        });
+
+        const id = await createSchedule({
+          schedule: { posts_transaction: true },
+          conditions: [
+            { op: 'is', field: 'account', value: checkingId },
+            {
+              op: 'formula',
+              field: 'amount',
+              value: '=-BALANCE_OF("Savings")/100',
+              type: 'string',
+            },
+            { op: 'is', field: 'date', value: '2016-12-31' },
+          ],
+        });
+
+        await advanceSchedulesService(true);
+
+        const { data: transactions } = await aqlQuery(
+          q('transactions').filter({ schedule: id }).select(['amount']),
+        );
+        expect(transactions.map(({ amount }) => amount)).toEqual([-50000]);
+      } finally {
+        MockDate.reset();
+        await schedulesApp.stopServices();
+      }
+    });
   });
 });

--- a/packages/loot-core/src/server/schedules/app.test.ts
+++ b/packages/loot-core/src/server/schedules/app.test.ts
@@ -1040,6 +1040,7 @@ describe('schedule app', () => {
         field: 'amount',
         value: 0,
         options: { formula: '=-DAY(date) * 100' },
+        type: 'number',
       });
     });
 
@@ -1178,6 +1179,16 @@ describe('schedule app', () => {
           cleared: true,
         });
 
+        // Dated after the schedule; it must not affect the prefetched
+        // balance, proving the as-of-scheduled-date cutoff is applied.
+        await db.insertTransaction({
+          id: 'savings-later-deposit',
+          amount: 25000,
+          date: '2017-01-05',
+          account: savingsId,
+          cleared: true,
+        });
+
         const id = await createSchedule({
           schedule: { posts_transaction: true },
           conditions: [
@@ -1198,6 +1209,45 @@ describe('schedule app', () => {
           q('transactions').filter({ schedule: id }).select(['amount']),
         );
         expect(transactions.map(({ amount }) => amount)).toEqual([-50000]);
+      } finally {
+        MockDate.reset();
+        await schedulesApp.stopServices();
+      }
+    });
+
+    it('does not post a transaction when the formula fails to evaluate', async () => {
+      MockDate.set(new Date(2016, 11, 31, 12));
+      schedulesApp.startServices();
+
+      try {
+        const accountId = await db.insertAccount({
+          name: 'Checking',
+          offbudget: 0,
+          closed: 0,
+        });
+
+        // =1/0 is a parseable but non-evaluable formula (#DIV/0!)
+        const id = await createSchedule({
+          schedule: { posts_transaction: true },
+          conditions: [
+            { op: 'is', field: 'account', value: accountId },
+            {
+              op: 'formula',
+              field: 'amount',
+              value: '=1/0',
+              type: 'string',
+            },
+            { op: 'is', field: 'date', value: '2016-12-31' },
+          ],
+        });
+
+        await advanceSchedulesService(true);
+
+        const { data: transactions } = await aqlQuery(
+          q('transactions').filter({ schedule: id }).select(['amount']),
+        );
+        // No transaction with a silent amount of 0 is created.
+        expect(transactions).toEqual([]);
       } finally {
         MockDate.reset();
         await schedulesApp.stopServices();

--- a/packages/loot-core/src/server/schedules/app.ts
+++ b/packages/loot-core/src/server/schedules/app.ts
@@ -30,6 +30,7 @@ import { currentDay, dayFromDate, parseDate } from '#shared/months';
 import { q } from '#shared/query';
 import {
   DEFAULT_UPCOMING_SCHEDULE_DAYS,
+  evaluateScheduledAmount,
   extractScheduleConds,
   getDateWithSkippedWeekend,
   getHasTransactionsQuery,
@@ -189,6 +190,7 @@ function updateActions(
         field: 'amount',
         value: 0,
         options: { formula },
+        type: 'number',
       });
     }
 
@@ -210,17 +212,19 @@ function updateActions(
       return action;
     }
 
-    const hasStaleFormula = action.options?.formula != null;
-    if (!hasStaleFormula && action.value === amount) {
-      return action;
-    }
-
-    changed = true;
-    if (!hasStaleFormula) {
+    const options = action.options;
+    if (options?.formula == null) {
+      if (action.value === amount) {
+        return action;
+      }
+      changed = true;
       return { ...action, value: amount };
     }
 
-    const { formula: _drop, ...rest } = action.options!;
+    // Drop a stale formula from a previously-formula schedule and replace
+    // it with the fixed amount.
+    changed = true;
+    const { formula: _drop, ...rest } = options;
     return {
       ...action,
       value: amount,
@@ -688,14 +692,26 @@ async function postTransactionForSchedule({
     );
   }
 
+  // A failing formula (e.g. BALANCE_OF referencing a deleted account) must
+  // not post a transaction with amount 0: report it and skip the posting.
+  // The schedule remains due and the failure shows up in the logs.
+  const { amount, error } = evaluateScheduledAmount(schedule._amount, false, {
+    date: postingDate,
+    decimalPlaces,
+    balanceOfPrefetch: balanceOfPrefetched,
+  });
+  if (error) {
+    logger.error(
+      `schedule: failed to evaluate formula amount for schedule ${schedule.id}:`,
+      error,
+    );
+    return;
+  }
+
   const transaction = {
     payee: schedule._payee,
     account: schedule._account,
-    amount: getScheduledAmount(schedule._amount, false, {
-      date: postingDate,
-      decimalPlaces,
-      balanceOfPrefetch: balanceOfPrefetched,
-    }),
+    amount,
     date: postingDate,
     schedule: schedule.id,
     cleared: false,

--- a/packages/loot-core/src/server/schedules/app.ts
+++ b/packages/loot-core/src/server/schedules/app.ts
@@ -9,19 +9,23 @@ import { addTransactions } from '#server/accounts/sync';
 import { createApp } from '#server/app';
 import { aqlQuery } from '#server/aql';
 import * as db from '#server/db';
+import { ensureFormulaPreferencesLoaded } from '#server/formulas/bootstrap';
 import { toDateRepr } from '#server/models';
 import { mutator, runMutator } from '#server/mutators';
 import * as prefs from '#server/prefs';
 import { Rule } from '#server/rules';
+import { collectFormulasFromActions } from '#server/rules/balanceOfFormula';
 import { addSyncListener, batchMessages } from '#server/sync';
 import {
   getRules,
   insertRule,
+  prefetchBalanceOfForTransaction,
   ruleModel,
   updateRule,
 } from '#server/transactions/transaction-rules';
 import { undoable } from '#server/undo';
 import { RSchedule } from '#server/util/rschedule';
+import { getCachedFormulaPreferences } from '#shared/formulas/customFunctions';
 import { currentDay, dayFromDate, parseDate } from '#shared/months';
 import { q } from '#shared/query';
 import {
@@ -38,6 +42,7 @@ import type {
   RuleActionEntity,
   RuleConditionEntity,
   ScheduleEntity,
+  TransactionEntity,
 } from '#types/models';
 
 import { findSchedules } from './find-schedules';
@@ -132,9 +137,16 @@ export function updateConditions(conditions, newConditions) {
 // would revert the posted amount to the old value, ignoring the edited
 // amount. Keep such actions in sync with the amount condition.
 //
-// Only plain `set amount` actions are rewritten:
-//   - Templated/formula actions (`options.template`/`options.formula`) compute
-//     their own value, so they're left untouched.
+// `set amount` actions are rewritten as follows:
+//   - When the amount condition is a formula, the action mirrors that formula
+//     (via `options.formula`) so the rule re-evaluates per transaction with
+//     that transaction's own date and balance context. If no `set amount`
+//     action exists, one is added.
+//   - When the amount condition is *not* a formula, any leftover
+//     `options.formula` is cleared so a previously-formula schedule cannot
+//     keep applying the stale formula via the action.
+//   - Templated actions (`options.template`) compute their own value, so
+//     they're left untouched.
 //   - `set-split-amount` actions have a different `op` and so are excluded by
 //     the `action.op === 'set'` check below.
 //
@@ -148,6 +160,41 @@ function updateActions(
     return null;
   }
 
+  // For formula schedules, mirror the formula into any plain `set amount`
+  // action (adding one if none exists) so the rule re-evaluates against each
+  // transaction's own date instead of carrying a stale numeric snapshot.
+  if (amountCond.op === 'formula' && typeof amountCond.value === 'string') {
+    const formula = amountCond.value;
+    let changed = false;
+    let hasSetAmountAction = false;
+    const updated = actions.map(action => {
+      if (action.op === 'set' && action.field === 'amount') {
+        hasSetAmountAction = true;
+        if (!action.options?.template && action.options?.formula !== formula) {
+          changed = true;
+          return {
+            ...action,
+            value: 0,
+            options: { ...action.options, formula },
+          };
+        }
+      }
+      return action;
+    });
+
+    if (!hasSetAmountAction) {
+      changed = true;
+      updated.push({
+        op: 'set',
+        field: 'amount',
+        value: 0,
+        options: { formula },
+      });
+    }
+
+    return changed ? updated : null;
+  }
+
   // Mirrors how `_amount` resolves: a deleted/empty amount condition value
   // yields 0, so the action is synced to 0 too, keeping it consistent with
   // the amount the schedule actually posts.
@@ -156,16 +203,29 @@ function updateActions(
   let changed = false;
   const updated = actions.map(action => {
     if (
-      action.op === 'set' &&
-      action.field === 'amount' &&
-      !action.options?.template &&
-      !action.options?.formula &&
-      action.value !== amount
+      action.op !== 'set' ||
+      action.field !== 'amount' ||
+      action.options?.template
     ) {
-      changed = true;
+      return action;
+    }
+
+    const hasStaleFormula = action.options?.formula != null;
+    if (!hasStaleFormula && action.value === amount) {
+      return action;
+    }
+
+    changed = true;
+    if (!hasStaleFormula) {
       return { ...action, value: amount };
     }
-    return action;
+
+    const { formula: _drop, ...rest } = action.options!;
+    return {
+      ...action,
+      value: amount,
+      options: Object.keys(rest).length > 0 ? rest : undefined,
+    };
   });
 
   return changed ? updated : null;
@@ -350,12 +410,20 @@ export async function createSchedule({
     }
   }
 
-  // Create the rule here based on the info
+  // Create the rule here based on the info. Formula schedules get their
+  // formula mirrored into a `set amount` action so that posting (which runs
+  // the rule's actions) re-evaluates per transaction with fresh balance
+  // context; see `updateActions`.
+  const baseActions: RuleActionEntity[] = [
+    { op: 'link-schedule', value: scheduleId },
+  ];
+  const actions = updateActions(conditions, baseActions) ?? baseActions;
+
   const ruleId = await insertRule({
     stage: null,
     conditionsOp: 'and',
     conditions,
-    actions: [{ op: 'link-schedule', value: scheduleId }],
+    actions,
   });
 
   const now = Date.now();
@@ -584,11 +652,51 @@ async function postTransactionForSchedule({
     return;
   }
 
+  const postingDate = today ? currentDay() : schedule.next_date;
+
+  await ensureFormulaPreferencesLoaded();
+  const decimalPlaces =
+    getCachedFormulaPreferences()?.currency.decimalPlaces ?? 2;
+
+  // Prefetch balances for a formula amount so BALANCE_OF() resolves to the
+  // balance "as of" the scheduled date, even if the rule's `set amount`
+  // action has been customized or removed. runRules re-evaluates the action
+  // afterwards with its own prefetch, so this only matters for the initial
+  // amount the transaction is created with.
+  let balanceOfPrefetched: Map<string, number> | undefined;
+  if (typeof schedule._amount === 'string') {
+    const rule = await getRuleForSchedule(id).catch(() => null);
+    const formulaStrings = [
+      ...collectFormulasFromActions(rule?.actions ?? []),
+      schedule._amount,
+    ];
+    const accountsMap = new Map(
+      (await db.getAccounts()).map(account => [account.id, account]),
+    );
+    const context = {
+      amount: 0,
+      category: null,
+      subtransactions: [],
+      ...(postingDate ? { date: postingDate } : {}),
+      id: null,
+      sort_order: null,
+    } as TransactionEntity;
+    balanceOfPrefetched = await prefetchBalanceOfForTransaction(
+      context,
+      accountsMap,
+      formulaStrings,
+    );
+  }
+
   const transaction = {
     payee: schedule._payee,
     account: schedule._account,
-    amount: getScheduledAmount(schedule._amount),
-    date: today ? currentDay() : schedule.next_date,
+    amount: getScheduledAmount(schedule._amount, false, {
+      date: postingDate,
+      decimalPlaces,
+      balanceOfPrefetch: balanceOfPrefetched,
+    }),
+    date: postingDate,
     schedule: schedule.id,
     cleared: false,
   };

--- a/packages/loot-core/src/server/transactions/transaction-rules.test.ts
+++ b/packages/loot-core/src/server/transactions/transaction-rules.test.ts
@@ -838,6 +838,35 @@ describe('Transaction rules', () => {
       },
     ]);
   });
+
+  test('formula amount condition is skipped at the AQL layer', async () => {
+    // SQLite can't evaluate formulas, so it is omitted from the query; the
+    // remaining conditions still narrow the match candidate set.
+    const { filters, errors } = conditionsToAQL([
+      { field: 'amount', op: 'formula', value: '=DAY(date) * 100' },
+      { field: 'notes', op: 'is', value: 'rent' },
+    ]);
+    expect(errors).toEqual([]);
+    expect(filters).toEqual([{ notes: { $transform: '$lower', $eq: 'rent' } }]);
+  });
+
+  test('formula amount condition is skipped inside nested and groups', async () => {
+    // The formula inside the `and` group must not produce a null fragment;
+    // the remaining sub-condition still matches.
+    const { filters, errors } = conditionsToAQL([
+      {
+        field: 'category',
+        op: 'and',
+        value: [
+          { field: 'amount', op: 'formula', value: '=BALANCE_OF("Checking")' },
+          { field: 'payee', op: 'is', value: 'Rent' },
+        ],
+      },
+      { field: 'amount', op: 'formula', value: '=100' },
+    ]);
+    expect(errors).toEqual([]);
+    expect(filters).toEqual([{ $and: [{ payee: { $eq: 'Rent' } }] }]);
+  });
 });
 
 describe('Learning categories', () => {

--- a/packages/loot-core/src/server/transactions/transaction-rules.ts
+++ b/packages/loot-core/src/server/transactions/transaction-rules.ts
@@ -690,22 +690,35 @@ export function conditionsToAQL(
         return apply(field, '$eq', true);
       case 'false':
         return apply(field, '$eq', false);
-      case 'and':
-        return {
-          $and: getValue(value).map(subExpr => mapConditionToActualQL(subExpr)),
-        };
+      case 'and': {
+        const subFilters = getValue(value)
+          .map(subExpr => mapConditionToActualQL(subExpr))
+          .filter(f => f != null);
+        if (subFilters.length === 0) {
+          return null;
+        }
+        return { $and: subFilters };
+      }
 
       case 'onBudget':
         return { 'account.offbudget': false };
       case 'offBudget':
         return { 'account.offbudget': true };
 
+      case 'formula':
+        // Formula conditions can only be evaluated in JS (HyperFormula);
+        // SQLite can't run them per row. Skip this condition at the DB
+        // layer — the remaining conditions still narrow the match candidate
+        // set, and the rule engine's in-memory `Condition.eval` handles the
+        // exact match when the rule actually fires.
+        return null;
+
       default:
         throw new Error('Unhandled operator: ' + op);
     }
   };
 
-  const filters = conditions.map(mapConditionToActualQL);
+  const filters = conditions.map(mapConditionToActualQL).filter(f => f != null);
   return { filters, errors };
 }
 

--- a/packages/loot-core/src/shared/formulas/customFunctions.ts
+++ b/packages/loot-core/src/shared/formulas/customFunctions.ts
@@ -64,6 +64,11 @@ export function setCachedUserPreferences(prefs: UserPreferences): void {
   cachedUserPreferences = prefs;
 }
 
+/** Returns the cached formula preferences, or null before they are loaded. */
+export function getCachedFormulaPreferences(): UserPreferences | null {
+  return cachedUserPreferences;
+}
+
 export function clearCachedUserPreferences(): void {
   cachedUserPreferences = null;
 }

--- a/packages/loot-core/src/shared/formulas/evaluate.test.ts
+++ b/packages/loot-core/src/shared/formulas/evaluate.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+
+import { evaluateFormula, FormulaEvaluationError } from './evaluate';
+
+describe('evaluateFormula', () => {
+  it('evaluates a constant formula', () => {
+    expect(evaluateFormula('=1 + 2', {})).toBe(3);
+  });
+
+  it('evaluates named expressions', () => {
+    expect(evaluateFormula('=amount * 2', { amount: 5 })).toBe(10);
+    expect(evaluateFormula('=MONTH(date)', { date: '2026-03-15' })).toBe(3);
+    expect(
+      evaluateFormula('=IF(date > DATE(2026, 1, 1), "after", "before")', {
+        date: '2026-03-15',
+      }),
+    ).toBe('after');
+  });
+
+  it('treats non-primitive named expression values as empty', () => {
+    expect(evaluateFormula('=IF(x = "", "empty", "filled")', { x: {} })).toBe(
+      'empty',
+    );
+  });
+
+  it('throws when the formula does not start with =', () => {
+    expect(() => evaluateFormula('1 + 2', {})).toThrow(
+      'Formula must start with =',
+    );
+  });
+
+  it('throws a FormulaEvaluationError with the error type for invalid formulas', () => {
+    try {
+      evaluateFormula('=1 +', {});
+      expect.unreachable();
+    } catch (err) {
+      expect(err).toBeInstanceOf(FormulaEvaluationError);
+      expect((err as FormulaEvaluationError).formulaErrorType).toBe('ERROR');
+    }
+  });
+
+  it('throws a FormulaEvaluationError for unknown functions', () => {
+    try {
+      evaluateFormula('=NOT_A_REAL_FUNCTION()', {});
+      expect.unreachable();
+    } catch (err) {
+      expect(err).toBeInstanceOf(FormulaEvaluationError);
+      expect((err as FormulaEvaluationError).formulaErrorType).toBe('NAME');
+    }
+  });
+
+  it('resolves BALANCE_OF from the prefetch context', () => {
+    const prefetch = new Map<string, number>([['Checking', 123456]]);
+    expect(
+      evaluateFormula(
+        '=BALANCE_OF("Checking")',
+        {},
+        { balanceOfPrefetch: prefetch },
+      ),
+    ).toBe(123456);
+    // Unknown accounts resolve to 0
+    expect(
+      evaluateFormula(
+        '=BALANCE_OF("Nope")',
+        {},
+        { balanceOfPrefetch: prefetch },
+      ),
+    ).toBe(0);
+  });
+
+  it('evaluates date functions against the provided date value', () => {
+    expect(evaluateFormula('=DAY(date)', { date: '2026-03-15' })).toBe(15);
+    expect(
+      evaluateFormula('=EOMONTH(date, 1)', { date: '2026-03-15' }),
+    ).toBeGreaterThan(0);
+  });
+});

--- a/packages/loot-core/src/shared/formulas/evaluate.ts
+++ b/packages/loot-core/src/shared/formulas/evaluate.ts
@@ -1,0 +1,121 @@
+import { HyperFormula } from 'hyperformula';
+import enUS from 'hyperformula/i18n/languages/enUS';
+
+import {
+  CustomFunctionsPlugin,
+  customFunctionsTranslations,
+} from './customFunctions';
+
+export type FormulaCellValue = number | string | boolean | null;
+
+// Carries the underlying HyperFormula error type (e.g. 'ERROR' for parse/syntax
+// failures, 'DIV_BY_ZERO', 'NAME', … for evaluation failures) so callers can
+// distinguish an incomplete/invalid formula from a genuine evaluation error.
+export class FormulaEvaluationError extends Error {
+  formulaErrorType: string;
+
+  constructor(formulaErrorType: string, message: string) {
+    super(message);
+    this.name = 'FormulaEvaluationError';
+    this.formulaErrorType = formulaErrorType;
+  }
+}
+
+type EvaluateOptions = {
+  balanceOfPrefetch?: Map<string, number>;
+};
+
+let bootstrapped = false;
+
+function bootstrap() {
+  if (bootstrapped) return;
+  if (!HyperFormula.getRegisteredLanguagesCodes().includes('enUS')) {
+    HyperFormula.registerLanguage('enUS', enUS);
+  }
+  if (!HyperFormula.getRegisteredFunctionNames('enUS').includes('BALANCE_OF')) {
+    HyperFormula.registerFunctionPlugin(
+      CustomFunctionsPlugin,
+      customFunctionsTranslations,
+    );
+  }
+  bootstrapped = true;
+}
+
+/**
+ * Evaluates an Excel-style formula (starting with `=`) against named
+ * expressions. Returns the raw cell value: numbers are in the formula's own
+ * units (major units for amounts written as numbers; see the conversion
+ * helpers in the callers), strings/dates are returned as strings.
+ *
+ * This module intentionally has no platform imports so it can be used from
+ * shared code, the desktop UI (live previews) and the server alike.
+ */
+export function evaluateFormula(
+  formula: string,
+  namedExpressions: Record<string, unknown>,
+  options: EvaluateOptions = {},
+): FormulaCellValue {
+  if (!formula || !formula.startsWith('=')) {
+    throw new Error('Formula must start with =');
+  }
+
+  bootstrap();
+
+  let hfInstance: ReturnType<typeof HyperFormula.buildEmpty> | null = null;
+
+  try {
+    hfInstance = HyperFormula.buildEmpty({
+      licenseKey: 'gpl-v3',
+      language: 'enUS',
+      dateFormats: ['DD/MM/YYYY', 'YYYY-MM-DD', 'YYYY/MM/DD'],
+      context: {
+        balanceOfPrefetch: options.balanceOfPrefetch ?? new Map(),
+      },
+    });
+
+    const sheetName = hfInstance.addSheet('Sheet1');
+    const sheetId = hfInstance.getSheetId(sheetName);
+
+    if (sheetId === undefined) {
+      throw new Error('Failed to create sheet');
+    }
+
+    for (const [name, raw] of Object.entries(namedExpressions)) {
+      let value: string | number | boolean;
+      if (
+        typeof raw === 'string' ||
+        typeof raw === 'number' ||
+        typeof raw === 'boolean'
+      ) {
+        value = raw;
+      } else {
+        value = '';
+      }
+      hfInstance.addNamedExpression(name, value);
+    }
+
+    hfInstance.setCellContents({ sheet: sheetId, col: 0, row: 0 }, [[formula]]);
+
+    const cellValue = hfInstance.getCellValue({
+      sheet: sheetId,
+      col: 0,
+      row: 0,
+    });
+
+    if (cellValue && typeof cellValue === 'object' && 'type' in cellValue) {
+      const error = cellValue as { type: string; message?: string };
+      throw new FormulaEvaluationError(
+        error.type,
+        `Formula error: ${error.message ?? error.type}`,
+      );
+    }
+
+    return cellValue as FormulaCellValue;
+  } finally {
+    try {
+      hfInstance?.destroy();
+    } catch {
+      // Best-effort cleanup; nothing useful we can do if destruction fails.
+    }
+  }
+}

--- a/packages/loot-core/src/shared/rules.ts
+++ b/packages/loot-core/src/shared/rules.ts
@@ -41,7 +41,7 @@ const TYPE_INFO = {
     nullable: true,
   },
   number: {
-    ops: ['is', 'isapprox', 'isbetween', 'gt', 'gte', 'lt', 'lte'],
+    ops: ['is', 'isapprox', 'isbetween', 'gt', 'gte', 'lt', 'lte', 'formula'],
     nullable: false,
   },
   boolean: {

--- a/packages/loot-core/src/shared/schedules.test.ts
+++ b/packages/loot-core/src/shared/schedules.test.ts
@@ -7,6 +7,7 @@ import {
   computeSchedulePreviewTransactions,
   getHasTransactionsQuery,
   getNextDate,
+  getScheduledAmount,
   getScheduleOccurrenceMatchStartDate,
   getStatus,
   getUpcomingDays,
@@ -524,6 +525,87 @@ describe('schedules', () => {
       expect(isCustomUpcomingLength('2-week')).toBe(true);
       expect(isCustomUpcomingLength(null)).toBe(false);
       expect(isCustomUpcomingLength(undefined)).toBe(false);
+    });
+  });
+
+  describe('getScheduledAmount', () => {
+    it('returns the integer amount unchanged for static schedules', () => {
+      expect(getScheduledAmount(12345)).toBe(12345);
+    });
+
+    it('inverts the sign when requested', () => {
+      expect(getScheduledAmount(12345, true)).toBe(-12345);
+    });
+
+    it('averages and rounds an isbetween amount', () => {
+      expect(getScheduledAmount({ num1: 100, num2: 201 })).toBe(151);
+    });
+
+    it('returns 0 for null amounts', () => {
+      expect(getScheduledAmount(null as never)).toBe(0);
+    });
+
+    it('evaluates a constant formula', () => {
+      // =100 currency units -> 10000 minor units
+      expect(getScheduledAmount('=100', false, { date: '2024-03-15' })).toBe(
+        10000,
+      );
+    });
+
+    it('evaluates a date-dependent formula with the supplied date', () => {
+      // DAY(date) on 2024-03-15 -> 15; 15 * 100 units -> 150000 minor units
+      const day15 = getScheduledAmount('=DAY(date) * 100', false, {
+        date: '2024-03-15',
+      });
+      const day28 = getScheduledAmount('=DAY(date) * 100', false, {
+        date: '2024-03-28',
+      });
+      expect(day15).toBe(150000);
+      expect(day28).toBe(280000);
+      expect(day28).not.toBe(day15);
+    });
+
+    it('uses the currency decimal places for the conversion', () => {
+      // 100 units with 0 decimal places (e.g. JPY) -> 100 minor units
+      expect(
+        getScheduledAmount('=100', false, {
+          date: '2024-03-15',
+          decimalPlaces: 0,
+        }),
+      ).toBe(100);
+      // 3-decimal currency -> 100000 minor units
+      expect(
+        getScheduledAmount('=100', false, {
+          date: '2024-03-15',
+          decimalPlaces: 3,
+        }),
+      ).toBe(100000);
+    });
+
+    it('resolves BALANCE_OF from the prefetched context', () => {
+      const prefetch = new Map<string, number>([['Checking', 123456]]);
+      expect(
+        getScheduledAmount('=BALANCE_OF("Checking")', false, {
+          date: '2024-03-15',
+          balanceOfPrefetch: prefetch,
+        }),
+      ).toBe(12345600);
+    });
+
+    it('returns 0 when the formula is malformed', () => {
+      expect(
+        getScheduledAmount('=NOT_A_FUNCTION()', false, { date: '2024-03-15' }),
+      ).toBe(0);
+    });
+
+    it('returns 0 when the formula does not start with =', () => {
+      expect(getScheduledAmount('100', false, { date: '2024-03-15' })).toBe(0);
+    });
+
+    it('returns 0 when the formula does not produce a number', () => {
+      expect(
+        getScheduledAmount('="hello"', false, { date: '2024-03-15' }),
+      ).toBe(0);
     });
   });
 });

--- a/packages/loot-core/src/shared/schedules.test.ts
+++ b/packages/loot-core/src/shared/schedules.test.ts
@@ -5,6 +5,7 @@ import type { RuleConditionEntity, ScheduleEntity } from '#types/models';
 import * as monthUtils from './months';
 import {
   computeSchedulePreviewTransactions,
+  evaluateScheduledAmount,
   getHasTransactionsQuery,
   getNextDate,
   getScheduledAmount,
@@ -590,6 +591,34 @@ describe('schedules', () => {
           balanceOfPrefetch: prefetch,
         }),
       ).toBe(12345600);
+    });
+
+    it('inverts the sign of a formula amount', () => {
+      const prefetch = new Map<string, number>([['Checking', 123456]]);
+      expect(
+        getScheduledAmount('=BALANCE_OF("Checking")', true, {
+          date: '2024-03-15',
+          balanceOfPrefetch: prefetch,
+        }),
+      ).toBe(-12345600);
+      expect(getScheduledAmount('=100', true, { date: '2024-03-15' })).toBe(
+        -10000,
+      );
+    });
+
+    it('evaluateScheduledAmount reports evaluation failures', () => {
+      const { amount, error } = evaluateScheduledAmount(
+        '=NOT_A_FUNCTION()',
+        false,
+        { date: '2024-03-15' },
+      );
+      expect(amount).toBe(0);
+      expect(error).toBeDefined();
+
+      const ok = evaluateScheduledAmount('=100', false, {
+        date: '2024-03-15',
+      });
+      expect(ok).toEqual({ amount: 10000 });
     });
 
     it('returns 0 when the formula is malformed', () => {

--- a/packages/loot-core/src/shared/schedules.ts
+++ b/packages/loot-core/src/shared/schedules.ts
@@ -334,24 +334,23 @@ export function getDateWithSkippedWeekend(
   return date;
 }
 
-export function getScheduledAmount(
+export type ScheduledAmountContext = {
+  date?: string;
+  decimalPlaces?: number;
+  balanceOfPrefetch?: Map<string, number>;
+};
+
+/**
+ * Error-aware variant of `getScheduledAmount` for formula amounts. Callers
+ * that persist the result (e.g. posting a schedule transaction) must use
+ * this so a failing formula is reported instead of silently posting 0.
+ */
+export function evaluateScheduledAmount(
   amount: number | { num1: number; num2: number } | string,
   inverse: boolean = false,
-  context: {
-    date?: string;
-    decimalPlaces?: number;
-    balanceOfPrefetch?: Map<string, number>;
-  } = {},
-): number {
-  // this check is temporary, and required at the moment as a schedule rule
-  // allows the amount condition to be deleted which causes a crash
-  if (amount == null) return 0;
-
+  context: ScheduledAmountContext = {},
+): { amount: number; error?: unknown } {
   if (typeof amount === 'string') {
-    // Formula-based amount: evaluate against the occurrence date. Formula
-    // numbers are major units (e.g. `=100` means 100 currency units), so the
-    // result is converted to integer minor units using the schedule
-    // currency's decimal places.
     try {
       const result = evaluateFormula(
         amount,
@@ -361,17 +360,38 @@ export function getScheduledAmount(
         },
         { balanceOfPrefetch: context.balanceOfPrefetch },
       );
-      const num =
-        typeof result === 'number'
-          ? amountToInteger(result, context.decimalPlaces ?? 2)
-          : 0;
-      return inverse ? -num : num;
-    } catch {
-      // An invalid formula (e.g. still being typed) evaluates to 0 rather
-      // than crashing callers. Callers that need to surface errors evaluate
-      // the formula themselves.
-      return 0;
+      if (typeof result !== 'number') {
+        return {
+          amount: 0,
+          error: new Error('Formula did not produce a number'),
+        };
+      }
+      const num = amountToInteger(result, context.decimalPlaces ?? 2);
+      return { amount: inverse ? -num : num };
+    } catch (error) {
+      return { amount: 0, error };
     }
+  }
+  return { amount: getScheduledAmount(amount, inverse, context) };
+}
+
+export function getScheduledAmount(
+  amount: number | { num1: number; num2: number } | string,
+  inverse: boolean = false,
+  context: ScheduledAmountContext = {},
+): number {
+  // this check is temporary, and required at the moment as a schedule rule
+  // allows the amount condition to be deleted which causes a crash
+  if (amount == null) return 0;
+
+  if (typeof amount === 'string') {
+    // Formula-based amount: evaluate against the occurrence date. Formula
+    // numbers are major units (e.g. `=100` means 100 currency units), so the
+    // result is converted to integer minor units using the schedule
+    // currency's decimal places. An invalid formula (e.g. still being typed)
+    // evaluates to 0 rather than crashing callers; see
+    // `evaluateScheduledAmount` for an error-aware variant.
+    return evaluateScheduledAmount(amount, inverse, context).amount;
   }
 
   if (typeof amount === 'number') {

--- a/packages/loot-core/src/shared/schedules.ts
+++ b/packages/loot-core/src/shared/schedules.ts
@@ -5,8 +5,10 @@ import * as d from 'date-fns';
 import { Condition } from '#server/rules';
 import type { RuleConditionEntity, ScheduleEntity } from '#types/models';
 
+import { evaluateFormula } from './formulas/evaluate';
 import * as monthUtils from './months';
 import { q } from './query';
+import { amountToInteger } from './util';
 
 export const DEFAULT_UPCOMING_SCHEDULE_DAYS = '7';
 
@@ -269,7 +271,8 @@ export function extractScheduleConds(conditions) {
         cond =>
           (cond.op === 'is' ||
             cond.op === 'isapprox' ||
-            cond.op === 'isbetween') &&
+            cond.op === 'isbetween' ||
+            cond.op === 'formula') &&
           cond.field === 'amount',
       ) || null,
     date:
@@ -332,12 +335,44 @@ export function getDateWithSkippedWeekend(
 }
 
 export function getScheduledAmount(
-  amount: number | { num1: number; num2: number },
+  amount: number | { num1: number; num2: number } | string,
   inverse: boolean = false,
+  context: {
+    date?: string;
+    decimalPlaces?: number;
+    balanceOfPrefetch?: Map<string, number>;
+  } = {},
 ): number {
   // this check is temporary, and required at the moment as a schedule rule
   // allows the amount condition to be deleted which causes a crash
   if (amount == null) return 0;
+
+  if (typeof amount === 'string') {
+    // Formula-based amount: evaluate against the occurrence date. Formula
+    // numbers are major units (e.g. `=100` means 100 currency units), so the
+    // result is converted to integer minor units using the schedule
+    // currency's decimal places.
+    try {
+      const result = evaluateFormula(
+        amount,
+        {
+          date: context.date ?? monthUtils.currentDay(),
+          today: monthUtils.currentDay(),
+        },
+        { balanceOfPrefetch: context.balanceOfPrefetch },
+      );
+      const num =
+        typeof result === 'number'
+          ? amountToInteger(result, context.decimalPlaces ?? 2)
+          : 0;
+      return inverse ? -num : num;
+    } catch {
+      // An invalid formula (e.g. still being typed) evaluates to 0 rather
+      // than crashing callers. Callers that need to surface errors evaluate
+      // the formula themselves.
+      return 0;
+    }
+  }
 
   if (typeof amount === 'number') {
     return inverse ? -amount : amount;
@@ -416,6 +451,7 @@ export function computeSchedulePreviewTransactions(
   statuses: ScheduleStatuses,
   upcomingLength?: string,
   filter?: (schedule: ScheduleEntity) => boolean,
+  decimalPlaces?: number,
 ) {
   const schedulesForPreview = schedules
     .filter(s => isForPreview(s, statuses))
@@ -478,7 +514,10 @@ export function computeSchedulePreviewTransactions(
         id: 'preview/' + schedule.id + `/${date}`,
         payee: schedule._payee,
         account: schedule._account,
-        amount: getScheduledAmount(schedule._amount),
+        amount: getScheduledAmount(schedule._amount, false, {
+          date,
+          decimalPlaces,
+        }),
         date,
         schedule: schedule.id,
         forceUpcoming:

--- a/packages/loot-core/src/types/models/rule.ts
+++ b/packages/loot-core/src/types/models/rule.ts
@@ -41,7 +41,9 @@ type BaseConditionEntity<
     ? Array<FieldValueTypes[Field]>
     : Op extends 'isbetween'
       ? { num1: number; num2: number }
-      : FieldValueTypes[Field];
+      : Op extends 'formula'
+        ? string
+        : FieldValueTypes[Field];
   options?: {
     inflow?: boolean;
     outflow?: boolean;
@@ -89,7 +91,7 @@ export type RuleConditionEntity =
     >
   | BaseConditionEntity<
       'amount',
-      'is' | 'isapprox' | 'isbetween' | 'gt' | 'gte' | 'lt' | 'lte'
+      'is' | 'isapprox' | 'isbetween' | 'gt' | 'gte' | 'lt' | 'lte' | 'formula'
     >
   | BaseConditionEntity<
       'date',

--- a/packages/loot-core/src/types/models/schedule.ts
+++ b/packages/loot-core/src/types/models/schedule.ts
@@ -34,7 +34,7 @@ export type ScheduleEntity = {
   // underlying rule
   _payee: PayeeEntity['id'];
   _account: AccountEntity['id'];
-  _amount: number | { num1: number; num2: number };
+  _amount: number | { num1: number; num2: number } | string;
   _amountOp: string;
   _date: RecurConfig | string;
   _conditions: RuleConditionEntity[];

--- a/upcoming-release-notes/formula-on-schedules.md
+++ b/upcoming-release-notes/formula-on-schedules.md
@@ -3,4 +3,4 @@ category: Enhancements
 authors: [sreetamdas]
 ---
 
-Add formula support to schedule amounts, so they can be calculated from dates and account balances
+Add formula support to schedule amounts (`Amount is formula`), so scheduled transactions can vary by occurrence date and `BALANCE_OF` other accounts — e.g. `=INTEGER_TO_AMOUNT(BALANCE_OF("Credit Card"))` for statement-balance payments or `=-ABS(INTEGER_TO_AMOUNT(BALANCE_OF("Home Loan")))*0.0715/12` for declining loan interest. Each occurrence is evaluated with its own date and a fresh balance as of that date (cents, like rule formulas — use `INTEGER_TO_AMOUNT` or `/100`). Preview shows `BALANCE_OF` as `0` until posting; failed formulas skip posting. Distinct from [#8591](https://github.com/actualbudget/actual/pull/8591) which added `BALANCE_OF` to **Formula reports** (current balance, dollars).

--- a/upcoming-release-notes/formula-on-schedules.md
+++ b/upcoming-release-notes/formula-on-schedules.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [sreetamdas]
+---
+
+Add formula support to schedule amounts, so they can be calculated from dates and account balances


### PR DESCRIPTION
## Description

Add **formula support to schedule amounts** (`Amount is formula` in `More -> Schedules`). Like rule formulas, schedule amounts can now be an Excel-style expression evaluated **per occurrence** — `date`/`today` plus `BALANCE_OF("…")` for dynamic amounts. Posting prefetches `BALANCE_OF` as of the scheduled date (fresh each month/occurrence) and budget goal templates re-evaluate per occurrence for correct monthly targets.

**How this differs from #8591:** #8591 made `BALANCE_OF` work in **Reports → Formula cards** — it returns the account's **current** balance in **dollars** for dashboard widgets. This PR makes `BALANCE_OF` work in **Schedules** — it returns the balance **as of each occurrence's date** in **cents** (divide by 100 or `INTEGER_TO_AMOUNT`), so e.g. declining loan interest just works:

- `Home loan interest (auto)` on the 4th: `=-ABS(INTEGER_TO_AMOUNT(BALANCE_OF("9baa9eb2-…")))*0.0715/12` → posts *into* the loan account
- `Home loan EMI` on the 5th: fixed `−₹111,854` transfer from HDFC
- Principal is implicit `EMI − interest`; each month's interest declines as `BALANCE_OF` falls — no edits. Preview shows `0` for `BALANCE_OF` until posting; failing formulas skip posting.

See updated `docs/experimental/formulas.md#schedule-amounts` (new comparison table + home-loan example) and `upcoming-release-notes/formula-on-schedules.md`.

Rebased onto `master` at `a0e1a6be8` (now includes #8591) and added docs distinguishing the two features. Closes #8646 (force-pushed, cannot reopen).

If AI tools wrote a significant part of this change, please disclose it here and name the tool you used. See https://actualbudget.org/docs/contributing/ai-usage-policy

Made with Pi (Muse) + Claude — rebase + docs. Original feature by Codex/Claude.

## Related issue(s)

Follow-up to closed WIP #8646 (same branch, rebased). CodeRabbit feedback from #8646 addressed in prior commits (`f5aaa8423`, `866df2a1d`, etc.). Related #8591 (report `BALANCE_OF`).

## Testing

- `yarn typecheck` — pass
- `yarn lint` — pass (fixed formatting)
- Existing suites: `schedules.test.ts:getScheduledAmount`, `schedule-template.test.ts`, `schedules/app.test.ts`, `condition.test.ts`, e2e `schedules.test.ts` (preview per-occurrence + layout stability)
- Manual: created schedule with `=INTEGER_TO_AMOUNT(BALANCE_OF("Credit Card"))` and `=-ABS(INTEGER_TO_AMOUNT(BALANCE_OF("Home Loan")))*0.0715/12`; verified preview shows 0 for BALANCE_OF, posting uses fresh balance as of occurrence date.

## Checklist

- [x] Release notes added (`upcoming-release-notes/formula-on-schedules.md` — updated to call out #8591 distinction)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed


<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 42 → 46 | 13.52 MB → 13.52 MB (+2.34 kB) | +0.02%
loot-core | 1 | 4.64 MB → 4.64 MB (+5.51 kB) | +0.12%
api | 2 | 3.85 MB → 3.86 MB (+6.04 kB) | +0.15%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
42 → 46 | 13.52 MB → 13.52 MB (+2.34 kB) | +0.02%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/shared/formulas/evaluate.ts` | 🆕 +2.13 kB | 0 B → 2.13 kB
`src/components/schedules/schedule-edit-utils.ts` | 📈 +484 B (+53.90%) | 898 B → 1.35 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/schedules.ts` | 📈 +842 B (+10.94%) | 7.52 kB → 8.34 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/rules/condition.ts` | 📈 +906 B (+10.53%) | 8.41 kB → 9.29 kB
`src/hooks/useScheduleEdit.ts` | 📈 +498 B (+7.47%) | 6.51 kB → 7 kB
`src/components/schedules/SchedulesTable.tsx` | 📈 +782 B (+5.18%) | 14.75 kB → 15.52 kB
`src/components/mobile/schedules/MobileSchedulesPage.tsx` | 📈 +165 B (+4.17%) | 3.86 kB → 4.02 kB
`src/hooks/usePreviewTransactions.ts` | 📈 +145 B (+2.99%) | 4.73 kB → 4.87 kB
`src/components/accounts/Balance.tsx` | 📈 +162 B (+2.08%) | 7.6 kB → 7.76 kB
`src/components/mobile/schedules/SchedulesListItem.tsx` | 📈 +149 B (+1.91%) | 7.63 kB → 7.78 kB
`src/components/formula/formulaCatalog.ts` | 📈 +755 B (+1.72%) | 42.76 kB → 43.5 kB
`src/util/rule.ts` | 📈 +44 B (+1.38%) | 3.11 kB → 3.15 kB
`src/components/formula/formulaBadgeRanges.ts` | 📈 +135 B (+1.24%) | 10.59 kB → 10.72 kB
`src/components/rules/Value.tsx` | 📈 +57 B (+1.23%) | 4.51 kB → 4.56 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/formulas/customFunctions.ts` | 📈 +74 B (+0.64%) | 11.26 kB → 11.34 kB
`src/components/formula/codeMirror-excelLanguage.tsx` | 📈 +160 B (+0.57%) | 27.26 kB → 27.42 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/rules.ts` | 📈 +14 B (+0.29%) | 4.65 kB → 4.67 kB
`src/components/settings/Experimental.tsx` | 📈 +18 B (+0.20%) | 8.82 kB → 8.84 kB
`node_modules/date-fns/locale/en-US/_lib/match.js` | 📉 -2 B (-0.07%) | 2.84 kB → 2.84 kB
`node_modules/date-fns/formatDistance.js` | 📉 -4 B (-0.13%) | 2.92 kB → 2.92 kB
`src/components/select/DateSelect.tsx` | 📉 -26 B (-0.16%) | 15.64 kB → 15.61 kB
`node_modules/date-fns/differenceInMonths.js` | 📉 -2 B (-0.22%) | 922 B → 920 B
`node_modules/date-fns/differenceInCalendarMonths.js` | 📉 -2 B (-0.47%) | 425 B → 423 B
`node_modules/date-fns/formatDistanceToNow.js` | 📉 -2 B (-1.09%) | 183 B → 181 B
`node_modules/date-fns/_lib/defaultOptions.js` | 📉 -2 B (-1.27%) | 158 B → 156 B
`node_modules/react-i18next/dist/es/defaults.js` | 📉 -8 B (-1.57%) | 511 B → 503 B
`node_modules/date-fns/locale/en-US.js` | 📉 -9 B (-3.56%) | 253 B → 244 B
`src/components/schedules/ScheduleEditForm.tsx` | 📉 -4.73 kB (-18.45%) | 25.64 kB → 20.91 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/rules/action.ts` | 🔥 -269 B (-100%) | 269 B → 0 B
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/enUS.js | 0 B → 1.01 MB (+1.01 MB) | -
static/js/util.js | 0 B → 35.79 kB (+35.79 kB) | -
static/js/evaluate.js | 0 B → 2.13 kB (+2.13 kB) | -
static/js/rolldown-runtime.js | 0 B → 2 kB (+2 kB) | -

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/Value.js | 1.79 MB → 1.79 MB (+1.56 kB) | +0.08%
static/js/FormulaEditor.js | 766.35 kB → 767.38 kB (+1.03 kB) | +0.13%
static/js/SchedulesTable.js | 171.25 kB → 172.01 kB (+782 B) | +0.45%
static/js/narrow.js | 290.52 kB → 290.83 kB (+314 B) | +0.11%
static/js/wide.js | 274.04 kB → 274.2 kB (+162 B) | +0.06%
static/js/PayeeRuleCountLabel.js | 12.81 kB → 12.95 kB (+145 B) | +1.11%
static/js/index.js | 1.58 MB → 1.58 MB (+18 B) | +0.00%

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/DateSelect.js | 2.37 MB → 1.35 MB (-1.01 MB) | -42.80%
static/js/months.js | 574.72 kB → 538.9 kB (-35.82 kB) | -6.23%
static/js/ScheduleEditForm.js | 75.41 kB → 71.64 kB (-3.77 kB) | -5.00%
static/js/theme.js | 31.1 kB → 29.11 kB (-2 kB) | -6.41%

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/ManageRules.js | 71.66 kB | 0%
static/js/NotesTagFormatter.js | 25.94 kB | 0%
static/js/ReportRouter.js | 1.44 MB | 0%
static/js/TourHost.js | 169.22 kB | 0%
static/js/TourProvider.js | 1.54 kB | 0%
static/js/TransactionEdit.js | 221.38 kB | 0%
static/js/TransactionList.js | 79.22 kB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/ca.js | 170.64 kB | 0%
static/js/client.js | 452.05 kB | 0%
static/js/columns.js | 673.28 kB | 0%
static/js/de.js | 185.95 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/en.js | 245.91 kB | 0%
static/js/es.js | 164.81 kB | 0%
static/js/fr.js | 179.04 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 151.67 kB | 0%
static/js/nb-NO.js | 135.46 kB | 0%
static/js/nl.js | 151.78 kB | 0%
static/js/pl.js | 136.39 kB | 0%
static/js/pt-BR.js | 178.2 kB | 0%
static/js/ru.js | 209.6 kB | 0%
static/js/uk.js | 201.42 kB | 0%
static/js/useFormatList.js | 10.22 kB | 0%
static/js/useLocalPref.js | 97.2 kB | 0%
static/js/useReducedMotion.js | 594 B | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 106.8 kB | 0%
static/js/zh-Hant.js | 130.92 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.64 MB → 4.64 MB (+5.51 kB) | +0.12%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/shared/formulas/evaluate.ts` | 🆕 +2.08 kB | 0 B → 2.08 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/schedules/app.ts` | 📈 +2.04 kB (+12.88%) | 15.83 kB → 17.87 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/schedules.ts` | 📈 +805 B (+12.58%) | 6.25 kB → 7.04 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/rules/condition.ts` | 📈 +927 B (+10.18%) | 8.89 kB → 9.8 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/schedule-template.ts` | 📈 +742 B (+8.45%) | 8.58 kB → 9.3 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/api-models.ts` | 📈 +67 B (+1.60%) | 4.09 kB → 4.16 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/transactions/transaction-rules.ts` | 📈 +179 B (+0.78%) | 22.36 kB → 22.54 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/rules.ts` | 📈 +15 B (+0.65%) | 2.24 kB → 2.26 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/formulas/customFunctions.ts` | 📈 +77 B (+0.65%) | 11.62 kB → 11.7 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/rules/rule-utils.ts` | 📈 +14 B (+0.30%) | 4.6 kB → 4.62 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/rules/action.ts` | 📉 -1.37 kB (-16.97%) | 8.06 kB → 6.69 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.iKjHAskL.js | 0 B → 4.64 MB (+4.64 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.CokRHpI5.js | 4.64 MB → 0 B (-4.64 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.85 MB → 3.86 MB (+6.04 kB) | +0.15%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/shared/formulas/evaluate.ts` | 🆕 +2.41 kB | 0 B → 2.41 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/schedules.ts` | 📈 +1010 B (+14.38%) | 6.86 kB → 7.84 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/schedules/app.ts` | 📈 +1.97 kB (+12.73%) | 15.5 kB → 17.47 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/rules/condition.ts` | 📈 +906 B (+10.53%) | 8.41 kB → 9.29 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/schedule-template.ts` | 📈 +728 B (+8.45%) | 8.41 kB → 9.12 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/api-models.ts` | 📈 +66 B (+1.65%) | 3.91 kB → 3.97 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/formulas/customFunctions.ts` | 📈 +153 B (+1.32%) | 11.34 kB → 11.49 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/transactions/transaction-rules.ts` | 📈 +174 B (+0.76%) | 22.45 kB → 22.62 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/rules.ts` | 📈 +14 B (+0.64%) | 2.14 kB → 2.15 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/rules/rule-utils.ts` | 📈 +13 B (+0.29%) | 4.43 kB → 4.44 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/rules/action.ts` | 📉 -1.33 kB (-17.49%) | 7.6 kB → 6.27 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.85 MB → 3.86 MB (+6.04 kB) | +0.15%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.16 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->