### PR TITLE
:chart_with_upwards_trend: Monte Carlo - Fix floor and ceiling/boundaries anchors

### DIFF
--- a/packages/desktop-client/src/components/reports/reports/monte-carlo/monteCarloSimulation.test.ts
+++ b/packages/desktop-client/src/components/reports/reports/monte-carlo/monteCarloSimulation.test.ts
@@ -537,6 +537,121 @@ describe('runMonteCarloSimulation', () => {
     expect(withRule.medianTotalWithdrawn).toBeLessThanOrEqual(100_000);
   });
 
+  it('floor-ceiling anchors its rate in the first spending year', () => {
+    // User-reported bug: with a zero-spend phase before retirement, the
+    // rule anchored to year 1's planned spending of 0, so every
+    // retirement year withdrew the floor (planned x 0.85). The anchor
+    // must instead be set where spending starts.
+    const result = runMonteCarloSimulation(
+      makeParams(
+        {
+          annualWithdrawal: 0,
+          horizonYears: 30,
+          currentAge: 55,
+          spendingPhases: [
+            { id: 'working', name: '', fromAge: null, annualWithdrawal: 0 },
+            {
+              id: 'retired',
+              name: '',
+              fromAge: 65,
+              annualWithdrawal: 60_000,
+            },
+          ],
+          withdrawalRule: {
+            ...WITHDRAWAL_RULE_DEFAULTS,
+            type: 'floor-ceiling',
+          },
+          captureRunDetail: 0,
+        },
+        {
+          startingBalance: 1_000_000,
+          expectedReturnMean: 0.05,
+          returnStdDev: 0,
+        },
+      ),
+    );
+
+    const rows = result.runDetail!;
+    // Accumulation years take nothing
+    for (const row of rows.slice(0, 10)) {
+      expect(row.withdrawal).toBe(0);
+    }
+    // The first retirement year withdraws exactly the planned amount
+    expect(rows[10].withdrawal).toBe(60_000);
+    // With steady growth the rate rule rises above the plan - it must
+    // not sit pinned at the 51,000 floor
+    expect(rows[11].withdrawal).toBeGreaterThan(60_000);
+    for (const row of rows.slice(11)) {
+      expect(row.withdrawal).toBeGreaterThanOrEqual(51_000);
+      expect(row.withdrawal).toBeLessThanOrEqual(72_000);
+    }
+  });
+
+  it('boundaries does not compound raises through zero-spend years', () => {
+    // A zero-spend year has a withdrawal rate of 0 - below any lower
+    // threshold - which must not be read as a "raise spending" signal
+    const result = runMonteCarloSimulation(
+      makeParams(
+        {
+          annualWithdrawal: 0,
+          horizonYears: 12,
+          currentAge: 55,
+          spendingPhases: [
+            { id: 'working', name: '', fromAge: null, annualWithdrawal: 0 },
+            {
+              id: 'retired',
+              name: '',
+              fromAge: 65,
+              annualWithdrawal: 40_000,
+            },
+          ],
+          withdrawalRule: { ...WITHDRAWAL_RULE_DEFAULTS, type: 'boundaries' },
+          captureRunDetail: 0,
+        },
+        {
+          startingBalance: 1_000_000,
+          expectedReturnMean: 0,
+          returnStdDev: 0,
+        },
+      ),
+    );
+
+    expect(result.runDetail![10].withdrawal).toBe(40_000);
+  });
+
+  it('ratcheting does not ratchet before spending starts', () => {
+    // Strong accumulation growth blows past the balance threshold long
+    // before retirement; the streak must not start counting until
+    // spending does
+    const result = runMonteCarloSimulation(
+      makeParams(
+        {
+          annualWithdrawal: 0,
+          horizonYears: 10,
+          currentAge: 60,
+          spendingPhases: [
+            { id: 'working', name: '', fromAge: null, annualWithdrawal: 0 },
+            {
+              id: 'retired',
+              name: '',
+              fromAge: 65,
+              annualWithdrawal: 10_000,
+            },
+          ],
+          withdrawalRule: { ...WITHDRAWAL_RULE_DEFAULTS, type: 'ratcheting' },
+          captureRunDetail: 0,
+        },
+        {
+          startingBalance: 100_000,
+          expectedReturnMean: 0.2,
+          returnStdDev: 0,
+        },
+      ),
+    );
+
+    expect(result.runDetail![5].withdrawal).toBe(10_000);
+  });
+
   it('floor-ceiling scales withdrawals with the pot within limits', () => {
     const base = makeParams(
       { annualWithdrawal: 10_000, horizonYears: 30 },

--- a/packages/desktop-client/src/components/reports/reports/monte-carlo/monteCarloSimulation.ts
+++ b/packages/desktop-client/src/components/reports/reports/monte-carlo/monteCarloSimulation.ts
@@ -894,6 +894,17 @@ export function runMonteCarloSimulation(
     plannedTodayByYear[year] = amount;
   }
 
+  // The first year with planned spending - withdrawal rules anchor here
+  // and only adjust from here on, so zero-spend years (accumulation
+  // before retirement) neither trigger nor drift them
+  let firstSpendingYear = Infinity;
+  for (let year = 1; year <= horizonYears; year++) {
+    if (plannedTodayByYear[year] > 0) {
+      firstSpendingYear = year;
+      break;
+    }
+  }
+
   // Planned contributions per pot per year, in today's money - split into
   // an inflation-adjusted and a flat portion so a year's deposit is
   // flat + adjusted × cumulativeInflation. Deterministic and shared by
@@ -998,10 +1009,6 @@ export function runMonteCarloSimulation(
     accessibleStartByYear[year] = accessibleStart;
   }
 
-  const initialRate =
-    accessibleStartByYear[1] > 0
-      ? plannedTodayByYear[1] / accessibleStartByYear[1]
-      : 0;
   const withdrawnTotals = new Float64Array(simulationCount);
   const depletionYearBySimulation = new Int32Array(simulationCount).fill(-1);
 
@@ -1020,6 +1027,10 @@ export function runMonteCarloSimulation(
     // Cuts/raises from the withdrawal rule compound here, applied on top of
     // the planned spending path (so they persist across spending phases)
     let adjustmentFactor = 1;
+    // Floor & ceiling's withdrawal rate, anchored per run in the first
+    // spending year so the first retirement withdrawal is the planned
+    // amount exactly
+    let floorCeilingAnchorRate = 0;
     // This replay's realized inflation path: each year draws its own rate
     // when inflation volatility is set
     let cumulativeInflation = 1;
@@ -1084,20 +1095,32 @@ export function runMonteCarloSimulation(
         }
 
         // Apply the dynamic withdrawal rule before taking this year's
-        // withdrawal (from year 2 - year 1 always uses the planned amount).
-        // Rules evaluate accessible wealth only: locked pots can't fund
-        // spending, so they must not drive cuts or raises until they unlock
-        if (year > 1 && rule.type === 'floor-ceiling') {
-          // Recompute rule: a fixed share of the accessible balance, kept
-          // within limits around the planned spending
-          withdrawal = clamp(
-            initialRate * accessibleTotal,
-            planned * (1 - rule.floorPct),
-            planned * (1 + rule.ceilingPct),
-          );
+        // withdrawal. Rules only operate in years with planned spending,
+        // measured from the first spending year: the anchor year takes
+        // the planned amount as-is, and zero-spend years (accumulation
+        // before retirement, or a later zero phase) neither adjust nor
+        // drift them. Rules evaluate accessible wealth only: locked pots
+        // can't fund spending, so they must not drive cuts or raises
+        // until they unlock
+        if (rule.type === 'floor-ceiling') {
+          if (year === firstSpendingYear) {
+            floorCeilingAnchorRate =
+              accessibleTotal > 0 ? planned / accessibleTotal : 0;
+          }
+          withdrawal =
+            planned > 0 && year > firstSpendingYear
+              ? // A fixed share of the accessible balance, kept within
+                // limits around the planned spending
+                clamp(
+                  floorCeilingAnchorRate * accessibleTotal,
+                  planned * (1 - rule.floorPct),
+                  planned * (1 + rule.ceilingPct),
+                )
+              : planned;
         } else {
           if (
-            year > 1 &&
+            planned > 0 &&
+            year > firstSpendingYear &&
             rule.type !== 'none' &&
             accessibleTotal > 0 &&
             accessibleStartByYear[year] > 0

--- a/packages/docs/docs/experimental/monte-carlo-analysis.md
+++ b/packages/docs/docs/experimental/monte-carlo-analysis.md
@@ -128,7 +128,7 @@ By default, the simulation withdraws the same (inflation-adjusted) amount every 
 
 All the rules share a few ideas:
 
-- Your **spending phases** set the planned amounts. The rules wake up in your first year of planned spending: that year takes the planned amount as-is, and from the next year onward the rule adjusts what's actually taken - independently in every replay, reacting to how that replay is going. Zero-spend years (for example, working years before retirement) neither trigger nor move the rules. A cut or raise carries across phase boundaries: if the rule cut your spending by 10% during a rough patch, the next phase's amount starts 10% lower too.
+- Your **spending phases** set the planned amounts. The rules wake up in your first year of planned spending: that year takes the planned amount (only a **Minimum withdrawal** set higher than it can override that), and from the next year onward the rule adjusts what's actually taken - independently in every replay, reacting to how that replay is going. Zero-spend years (for example, working years before retirement) neither trigger nor move the rules. A cut or raise carries across phase boundaries: if the rule cut your spending by 10% during a rough patch, the next phase's amount starts 10% lower too.
 - Rules usually improve your **success rate** by cutting spending in bad times, but that safety isn't free - you get it by living on less. Keep an eye on the **Median total withdrawn** stat to see what a rule costs you in income.
 - Rules only see the wealth you can actually spend. If a pension is locked until its access age, it doesn't earn you spending raises while a bridge pot pays the bills - the rules watch the accessible pots, and the pension starts counting the moment it unlocks.
 

--- a/packages/docs/docs/experimental/monte-carlo-analysis.md
+++ b/packages/docs/docs/experimental/monte-carlo-analysis.md
@@ -128,7 +128,7 @@ By default, the simulation withdraws the same (inflation-adjusted) amount every 
 
 All the rules share a few ideas:
 
-- Your **spending phases** set the planned amounts. From the second year onward, the rule adjusts what's actually taken - independently in every replay, reacting to how that replay is going. A cut or raise carries across phase boundaries: if the rule cut your spending by 10% during a rough patch, the next phase's amount starts 10% lower too.
+- Your **spending phases** set the planned amounts. The rules wake up in your first year of planned spending: that year takes the planned amount as-is, and from the next year onward the rule adjusts what's actually taken - independently in every replay, reacting to how that replay is going. Zero-spend years (for example, working years before retirement) neither trigger nor move the rules. A cut or raise carries across phase boundaries: if the rule cut your spending by 10% during a rough patch, the next phase's amount starts 10% lower too.
 - Rules usually improve your **success rate** by cutting spending in bad times, but that safety isn't free - you get it by living on less. Keep an eye on the **Median total withdrawn** stat to see what a rule costs you in income.
 - Rules only see the wealth you can actually spend. If a pension is locked until its access age, it doesn't earn you spending raises while a bridge pot pays the bills - the rules watch the accessible pots, and the pension starts counting the moment it unlocks.
 
@@ -144,7 +144,7 @@ The optimist's rule: withdrawals only ever go **up**, never down. If your balanc
 
 ### Floor & Ceiling (Bengen)
 
-Instead of a fixed amount, each year you withdraw a fixed **percentage of whatever the pots are currently worth** - so spending naturally falls in bad years and rises in good ones. To stop that swinging too wildly, the withdrawal is kept within a floor and a ceiling around your original (inflation-adjusted) amount.
+Instead of a fixed amount, each year you withdraw a fixed **percentage of whatever the pots are currently worth** - so spending naturally falls in bad years and rises in good ones. The percentage is set in your first year of planned spending (your planned amount divided by your accessible wealth at that point), and the withdrawal is then kept within a floor and a ceiling around your planned (inflation-adjusted) amount so it can't swing too wildly.
 
 ### Boundaries
 

--- a/upcoming-release-notes/fix-monte-carlo-rules-zero-spend.md
+++ b/upcoming-release-notes/fix-monte-carlo-rules-zero-spend.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [MikesGlitch]
+---
+
+Fix Monte Carlo withdrawal rules misbehaving when retirement starts after years of zero planned spending


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

AI helped with this

Floor and Ceiling & Boundaries rules were anchoring to the first year instead of the first spending year. Changed it to anchor to the first spending year.

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

<!-- If AI tools wrote a significant part of this change, please disclose it here and name the tool you used. See https://actualbudget.org/docs/contributing/ai-usage-policy -->

## Related issue(s)

Reported here https://github.com/actualbudget/actual/issues/8571#issuecomment-5526858255
<!-- e.g. Fixes #123, Relates to #456 -->

## Testing

Upper ceiling increases to `20% of 60k + initial 60k which is 72k`

Note: Before this change, it was taking the floor amount instead of the upper amount.

<img width="1637" height="818" alt="image" src="https://github.com/user-attachments/assets/b6232a17-c185-447b-85c8-69c303feb4f9" />


Lowers to initial `60k - 15% of 60k  which is 51k `

<img width="1637" height="818" alt="image" src="https://github.com/user-attachments/assets/e14fa98c-3353-40b6-91f0-a19545342899" />


<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 42 | 13.52 MB → 13.52 MB (+857 B) | +0.01%
loot-core | 1 | 4.63 MB | 0%
api | 2 | 3.85 MB | 0%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
42 | 13.52 MB → 13.52 MB (+857 B) | +0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/reports/reports/monte-carlo/monteCarloSimulation.ts` | 📈 +293 B (+0.91%) | 31.33 kB → 31.61 kB
`locale/de.json` | 📈 +564 B (+0.30%) | 185.95 kB → 186.5 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/de.js | 185.95 kB → 186.5 kB (+564 B) | +0.30%
static/js/ReportRouter.js | 1.44 MB → 1.44 MB (+293 B) | +0.02%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.58 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/DateSelect.js | 2.37 MB | 0%
static/js/FormulaEditor.js | 766.35 kB | 0%
static/js/ManageRules.js | 71.66 kB | 0%
static/js/NotesTagFormatter.js | 25.94 kB | 0%
static/js/PayeeRuleCountLabel.js | 12.81 kB | 0%
static/js/ScheduleEditForm.js | 75.41 kB | 0%
static/js/SchedulesTable.js | 171.25 kB | 0%
static/js/TourHost.js | 169.22 kB | 0%
static/js/TourProvider.js | 1.54 kB | 0%
static/js/TransactionEdit.js | 221.38 kB | 0%
static/js/TransactionList.js | 79.22 kB | 0%
static/js/Value.js | 1.79 MB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/ca.js | 170.64 kB | 0%
static/js/client.js | 452.05 kB | 0%
static/js/columns.js | 673.28 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/en.js | 245.91 kB | 0%
static/js/es.js | 164.81 kB | 0%
static/js/fr.js | 179.04 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 151.67 kB | 0%
static/js/months.js | 574.72 kB | 0%
static/js/narrow.js | 290.52 kB | 0%
static/js/nb-NO.js | 135.46 kB | 0%
static/js/nl.js | 151.78 kB | 0%
static/js/pl.js | 136.39 kB | 0%
static/js/pt-BR.js | 178.2 kB | 0%
static/js/ru.js | 212.8 kB | 0%
static/js/theme.js | 31.1 kB | 0%
static/js/uk.js | 201.42 kB | 0%
static/js/useFormatList.js | 10.22 kB | 0%
static/js/useLocalPref.js | 97.2 kB | 0%
static/js/useReducedMotion.js | 594 B | 0%
static/js/wide.js | 274.04 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 106.8 kB | 0%
static/js/zh-Hant.js | 130.92 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.63 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.EDh4AUh5.js | 4.63 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.85 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.85 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.16 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->