### PR TITLE
fix schedules moved before weekend occasionally becoming stuck

### DIFF
--- a/packages/loot-core/src/server/schedules/app.test.ts
+++ b/packages/loot-core/src/server/schedules/app.test.ts
@@ -597,6 +597,46 @@ describe('schedule app', () => {
       expect(row.next_date).toBe('2020-12-11');
     });
 
+    it('skipNextDate keeps the next occurrence when moving `before` weekend', async () => {
+      /* Dec 2020 calendar for reference:
+        | Su | Mo | Tu | We | Th | Fr | Sa |
+        |    |    | 01 | 02 | 03 | 04 | 05 |
+        | 06 | 07 | 08 | 09 | 10 | 11 | 12 |
+        | 13 | 14 | 15 | 16 | 17 | 18 | 19 |
+        | 20 | 21 | 22 | 23 | 24 | 25 | 26 |
+        | 27 | 28 | 29 | 30 | 31 |
+        */
+      const id = await createSchedule({
+        conditions: [
+          {
+            op: 'is',
+            field: 'date',
+            value: {
+              start: '2020-12-04',
+              frequency: 'daily',
+              patterns: [],
+              skipWeekend: true,
+              weekendSolveMode: 'before',
+            },
+          },
+        ],
+      });
+
+      let res = await aqlQuery(
+        q('schedules').filter({ id }).select(['next_date']),
+      );
+      let row = res.data[0];
+
+      expect(row.next_date).toBe('2020-12-04');
+
+      await skipNextDate({ id });
+
+      res = await aqlQuery(q('schedules').filter({ id }).select(['next_date']));
+      row = res.data[0];
+
+      expect(row.next_date).toBe('2020-12-07');
+    });
+
     it('auto-posts every missed recurring occurrence while catching up', async () => {
       MockDate.set(new Date(2016, 11, 31, 12));
       schedulesApp.startServices();
@@ -747,6 +787,95 @@ describe('schedule app', () => {
         } = await aqlQuery(q('schedules').filter({ id }).select(['next_date']));
 
         expect(schedule.next_date).toBe('2017-01-02');
+      } finally {
+        MockDate.reset();
+        await schedulesApp.stopServices();
+      }
+    });
+
+    it('catches up an auto-post schedule moved `before` a weekend occurrence', async () => {
+      /* Dec 2016 / Jan 2017 calendar for reference:
+        | Su | Mo | Tu | We | Th | Fr | Sa |
+        | 18 | 19 | 20 | 21 | 22 | 23 | 24 |
+        | 25 | 26 | 27 | 28 | 29 | 30 | 31 |
+        | 01 | 02 | 03 | 04 | 05 | 06 | 07 |
+        */
+      MockDate.set(new Date(2016, 11, 31, 12));
+      schedulesApp.startServices();
+
+      try {
+        const accountId = await db.insertAccount({
+          name: 'Checking',
+          offbudget: 0,
+          closed: 0,
+        });
+
+        const id = await createSchedule({
+          schedule: { posts_transaction: true },
+          conditions: [
+            {
+              op: 'is',
+              field: 'account',
+              value: accountId,
+            },
+            {
+              op: 'is',
+              field: 'amount',
+              value: -10000,
+            },
+            {
+              op: 'is',
+              field: 'date',
+              value: {
+                start: '2016-12-24',
+                frequency: 'weekly',
+                interval: 1,
+                patterns: [],
+                skipWeekend: true,
+                weekendSolveMode: 'before',
+              },
+            },
+          ],
+        });
+        const nextDateRow = await db.first<{
+          id: string;
+        }>('SELECT id FROM schedules_next_date WHERE schedule_id = ?', [id]);
+
+        await db.update('schedules_next_date', {
+          id: nextDateRow.id,
+          local_next_date: 20161223,
+          local_next_date_ts: Date.now(),
+          base_next_date: 20161223,
+          base_next_date_ts: Date.now(),
+        });
+        await db.insertTransaction({
+          account: accountId,
+          amount: -10000,
+          date: '2016-12-23',
+          schedule: id,
+        });
+
+        await advanceSchedulesService(true);
+
+        const { data: transactions } = await aqlQuery(
+          q('transactions')
+            .filter({ schedule: id })
+            .select(['date', 'amount'])
+            .orderBy({ date: 'asc' }),
+        );
+
+        expect(
+          transactions.map(({ date, amount }) => ({ date, amount })),
+        ).toEqual([
+          { date: '2016-12-23', amount: -10000 },
+          { date: '2016-12-30', amount: -10000 },
+        ]);
+
+        const {
+          data: [schedule],
+        } = await aqlQuery(q('schedules').filter({ id }).select(['next_date']));
+
+        expect(schedule.next_date).toBe('2017-01-06');
       } finally {
         MockDate.reset();
         await schedulesApp.stopServices();

--- a/packages/loot-core/src/server/schedules/app.ts
+++ b/packages/loot-core/src/server/schedules/app.ts
@@ -22,7 +22,7 @@ import {
 } from '#server/transactions/transaction-rules';
 import { undoable } from '#server/undo';
 import { RSchedule } from '#server/util/rschedule';
-import { currentDay, dayFromDate, parseDate } from '#shared/months';
+import { currentDay, dayFromDate } from '#shared/months';
 import { q } from '#shared/query';
 import {
   DEFAULT_UPCOMING_SCHEDULE_DAYS,
@@ -30,6 +30,7 @@ import {
   getDateWithSkippedWeekend,
   getHasTransactionsQuery,
   getNextDate,
+  getNextDateAfter,
   getScheduledAmount,
   getStatus,
   recurConfigToRSchedule,
@@ -210,16 +211,14 @@ async function fixRuleForSchedule(id) {
 
 export async function setNextDate({
   id,
-  start,
   conditions,
   reset,
-  skipRequested,
+  advance,
 }: {
   id: string;
-  start?;
   conditions?;
   reset?: boolean;
-  skipRequested?: boolean;
+  advance?: boolean;
 }) {
   if (conditions == null) {
     const rule = await getRuleForSchedule(id);
@@ -231,32 +230,15 @@ export async function setNextDate({
 
   const { date: dateCond } = extractScheduleConds(conditions);
 
-  let { data: nextDate } = await aqlQuery(
+  const { data: nextDate } = await aqlQuery(
     q('schedules').filter({ id }).calculate('next_date'),
   );
 
-  if (skipRequested === true) {
-    const skipWeekend: boolean = dateCond.value?.skipWeekend;
-    const weekendSolveMode: string = dateCond.value?.weekendSolveMode;
-
-    if (weekendSolveMode === 'before' && skipWeekend === true) {
-      const parsedNextDate = parseDate(nextDate);
-      if (d.isFriday(parsedNextDate) || d.isWeekend(parsedNextDate)) {
-        // nextDate is on weekend or friday, moving to monday
-        // so getNextDate and getDateWithSkippedWeekend
-        // don't push the date back to Friday, thus causing
-        // `(newNextDate !== nextDate) ` to be false and not updating the next date
-        nextDate = dayFromDate(d.nextMonday(parsedNextDate));
-      }
-    }
-  }
-
   // Only do this if a date condition exists
   if (dateCond) {
-    const newNextDate = getNextDate(
-      dateCond,
-      start ? start(nextDate) : new Date(),
-    );
+    const newNextDate = advance
+      ? getNextDateAfter(dateCond, nextDate)
+      : getNextDate(dateCond, new Date());
 
     if (newNextDate != null && newNextDate !== nextDate) {
       // Our `update` functon requires the id of the item and we don't
@@ -482,13 +464,7 @@ export async function deleteSchedule({ id }) {
 }
 
 export async function skipNextDate({ id }) {
-  return setNextDate({
-    id,
-    start: nextDate => {
-      return d.addDays(parseDate(nextDate), 1);
-    },
-    skipRequested: true,
-  });
+  return setNextDate({ id, advance: true });
 }
 
 function discoverSchedules() {
@@ -642,10 +618,7 @@ async function advanceRecurringScheduleFromNextDate(
   const previousNextDate = schedule.next_date;
 
   try {
-    await setNextDate({
-      id: schedule.id,
-      start: nextDate => d.addDays(parseDate(nextDate), 1),
-    });
+    await setNextDate({ id: schedule.id, advance: true });
   } catch {
     // This might error if the rule is corrupted and it can't find the rule.
     return null;

--- a/packages/loot-core/src/shared/schedules.test.ts
+++ b/packages/loot-core/src/shared/schedules.test.ts
@@ -7,6 +7,7 @@ import {
   computeSchedulePreviewTransactions,
   getHasTransactionsQuery,
   getNextDate,
+  getNextDateAfter,
   getScheduleOccurrenceMatchStartDate,
   getStatus,
   getUpcomingDays,
@@ -495,6 +496,77 @@ describe('schedules', () => {
 
       const result = getNextDate(dateCond, new Date(2017, 0, 1));
       expect(result).toBeNull();
+    });
+  });
+
+  describe('getNextDateAfter', () => {
+    /* Dec 2020 calendar for reference:
+      | Su | Mo | Tu | We | Th | Fr | Sa |
+      |    |    | 01 | 02 | 03 | 04 | 05 |
+      | 06 | 07 | 08 | 09 | 10 | 11 | 12 |
+      | 13 | 14 | 15 | 16 | 17 | 18 | 19 |
+      | 20 | 21 | 22 | 23 | 24 | 25 | 26 |
+      | 27 | 28 | 29 | 30 | 31 |
+      */
+    function weeklyOnSaturday(extra = {}) {
+      return {
+        op: 'isapprox',
+        value: {
+          start: '2020-12-05',
+          frequency: 'weekly',
+          patterns: [],
+          ...extra,
+        },
+      };
+    }
+
+    it('returns the next occurrence after the given date', () => {
+      expect(getNextDateAfter(weeklyOnSaturday(), '2020-12-05')).toBe(
+        '2020-12-12',
+      );
+    });
+
+    it('returns the next occurrence when moving `after` the weekend', () => {
+      const dateCond = weeklyOnSaturday({
+        skipWeekend: true,
+        weekendSolveMode: 'after',
+      });
+
+      expect(getNextDateAfter(dateCond, '2020-12-07')).toBe('2020-12-14');
+    });
+
+    it('does not return the same occurrence when moving `before` the weekend', () => {
+      const dateCond = weeklyOnSaturday({
+        skipWeekend: true,
+        weekendSolveMode: 'before',
+      });
+
+      expect(getNextDateAfter(dateCond, '2020-12-04')).toBe('2020-12-11');
+    });
+
+    it('keeps a Monday occurrence that follows a `before` weekend adjustment', () => {
+      const dateCond = {
+        op: 'isapprox',
+        value: {
+          start: '2020-12-04',
+          frequency: 'daily',
+          patterns: [],
+          skipWeekend: true,
+          weekendSolveMode: 'before',
+        },
+      };
+
+      expect(getNextDateAfter(dateCond, '2020-12-04')).toBe('2020-12-07');
+    });
+
+    it('returns null when the schedule has no further occurrences', () => {
+      const dateCond = weeklyOnSaturday({
+        endMode: 'after_n_occurrences',
+        endOccurrences: 2,
+      });
+
+      expect(getNextDateAfter(dateCond, '2020-12-05')).toBe('2020-12-12');
+      expect(getNextDateAfter(dateCond, '2020-12-12')).toBeNull();
     });
   });
 

--- a/packages/loot-core/src/shared/schedules.test.ts
+++ b/packages/loot-core/src/shared/schedules.test.ts
@@ -583,6 +583,26 @@ describe('schedules', () => {
       expect(getNextDateAfter(dateCond, '2020-12-04')).toBe('2020-12-07');
     });
 
+    it('walks past every occurrence that resolves on or before the given date', () => {
+      /* Aug 2026 calendar for reference:
+        | Su | Mo | Tu | We | Th | Fr | Sa |
+        | 23 | 24 | 25 | 26 | 27 | 28 | 29 |
+        | 30 | 31 |
+        */
+      const dateCond = {
+        op: 'isapprox',
+        value: {
+          start: '2026-08-24',
+          frequency: 'daily',
+          patterns: [],
+          skipWeekend: true,
+          weekendSolveMode: 'before',
+        },
+      };
+
+      expect(getNextDateAfter(dateCond, '2026-08-28')).toBe('2026-08-31');
+    });
+
     it('returns null when the schedule has no further occurrences', () => {
       const dateCond = weeklyOnSaturday({
         endMode: 'after_n_occurrences',

--- a/packages/loot-core/src/shared/schedules.test.ts
+++ b/packages/loot-core/src/shared/schedules.test.ts
@@ -535,6 +535,30 @@ describe('schedules', () => {
       expect(getNextDateAfter(dateCond, '2020-12-07')).toBe('2020-12-14');
     });
 
+    it('includes a weekend occurrence moved `after` the given date', () => {
+      const dateCond = weeklyOnSaturday({
+        skipWeekend: true,
+        weekendSolveMode: 'after',
+      });
+
+      expect(getNextDateAfter(dateCond, '2020-12-13')).toBe('2020-12-14');
+    });
+
+    it('does not return the same occurrence when moving `after` the weekend', () => {
+      const dateCond = {
+        op: 'isapprox',
+        value: {
+          start: '2020-12-06',
+          frequency: 'weekly',
+          patterns: [],
+          skipWeekend: true,
+          weekendSolveMode: 'after',
+        },
+      };
+
+      expect(getNextDateAfter(dateCond, '2020-12-07')).toBe('2020-12-14');
+    });
+
     it('does not return the same occurrence when moving `before` the weekend', () => {
       const dateCond = weeklyOnSaturday({
         skipWeekend: true,

--- a/packages/loot-core/src/shared/schedules.ts
+++ b/packages/loot-core/src/shared/schedules.ts
@@ -318,7 +318,7 @@ export function getNextDate(
 const MAX_ADVANCE_ATTEMPTS = 7;
 
 export function getNextDateAfter(dateCond, afterDate: string): string | null {
-  let start = d.addDays(monthUtils.parseDate(afterDate), 1);
+  let start = d.subDays(monthUtils.parseDate(afterDate), 1);
 
   for (let attempt = 0; attempt < MAX_ADVANCE_ATTEMPTS; attempt++) {
     const occurrence = getNextDate(dateCond, start, true);

--- a/packages/loot-core/src/shared/schedules.ts
+++ b/packages/loot-core/src/shared/schedules.ts
@@ -315,6 +315,28 @@ export function getNextDate(
   return null;
 }
 
+const MAX_ADVANCE_ATTEMPTS = 7;
+
+export function getNextDateAfter(dateCond, afterDate: string): string | null {
+  let start = d.addDays(monthUtils.parseDate(afterDate), 1);
+
+  for (let attempt = 0; attempt < MAX_ADVANCE_ATTEMPTS; attempt++) {
+    const occurrence = getNextDate(dateCond, start, true);
+    if (occurrence == null || occurrence < monthUtils.dayFromDate(start)) {
+      return null;
+    }
+
+    const nextDate = getNextDate(dateCond, start);
+    if (nextDate != null && nextDate > afterDate) {
+      return nextDate;
+    }
+
+    start = d.addDays(monthUtils.parseDate(occurrence), 1);
+  }
+
+  return null;
+}
+
 export function getDateWithSkippedWeekend(
   date: Date,
   solveMode: 'after' | 'before',

--- a/upcoming-release-notes/fix-schedules-stuck-before-weekend.md
+++ b/upcoming-release-notes/fix-schedules-stuck-before-weekend.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [matt-fidd]
+---
+
+Fix schedules set to run before the weekend getting stuck on the same date and no longer posting


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

<!-- If AI tools wrote a significant part of this change, please disclose it here and name the tool you used. See https://actualbudget.org/docs/contributing/ai-usage-policy -->

This looks to be a latent bug that's more recently been exposed by the improved catch-up logic. Essentially, the root cause was that we saved the next date as the effective next date (that is, after being shifted forwards/backwards by weekend solving). This meant that any logic that searched for the next date after that by adding one two it, ended up solving backwards to before the weekend again, getting stuck.

Now I'd have expected to see more reports about this, but it looks like the first time since the catch up logic was introduced that we've had a month where it was most likely to strike, so that could explain it.

Either way, here's the fix, and it tidies up some duplication and makes it more robust overall

Tests written by Claude (pretty calendars included)

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

Confirmed against a local budget (and some date fiddling on my device)
Also added these tests that fail against master and pass here

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 42 | 13.52 MB | 0%
loot-core | 1 | 4.64 MB → 4.63 MB (-83 B) | -0.00%
api | 2 | 3.85 MB → 3.85 MB (-482 B) | -0.01%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
42 | 13.52 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.58 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/DateSelect.js | 2.37 MB | 0%
static/js/FormulaEditor.js | 766.35 kB | 0%
static/js/ManageRules.js | 71.66 kB | 0%
static/js/NotesTagFormatter.js | 25.94 kB | 0%
static/js/PayeeRuleCountLabel.js | 12.81 kB | 0%
static/js/ReportRouter.js | 1.44 MB | 0%
static/js/ScheduleEditForm.js | 75.41 kB | 0%
static/js/SchedulesTable.js | 171.25 kB | 0%
static/js/TourHost.js | 169.22 kB | 0%
static/js/TourProvider.js | 1.54 kB | 0%
static/js/TransactionEdit.js | 221.38 kB | 0%
static/js/TransactionList.js | 79.22 kB | 0%
static/js/Value.js | 1.79 MB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/ca.js | 170.64 kB | 0%
static/js/client.js | 452.05 kB | 0%
static/js/columns.js | 673.28 kB | 0%
static/js/de.js | 185.95 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/en.js | 245.91 kB | 0%
static/js/es.js | 164.81 kB | 0%
static/js/fr.js | 179.04 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 151.67 kB | 0%
static/js/months.js | 574.72 kB | 0%
static/js/narrow.js | 290.52 kB | 0%
static/js/nb-NO.js | 135.46 kB | 0%
static/js/nl.js | 151.78 kB | 0%
static/js/pl.js | 136.39 kB | 0%
static/js/pt-BR.js | 178.2 kB | 0%
static/js/ru.js | 212.8 kB | 0%
static/js/theme.js | 31.1 kB | 0%
static/js/uk.js | 201.42 kB | 0%
static/js/useFormatList.js | 10.22 kB | 0%
static/js/useLocalPref.js | 97.2 kB | 0%
static/js/useReducedMotion.js | 594 B | 0%
static/js/wide.js | 274.04 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 106.8 kB | 0%
static/js/zh-Hant.js | 130.92 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.64 MB → 4.63 MB (-83 B) | -0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/shared/schedules.ts` | 📈 +519 B (+8.11%) | 6.25 kB → 6.76 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/schedules/app.ts` | 📉 -449 B (-2.77%) | 15.83 kB → 15.39 kB
`node_modules/date-fns/isFriday.js` | 🔥 -153 B (-100%) | 153 B → 0 B
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.EDh4AUh5.js | 0 B → 4.63 MB (+4.63 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.CokRHpI5.js | 4.64 MB → 0 B (-4.64 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.85 MB → 3.85 MB (-482 B) | -0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/shared/schedules.ts` | 📈 +507 B (+7.22%) | 6.86 kB → 7.35 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/schedules/app.ts` | 📉 -439 B (-2.77%) | 15.5 kB → 15.07 kB
`node_modules/date-fns/isFriday.js` | 🔥 -550 B (-100%) | 550 B → 0 B
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.85 MB → 3.85 MB (-482 B) | -0.01%

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.16 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->