### PR TITLE
Schedule forecast smoothing

### DIFF
--- a/packages/loot-core/src/server/budget/category-template-context.test.ts
+++ b/packages/loot-core/src/server/budget/category-template-context.test.ts
@@ -3,13 +3,19 @@ import { vi } from 'vitest';
 import * as aql from '#server/aql';
 import * as db from '#server/db';
 import type { DbCategory } from '#server/db';
+import { Rule } from '#server/rules';
+import { getRuleForSchedule } from '#server/schedules/app';
 import { amountToInteger } from '#shared/util';
 import type { CategoryEntity } from '#types/models';
 import type { ByTemplate, Template } from '#types/models/templates';
 
 import * as actions from './actions';
-import { CategoryTemplateContext } from './category-template-context';
+import {
+  CategoryTemplateContext,
+  scheduleForecastConfig,
+} from './category-template-context';
 import { distributeRemainder } from './goal-template';
+import { runSchedule, runScheduleForecast } from './schedule-template';
 import * as statements from './statements';
 
 // Mock getSheetValue and getCategories
@@ -22,7 +28,14 @@ vi.mock('./actions', () => ({
 
 vi.mock('#server/db', () => ({
   getCategories: vi.fn(),
+  first: vi.fn(),
+  getAccounts: vi.fn(),
 }));
+
+vi.mock('#server/schedules/app', async () => {
+  const actualModule = await vi.importActual('#server/schedules/app');
+  return { ...actualModule, getRuleForSchedule: vi.fn() };
+});
 
 vi.mock('#server/aql', () => ({
   aqlQuery: vi.fn(),
@@ -1206,6 +1219,175 @@ describe('CategoryTemplateContext', () => {
       );
       const result = instance.runRemainder(99, 100);
       expect(result).toBe(99);
+    });
+  });
+
+  describe('schedule template gating', () => {
+    const category: CategoryEntity = {
+      id: 'gate-cat',
+      name: 'Gate Category',
+      group: 'g',
+      is_income: false,
+    };
+    const templates: Template[] = [
+      {
+        type: 'schedule',
+        name: 'Internet',
+        directive: 'template',
+        priority: 1,
+      },
+      {
+        type: 'schedule',
+        name: 'Insurance',
+        directive: 'template',
+        priority: 1,
+      },
+    ];
+
+    function mockTwoSchedules() {
+      vi.mocked(statements.getActiveSchedules).mockResolvedValue([
+        { name: 'Internet', id: 's1' },
+        { name: 'Insurance', id: 's2' },
+      ] as Awaited<ReturnType<typeof statements.getActiveSchedules>>);
+      vi.mocked(db.getAccounts).mockResolvedValue([]);
+      vi.mocked(db.first).mockImplementation(async (_q, params?: unknown[]) => {
+        const name = (params as string[] | undefined)?.[0] ?? '';
+        return { id: name === 'Internet' ? 1 : 2, completed: 0 };
+      });
+      vi.mocked(getRuleForSchedule).mockImplementation(async id => {
+        const isInternet = Number(id) === 1;
+        return new Rule({
+          id: String(id),
+          stage: 'pre',
+          conditionsOp: 'and',
+          conditions: [
+            {
+              op: 'is',
+              field: 'date',
+              value: isInternet
+                ? {
+                    start: '2024-01-15',
+                    interval: 1,
+                    frequency: 'monthly',
+                    patterns: [],
+                    skipWeekend: false,
+                    weekendSolveMode: 'before',
+                    endMode: 'never',
+                    endOccurrences: 1,
+                    endDate: '2099-01-01',
+                  }
+                : {
+                    start: '2024-12-15',
+                    interval: 1,
+                    frequency: 'yearly',
+                    patterns: [],
+                    skipWeekend: false,
+                    weekendSolveMode: 'before',
+                    endMode: 'never',
+                    endOccurrences: 1,
+                    endDate: '2099-01-01',
+                  },
+              type: 'date',
+            },
+            {
+              op: 'is',
+              field: 'amount',
+              value: isInternet ? -10000 : -60000,
+              type: 'number',
+            },
+          ],
+          actions: [],
+        });
+      });
+      vi.mocked(actions.isTrackingBudget).mockReturnValue(false);
+    }
+
+    beforeEach(() => {
+      mockPreferences(false, 'USD');
+      vi.mocked(actions.getSheetValue).mockResolvedValue(0);
+      vi.mocked(actions.getSheetBoolean).mockResolvedValue(false);
+      vi.mocked(actions.isTrackingBudget).mockReturnValue(false);
+      mockTwoSchedules();
+    });
+
+    afterEach(() => {
+      scheduleForecastConfig.enabled = false;
+    });
+
+    it('dispatches to runSchedule when the gate is explicitly disabled', async () => {
+      scheduleForecastConfig.enabled = false;
+
+      const instance = await CategoryTemplateContext.init(
+        templates,
+        category,
+        '2024-01',
+        0,
+      );
+      const result = await instance.runTemplatesForPriority(1, 100000, 100000);
+
+      const expected = await runSchedule(
+        templates,
+        '2024-01',
+        0,
+        0,
+        0,
+        0,
+        [],
+        category,
+        {
+          code: 'USD',
+          symbol: '$',
+          name: 'US Dollar',
+          decimalPlaces: 2,
+          numberFormat: 'comma-dot',
+          symbolFirst: true,
+        },
+      );
+      expect(result).toBe(expected.to_budget);
+    });
+
+    it('dispatches to runScheduleForecast when the gate is explicitly enabled', async () => {
+      scheduleForecastConfig.enabled = true;
+      vi.mocked(aql.aqlQuery).mockImplementation(async (query: unknown) => {
+        const queryStr = JSON.stringify(query);
+        if (queryStr.includes('transactions')) {
+          return { data: [], dependencies: [] };
+        }
+        if (queryStr.includes('hideFraction')) {
+          return { data: [{ value: 'false' }], dependencies: [] };
+        }
+        if (queryStr.includes('defaultCurrencyCode')) {
+          return { data: [{ value: 'USD' }], dependencies: [] };
+        }
+        return { data: [], dependencies: [] };
+      });
+
+      const instance = await CategoryTemplateContext.init(
+        templates,
+        category,
+        '2024-01',
+        0,
+      );
+      const result = await instance.runTemplatesForPriority(1, 100000, 100000);
+
+      const expected = await runScheduleForecast(
+        templates,
+        '2024-01',
+        0,
+        0,
+        0,
+        [],
+        category,
+        {
+          code: 'USD',
+          symbol: '$',
+          name: 'US Dollar',
+          decimalPlaces: 2,
+          numberFormat: 'comma-dot',
+          symbolFirst: true,
+        },
+      );
+      expect(result).toBe(expected.to_budget);
     });
   });
 

--- a/packages/loot-core/src/server/budget/category-template-context.test.ts
+++ b/packages/loot-core/src/server/budget/category-template-context.test.ts
@@ -1322,6 +1322,69 @@ describe('CategoryTemplateContext', () => {
       scheduleForecastConfig.enabled = false;
     });
 
+    it('dispatches to runScheduleForecast by default, without setting the gate', async () => {
+      // Must run before any other test in this block sets
+      // scheduleForecastConfig.enabled — it asserts the module's untouched
+      // initial value rather than a value a test set.
+      expect(scheduleForecastConfig.enabled).toBe(true);
+      vi.mocked(aql.aqlQuery).mockImplementation(async (query: unknown) => {
+        const queryStr = JSON.stringify(query);
+        if (queryStr.includes('transactions')) {
+          return { data: [], dependencies: [] };
+        }
+        if (queryStr.includes('hideFraction')) {
+          return { data: [{ value: 'false' }], dependencies: [] };
+        }
+        if (queryStr.includes('defaultCurrencyCode')) {
+          return { data: [{ value: 'USD' }], dependencies: [] };
+        }
+        return { data: [], dependencies: [] };
+      });
+
+      const instance = await CategoryTemplateContext.init(
+        templates,
+        category,
+        '2024-01',
+        0,
+      );
+      const result = await instance.runTemplatesForPriority(1, 100000, 100000);
+
+      const currency = {
+        code: 'USD',
+        symbol: '$',
+        name: 'US Dollar',
+        decimalPlaces: 2,
+        numberFormat: 'comma-dot',
+        symbolFirst: true,
+      } satisfies Currency;
+      const expected = await runScheduleForecast(
+        templates,
+        '2024-01',
+        0,
+        0,
+        0,
+        [],
+        category,
+        currency,
+      );
+      // Guard against this test coincidentally passing if the dispatch gate
+      // is broken: confirm the two algorithms actually produce different
+      // totals for this fixture before asserting which one was dispatched.
+      const otherAlgorithm = await runSchedule(
+        templates,
+        '2024-01',
+        0,
+        0,
+        0,
+        0,
+        [],
+        category,
+        currency,
+      );
+      expect(expected.to_budget).not.toBe(otherAlgorithm.to_budget);
+      expect(result).toBe(expected.to_budget);
+    });
+
     it('dispatches to runSchedule when the gate is explicitly disabled', async () => {
       scheduleForecastConfig.enabled = false;
 

--- a/packages/loot-core/src/server/budget/category-template-context.test.ts
+++ b/packages/loot-core/src/server/budget/category-template-context.test.ts
@@ -5,6 +5,7 @@ import * as db from '#server/db';
 import type { DbCategory } from '#server/db';
 import { Rule } from '#server/rules';
 import { getRuleForSchedule } from '#server/schedules/app';
+import type { Currency } from '#shared/currencies';
 import { amountToInteger } from '#shared/util';
 import type { CategoryEntity } from '#types/models';
 import type { ByTemplate, Template } from '#types/models/templates';
@@ -1264,11 +1265,18 @@ describe('CategoryTemplateContext', () => {
             {
               op: 'is',
               field: 'date',
+              // Both schedules are non-monthly with different due dates
+              // (not one pay-month-of + one sinking): a uniform monthly
+              // schedule mixed with a single sinking schedule happens to
+              // make runSchedule and runScheduleForecast agree numerically
+              // for this fixture shape, which would let a broken dispatch
+              // gate pass unnoticed (see the differs-by-construction
+              // assertion below).
               value: isInternet
                 ? {
-                    start: '2024-01-15',
+                    start: '2024-03-15',
                     interval: 1,
-                    frequency: 'monthly',
+                    frequency: 'yearly',
                     patterns: [],
                     skipWeekend: false,
                     weekendSolveMode: 'before',
@@ -1325,6 +1333,14 @@ describe('CategoryTemplateContext', () => {
       );
       const result = await instance.runTemplatesForPriority(1, 100000, 100000);
 
+      const currency = {
+        code: 'USD',
+        symbol: '$',
+        name: 'US Dollar',
+        decimalPlaces: 2,
+        numberFormat: 'comma-dot',
+        symbolFirst: true,
+      } satisfies Currency;
       const expected = await runSchedule(
         templates,
         '2024-01',
@@ -1334,15 +1350,23 @@ describe('CategoryTemplateContext', () => {
         0,
         [],
         category,
-        {
-          code: 'USD',
-          symbol: '$',
-          name: 'US Dollar',
-          decimalPlaces: 2,
-          numberFormat: 'comma-dot',
-          symbolFirst: true,
-        },
+        currency,
       );
+      // Guard against this test coincidentally passing if the dispatch gate
+      // is broken: confirm the two algorithms actually produce different
+      // totals for this fixture before asserting which one was dispatched.
+      vi.mocked(aql.aqlQuery).mockResolvedValue({ data: [], dependencies: [] });
+      const otherAlgorithm = await runScheduleForecast(
+        templates,
+        '2024-01',
+        0,
+        0,
+        0,
+        [],
+        category,
+        currency,
+      );
+      expect(expected.to_budget).not.toBe(otherAlgorithm.to_budget);
       expect(result).toBe(expected.to_budget);
     });
 
@@ -1370,6 +1394,14 @@ describe('CategoryTemplateContext', () => {
       );
       const result = await instance.runTemplatesForPriority(1, 100000, 100000);
 
+      const currency = {
+        code: 'USD',
+        symbol: '$',
+        name: 'US Dollar',
+        decimalPlaces: 2,
+        numberFormat: 'comma-dot',
+        symbolFirst: true,
+      } satisfies Currency;
       const expected = await runScheduleForecast(
         templates,
         '2024-01',
@@ -1378,15 +1410,23 @@ describe('CategoryTemplateContext', () => {
         0,
         [],
         category,
-        {
-          code: 'USD',
-          symbol: '$',
-          name: 'US Dollar',
-          decimalPlaces: 2,
-          numberFormat: 'comma-dot',
-          symbolFirst: true,
-        },
+        currency,
       );
+      // Guard against this test coincidentally passing if the dispatch gate
+      // is broken: confirm the two algorithms actually produce different
+      // totals for this fixture before asserting which one was dispatched.
+      const otherAlgorithm = await runSchedule(
+        templates,
+        '2024-01',
+        0,
+        0,
+        0,
+        0,
+        [],
+        category,
+        currency,
+      );
+      expect(expected.to_budget).not.toBe(otherAlgorithm.to_budget);
       expect(result).toBe(expected.to_budget);
     });
   });

--- a/packages/loot-core/src/server/budget/category-template-context.ts
+++ b/packages/loot-core/src/server/budget/category-template-context.ts
@@ -38,7 +38,6 @@ import { getActiveSchedules } from './statements';
 // paths (and their AQL imports) still ship regardless of this flag's
 // value. Not yet a user-facing or per-category setting — flip to measure
 // perf before deciding rollout.
-// See docs/superpowers/specs/2026-09-02-schedule-forecast-smoothing-design.md
 //
 // Exported as a mutable object, not a bare const, so tests can flip it
 // per-`describe`/`it` block and exercise both dispatch paths through the

--- a/packages/loot-core/src/server/budget/category-template-context.ts
+++ b/packages/loot-core/src/server/budget/category-template-context.ts
@@ -30,10 +30,14 @@ import {
 import { runSchedule, runScheduleForecast } from './schedule-template';
 import { getActiveSchedules } from './statements';
 
-// Build-time switch: selects the 60-month-forecast smoothing algorithm
-// (runScheduleForecast) instead of today's payMonthOf/sinking heuristic
-// (runSchedule) for schedule-type templates. Not yet a user-facing or
-// per-category setting — flip to measure perf before deciding rollout.
+// Test-settable module-level switch: selects the 60-month-forecast
+// smoothing algorithm (runScheduleForecast) instead of today's
+// payMonthOf/sinking heuristic (runSchedule) for schedule-type templates.
+// This is a mutable exported object read at call time, not a build-time
+// constant — no bundler can tree-shake the disabled branch, so both code
+// paths (and their AQL imports) still ship regardless of this flag's
+// value. Not yet a user-facing or per-category setting — flip to measure
+// perf before deciding rollout.
 // See docs/superpowers/specs/2026-09-02-schedule-forecast-smoothing-design.md
 //
 // Exported as a mutable object, not a bare const, so tests can flip it

--- a/packages/loot-core/src/server/budget/category-template-context.ts
+++ b/packages/loot-core/src/server/budget/category-template-context.ts
@@ -27,8 +27,21 @@ import {
   getSheetValue,
   isTrackingBudget,
 } from './actions';
-import { runSchedule } from './schedule-template';
+import { runSchedule, runScheduleForecast } from './schedule-template';
 import { getActiveSchedules } from './statements';
+
+// Build-time switch: selects the 60-month-forecast smoothing algorithm
+// (runScheduleForecast) instead of today's payMonthOf/sinking heuristic
+// (runSchedule) for schedule-type templates. Not yet a user-facing or
+// per-category setting — flip to measure perf before deciding rollout.
+// See docs/superpowers/specs/2026-09-02-schedule-forecast-smoothing-design.md
+//
+// Exported as a mutable object, not a bare const, so tests can flip it
+// per-`describe`/`it` block and exercise both dispatch paths through the
+// same integration surface, rather than only reaching runSchedule and
+// runScheduleForecast directly (schedule-template.test.ts) or having to
+// module-mock this file to test the gate itself.
+export const scheduleForecastConfig = { enabled: false };
 
 export class CategoryTemplateContext {
   /*----------------------------------------------------------------------------
@@ -209,21 +222,37 @@ export class CategoryTemplateContext {
         case 'schedule': {
           if (!scheduleFlag) {
             const budgeted = this.fromLastMonth + toBudget;
-            const ret = await runSchedule(
-              t,
-              this.month,
-              budgeted,
-              remainder,
-              this.fromLastMonth,
-              toBudget,
-              [],
-              this.category,
-              this.currency,
-            );
+            let ret:
+              | Awaited<ReturnType<typeof runSchedule>>
+              | Awaited<ReturnType<typeof runScheduleForecast>>;
+            if (scheduleForecastConfig.enabled) {
+              ret = await runScheduleForecast(
+                t,
+                this.month,
+                budgeted,
+                this.fromLastMonth,
+                toBudget,
+                [],
+                this.category,
+                this.currency,
+              );
+            } else {
+              ret = await runSchedule(
+                t,
+                this.month,
+                budgeted,
+                remainder,
+                this.fromLastMonth,
+                toBudget,
+                [],
+                this.category,
+                this.currency,
+              );
+            }
             // Schedules assume that its to budget value is the whole thing so this
             // needs to remove the previous funds so they aren't double counted
             newBudget = ret.to_budget - toBudget;
-            remainder = ret.remainder;
+            remainder = 'remainder' in ret ? ret.remainder : remainder;
             schedulePerTemplate = ret.perScheduleMonthly;
             scheduleFlag = true;
           }

--- a/packages/loot-core/src/server/budget/category-template-context.ts
+++ b/packages/loot-core/src/server/budget/category-template-context.ts
@@ -36,15 +36,15 @@ import { getActiveSchedules } from './statements';
 // This is a mutable exported object read at call time, not a build-time
 // constant — no bundler can tree-shake the disabled branch, so both code
 // paths (and their AQL imports) still ship regardless of this flag's
-// value. Not yet a user-facing or per-category setting — flip to measure
-// perf before deciding rollout.
+// value. Defaulted on for this branch/PR so reviewers exercise the new
+// algorithm directly; not yet a per-category setting.
 //
 // Exported as a mutable object, not a bare const, so tests can flip it
 // per-`describe`/`it` block and exercise both dispatch paths through the
 // same integration surface, rather than only reaching runSchedule and
 // runScheduleForecast directly (schedule-template.test.ts) or having to
 // module-mock this file to test the gate itself.
-export const scheduleForecastConfig = { enabled: false };
+export const scheduleForecastConfig = { enabled: true };
 
 export class CategoryTemplateContext {
   /*----------------------------------------------------------------------------

--- a/packages/loot-core/src/server/budget/schedule-template.test.ts
+++ b/packages/loot-core/src/server/budget/schedule-template.test.ts
@@ -1,3 +1,4 @@
+import { aqlQuery } from '#server/aql';
 import * as db from '#server/db';
 import { Rule } from '#server/rules';
 import { getRuleForSchedule } from '#server/schedules/app';
@@ -5,9 +6,14 @@ import type { Currency } from '#shared/currencies';
 import type { CategoryEntity } from '#types/models';
 
 import { isTrackingBudget } from './actions';
-import { createScheduleList, runSchedule } from './schedule-template';
+import {
+  buildMonthlyOutflow,
+  createScheduleList,
+  runSchedule,
+} from './schedule-template';
 
 vi.mock('#server/db');
+vi.mock('#server/aql');
 vi.mock('./actions');
 vi.mock('#server/schedules/app', async () => {
   const actualModule = await vi.importActual('#server/schedules/app');
@@ -719,5 +725,71 @@ describe('createScheduleList', () => {
 
     expect(t[0].dateConditions).toBeDefined();
     expect(t[0].dateConditions.value.frequency).toBe('monthly');
+  });
+});
+
+describe('buildMonthlyOutflow', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(db.getAccounts).mockResolvedValue([]);
+  });
+
+  it('buckets each monthly schedule occurrence into its own month index', async () => {
+    mockSingleSchedule({
+      start: '2024-01-15',
+      amount: -10000,
+      frequency: 'monthly',
+    });
+    const template = {
+      type: 'schedule',
+      name: 'Rent',
+      priority: 0,
+      directive: 'template',
+    } as const;
+    const { t } = await createScheduleList(
+      [template],
+      '2024-01-01',
+      defaultCategory,
+      defaultCurrency,
+    );
+
+    vi.mocked(aqlQuery).mockResolvedValue({ data: [] } as never);
+
+    const outflow = await buildMonthlyOutflow(t, '2024-01-01', defaultCategory);
+
+    expect(outflow).toHaveLength(60);
+    expect(outflow[0]).toBe(10000);
+    expect(outflow[1]).toBe(10000);
+    expect(outflow[59]).toBe(10000);
+  });
+
+  it('adds an unlinked future-dated transaction only to its own month', async () => {
+    mockSingleSchedule({
+      start: '2024-01-15',
+      amount: -10000,
+      frequency: 'monthly',
+    });
+    const template = {
+      type: 'schedule',
+      name: 'Rent',
+      priority: 0,
+      directive: 'template',
+    } as const;
+    const { t } = await createScheduleList(
+      [template],
+      '2024-01-01',
+      defaultCategory,
+      defaultCurrency,
+    );
+
+    vi.mocked(aqlQuery).mockResolvedValue({
+      data: [{ amount: -5000, date: '2024-03-10' }],
+    } as never);
+
+    const outflow = await buildMonthlyOutflow(t, '2024-01-01', defaultCategory);
+
+    expect(outflow[0]).toBe(10000);
+    expect(outflow[2]).toBe(15000); // March: 10000 schedule + 5000 unlinked
+    expect(outflow[3]).toBe(10000);
   });
 });

--- a/packages/loot-core/src/server/budget/schedule-template.test.ts
+++ b/packages/loot-core/src/server/budget/schedule-template.test.ts
@@ -966,6 +966,107 @@ describe('runScheduleForecast', () => {
     expect(result.to_budget).toBe(10000);
     expect(result.perScheduleMonthly.get(template_lines[1])).toBe(10000);
   });
+
+  it('splits perScheduleMonthly by monthly-equivalent contribution, not raw target, for a monthly + yearly mix', async () => {
+    const template_lines = [
+      {
+        type: 'schedule',
+        name: 'Monthly',
+        priority: 0,
+        directive: 'template',
+      } as const,
+      {
+        type: 'schedule',
+        name: 'Yearly',
+        priority: 0,
+        directive: 'template',
+      } as const,
+    ];
+    mockSchedulesByName({
+      Monthly: {
+        spec: { start: '2024-01-15', amount: -10000, frequency: 'monthly' },
+      },
+      Yearly: {
+        spec: { start: '2024-12-15', amount: -60000, frequency: 'yearly' },
+      },
+    });
+
+    const result = await runScheduleForecast(
+      template_lines,
+      '2024-01-01',
+      0,
+      0,
+      0,
+      [],
+      defaultCategory,
+      defaultCurrency,
+    );
+
+    // No full-flag entries and a starting balance of 0, so the whole
+    // to_budget is the smoothed candidate.
+    const candidate = result.to_budget;
+    const monthlyShare = result.perScheduleMonthly.get(template_lines[0]);
+    const yearlyShare = result.perScheduleMonthly.get(template_lines[1]);
+    expect(monthlyShare).toBeDefined();
+    expect(yearlyShare).toBeDefined();
+    if (monthlyShare === undefined || yearlyShare === undefined) {
+      throw new Error('unreachable');
+    }
+
+    // Monthly-equivalent weights are 10000 (Monthly, target/1) and 5000
+    // (Yearly, target/1/12 = 60000/12) -- a 2:1 ratio -- not the raw
+    // 10000:60000 (1:6) ratio a naive split on entry.target would produce.
+    expect(monthlyShare / yearlyShare).toBeCloseTo(2, 1);
+    // The two shares should still (modulo per-share rounding) add back up
+    // to the single smoothed candidate.
+    expect(monthlyShare + yearlyShare).toBeGreaterThanOrEqual(candidate - 1);
+    expect(monthlyShare + yearlyShare).toBeLessThanOrEqual(candidate + 1);
+  });
+
+  it('never produces a non-finite perScheduleMonthly share when smooth schedules in one category offset to a zero net weight', async () => {
+    const template_lines = [
+      {
+        type: 'schedule',
+        name: 'Expense',
+        priority: 0,
+        directive: 'template',
+      } as const,
+      {
+        type: 'schedule',
+        name: 'Refund',
+        priority: 0,
+        directive: 'template',
+      } as const,
+    ];
+    mockSchedulesByName({
+      // Monthly-equivalent weight: 10000 (target / interval).
+      Expense: {
+        spec: { start: '2024-01-15', amount: -10000, frequency: 'monthly' },
+      },
+      // Monthly-equivalent weight: -120000 / 1 / 12 = -10000, exactly
+      // offsetting Expense's weight so the total nets to zero while
+      // neither individual weight is zero.
+      Refund: {
+        spec: { start: '2024-01-15', amount: 120000, frequency: 'yearly' },
+      },
+    });
+
+    const result = await runScheduleForecast(
+      template_lines,
+      '2024-01-01',
+      0,
+      0,
+      0,
+      [],
+      defaultCategory,
+      defaultCurrency,
+    );
+
+    expect(result.perScheduleMonthly.size).toBe(2);
+    for (const share of result.perScheduleMonthly.values()) {
+      expect(Number.isFinite(share)).toBe(true);
+    }
+  });
 });
 
 describe('solveMonthlyContribution', () => {

--- a/packages/loot-core/src/server/budget/schedule-template.test.ts
+++ b/packages/loot-core/src/server/budget/schedule-template.test.ts
@@ -795,6 +795,49 @@ describe('buildMonthlyOutflow', () => {
     expect(outflow[2]).toBe(15000); // March: 10000 schedule + 5000 unlinked
     expect(outflow[3]).toBe(10000);
   });
+
+  it('buckets a weekly schedule by its per-occurrence amount, not its monthly-aggregated target', async () => {
+    // Regression test for the sub-monthly over-forecast bug: `target` on a
+    // weekly entry is the *aggregated* monthly total (createScheduleList
+    // sums every occurrence landing in its aggregation window into
+    // `target`), not a per-occurrence amount. Bucketing occurrences by
+    // `target` instead of `perOccurrenceAmount` would multiply an
+    // already-aggregated monthly total by the occurrence count again.
+    //
+    // 2024-01-01 is a Monday, so weekly-every-Monday from that date lands
+    // on 5 Mondays in January (1, 8, 15, 22, 29) and 4 in February (5, 12,
+    // 19, 26) -- a real, independently-verifiable calendar fact, not a
+    // number derived from the code under test.
+    mockSingleSchedule({
+      start: '2024-01-01',
+      amount: -1000,
+      frequency: 'weekly',
+    });
+    const template = {
+      type: 'schedule',
+      name: 'Weekly Bill',
+      priority: 0,
+      directive: 'template',
+    } as const;
+    const { t } = await createScheduleList(
+      [template],
+      '2024-01-01',
+      defaultCategory,
+      defaultCurrency,
+    );
+
+    // Sanity check on the fixture itself: target is the aggregated
+    // January total (5 occurrences), not the single-occurrence amount.
+    expect(t[0].target).toBe(5000);
+    expect(t[0].perOccurrenceAmount).toBe(1000);
+
+    vi.mocked(aqlQuery).mockResolvedValue({ data: [] } as never);
+
+    const outflow = await buildMonthlyOutflow(t, '2024-01-01', defaultCategory);
+
+    expect(outflow[0]).toBe(5000); // 5 Mondays in January x $10
+    expect(outflow[1]).toBe(4000); // 4 Mondays in February x $10
+  });
 });
 
 describe('runScheduleForecast', () => {
@@ -1065,6 +1108,111 @@ describe('runScheduleForecast', () => {
     expect(result.perScheduleMonthly.size).toBe(2);
     for (const share of result.perScheduleMonthly.values()) {
       expect(Number.isFinite(share)).toBe(true);
+    }
+  });
+});
+
+describe('runScheduleForecast (real AQL query path)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(db.getAccounts).mockResolvedValue([]);
+  });
+
+  it('builds and compiles a real unlinked-transaction query for a month-shaped current_month and a weekly schedule', async () => {
+    // Integration regression test for Fix 1 (month-shaped `current_month`
+    // like '2024-01' must not throw a CompileError from the AQL date
+    // caster, which requires day-shaped date literals) and Fix 2 (a
+    // weekly, non-monthly schedule must not be over-counted).
+    //
+    // `#server/aql` is automocked for the rest of this file (see the
+    // top-level `vi.mock('#server/aql')`), which is exactly what would
+    // hide both of these bugs: the query never actually gets built or
+    // compiled. To exercise the real query-building/compiling path we
+    // unmock just this module and re-import it (and its dependents) into
+    // a fresh module registry, while `#server/db` stays mocked -- so the
+    // real AQL compiler runs, and only the actual SQLite read at the very
+    // bottom (`db.all`) is stubbed.
+    vi.resetModules();
+    vi.doUnmock('#server/aql');
+
+    const dbMod = await import('#server/db');
+    vi.mocked(dbMod.getAccounts).mockResolvedValue([]);
+    vi.mocked(dbMod.first).mockResolvedValue({ id: 1, completed: 0 } as never);
+    // The compiler's date caster stores dates as an integer (YYYYMMDD);
+    // db.all returns raw SQLite rows, which applyTypes then converts back
+    // to a 'yyyy-MM-dd' string via convertOutputType.
+    // Return a fresh array/object on every call: `applyTypes` mutates the
+    // returned rows in place when converting output types, and this test
+    // calls the real query-building path more than once (`runScheduleForecast`
+    // internally, then again independently below to verify the result).
+    vi.mocked(dbMod.all).mockImplementation(
+      async () => [{ amount: -500, date: 20240120 }] as never,
+    );
+
+    const scheduleAppMod = await import('#server/schedules/app');
+    vi.mocked(scheduleAppMod.getRuleForSchedule).mockResolvedValue(
+      makeRule({ start: '2024-01-01', amount: -1000, frequency: 'weekly' }),
+    );
+
+    const actionsMod = await import('./actions');
+    vi.mocked(actionsMod.isTrackingBudget).mockReturnValue(false);
+
+    const scheduleTemplateMod = await import('./schedule-template');
+
+    const template_lines = [
+      {
+        type: 'schedule',
+        name: 'Weekly Bill',
+        priority: 0,
+        directive: 'template',
+      } as const,
+    ];
+
+    try {
+      // Month-shaped, as the real budget engine passes it -- this is what
+      // Fix 1 makes safe to pass straight to the AQL query.
+      const result = await scheduleTemplateMod.runScheduleForecast(
+        template_lines,
+        '2024-01',
+        0,
+        0,
+        0,
+        [],
+        defaultCategory,
+        defaultCurrency,
+      );
+
+      expect(result.errors).toHaveLength(0);
+      // Re-derive the projection independently to confirm the query result
+      // (the unlinked $5 transaction on 2024-01-20) and the weekly
+      // schedule's per-occurrence amount were both folded in correctly,
+      // rather than asserting a value that could pass by coincidence.
+      const { t } = await scheduleTemplateMod.createScheduleList(
+        template_lines as ScheduleTemplate[],
+        '2024-01',
+        defaultCategory,
+        defaultCurrency,
+      );
+      const outflow = await scheduleTemplateMod.buildMonthlyOutflow(
+        t,
+        '2024-01',
+        defaultCategory,
+      );
+      // 5 Mondays in January 2024 x $10 + the $5 unlinked transaction.
+      expect(outflow[0]).toBe(5000 + 500);
+
+      let runningBalance = 0;
+      let minBalance = Infinity;
+      for (let i = 0; i < 60; i++) {
+        runningBalance += result.to_budget - outflow[i];
+        minBalance = Math.min(minBalance, runningBalance);
+      }
+      expect(minBalance).toBeGreaterThanOrEqual(0);
+    } finally {
+      // Restore the file-wide automock and module registry for any tests
+      // that run after this one.
+      vi.doMock('#server/aql');
+      vi.resetModules();
     }
   });
 });

--- a/packages/loot-core/src/server/budget/schedule-template.test.ts
+++ b/packages/loot-core/src/server/budget/schedule-template.test.ts
@@ -1229,9 +1229,9 @@ describe('solveMonthlyContribution', () => {
   });
 
   it('picks the early month with the larger threshold, not the late month with the larger raw balance', () => {
-    // Regression test for the weighting bug the closed form replaces
-    // (see the design spec's Iteration Algorithm > Derivation section).
-    // Month 0 needs 100/cent-month (weight 1); month 59 needs slightly
+    // Regression test for a weighting bug in an earlier guess-and-correct
+    // version of solveMonthlyContribution (see that function's own doc
+    // comment for the derivation). Month 0 needs 100/cent-month (weight 1); month 59 needs slightly
     // less per-cent-month but the raw shortfall at any shared candidate
     // is larger there purely because of the (i+1) weighting. The
     // correct answer is governed by whichever month's *threshold*

--- a/packages/loot-core/src/server/budget/schedule-template.test.ts
+++ b/packages/loot-core/src/server/budget/schedule-template.test.ts
@@ -756,7 +756,7 @@ describe('buildMonthlyOutflow', () => {
       defaultCurrency,
     );
 
-    vi.mocked(aqlQuery).mockResolvedValue({ data: [] } as never);
+    vi.mocked(aqlQuery).mockResolvedValue({ data: [], dependencies: [] });
 
     const outflow = await buildMonthlyOutflow(t, '2024-01-01', defaultCategory);
 
@@ -787,7 +787,8 @@ describe('buildMonthlyOutflow', () => {
 
     vi.mocked(aqlQuery).mockResolvedValue({
       data: [{ amount: -5000, date: '2024-03-10' }],
-    } as never);
+      dependencies: [],
+    });
 
     const outflow = await buildMonthlyOutflow(t, '2024-01-01', defaultCategory);
 
@@ -831,7 +832,7 @@ describe('buildMonthlyOutflow', () => {
     expect(t[0].target).toBe(5000);
     expect(t[0].perOccurrenceAmount).toBe(1000);
 
-    vi.mocked(aqlQuery).mockResolvedValue({ data: [] } as never);
+    vi.mocked(aqlQuery).mockResolvedValue({ data: [], dependencies: [] });
 
     const outflow = await buildMonthlyOutflow(t, '2024-01-01', defaultCategory);
 
@@ -844,7 +845,7 @@ describe('runScheduleForecast', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(db.getAccounts).mockResolvedValue([]);
-    vi.mocked(aqlQuery).mockResolvedValue({ data: [] } as never);
+    vi.mocked(aqlQuery).mockResolvedValue({ data: [], dependencies: [] });
   });
 
   it('contributes the exact monthly amount for a single monthly schedule', async () => {
@@ -1110,6 +1111,63 @@ describe('runScheduleForecast', () => {
       expect(Number.isFinite(share)).toBe(true);
     }
   });
+
+  it('never underfunds two annual schedules with different due dates, sharing a category (regression: actualbudget/actual#6513)', async () => {
+    // #6513: two annual schedules in one category (£100 due Feb, £90 due
+    // Mar), with £80 already banked going into January, under-budgeted
+    // every month under runSchedule's independent per-schedule remainder
+    // chaining. Assert runScheduleForecast's own postcondition directly —
+    // every projected month-end balance stays non-negative — rather than
+    // comparing its output against runSchedule's.
+    const template_lines = [
+      {
+        type: 'schedule',
+        name: 'Bill A',
+        priority: 0,
+        directive: 'template',
+      } as const,
+      {
+        type: 'schedule',
+        name: 'Bill B',
+        priority: 0,
+        directive: 'template',
+      } as const,
+    ];
+    mockSchedulesByName({
+      'Bill A': {
+        spec: { start: '2025-02-15', amount: -10000, frequency: 'yearly' },
+      },
+      'Bill B': {
+        spec: { start: '2025-03-15', amount: -9000, frequency: 'yearly' },
+      },
+    });
+
+    const result = await runScheduleForecast(
+      template_lines,
+      '2025-01-01',
+      8000,
+      8000,
+      0,
+      [],
+      defaultCategory,
+      defaultCurrency,
+    );
+
+    const { t } = await createScheduleList(
+      template_lines as ScheduleTemplate[],
+      '2025-01-01',
+      defaultCategory,
+      defaultCurrency,
+    );
+    const outflow = await buildMonthlyOutflow(t, '2025-01-01', defaultCategory);
+    let runningBalance = 8000;
+    let minBalance = Infinity;
+    for (let i = 0; i < 60; i++) {
+      runningBalance += result.to_budget - outflow[i];
+      minBalance = Math.min(minBalance, runningBalance);
+    }
+    expect(minBalance).toBeGreaterThanOrEqual(0);
+  });
 });
 
 describe('runScheduleForecast (real AQL query path)', () => {
@@ -1228,15 +1286,16 @@ describe('solveMonthlyContribution', () => {
     expect((candidate - 1) * 31).toBeLessThan(60000);
   });
 
-  it('picks the early month with the larger threshold, not the late month with the larger raw balance', () => {
+  it('picks the month with the larger cumulative threshold, not the one with the larger raw balance', () => {
     // Regression test for a weighting bug in an earlier guess-and-correct
     // version of solveMonthlyContribution (see that function's own doc
-    // comment for the derivation). Month 0 needs 100/cent-month (weight 1); month 59 needs slightly
-    // less per-cent-month but the raw shortfall at any shared candidate
-    // is larger there purely because of the (i+1) weighting. The
-    // correct answer is governed by whichever month's *threshold*
-    // (need / (i+1)) is larger, not whichever month's raw balance is
-    // more negative — here that's month 0.
+    // comment for the derivation). Month 0's threshold is 100 (weight 1);
+    // month 59's is higher, at 149, but at any shared candidate near 149
+    // its raw shortfall (threshold gap x weight) is *smaller* than month
+    // 0's would be, purely because of the (i+1) weighting. The correct
+    // answer is governed by whichever month's *threshold* (need / (i+1))
+    // is larger — here that's month 59, not whichever month's raw balance
+    // looks more negative at some candidate.
     // Month 0's own outflow is 100 (threshold_0 = 100/1 = 100). Month
     // 59's *cumulative* outflow needs to make threshold_59 = 149, i.e.
     // cumsum_59 = 149 * 60 = 8940, with month 0's 100 already part of

--- a/packages/loot-core/src/server/budget/schedule-template.test.ts
+++ b/packages/loot-core/src/server/budget/schedule-template.test.ts
@@ -5,7 +5,7 @@ import type { Currency } from '#shared/currencies';
 import type { CategoryEntity } from '#types/models';
 
 import { isTrackingBudget } from './actions';
-import { runSchedule } from './schedule-template';
+import { createScheduleList, runSchedule } from './schedule-template';
 
 vi.mock('#server/db');
 vi.mock('./actions');
@@ -688,5 +688,36 @@ describe('runSchedule', () => {
       defaultCurrency,
     );
     expect(result.to_budget).toBe(0);
+  });
+});
+
+describe('createScheduleList', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(db.getAccounts).mockResolvedValue([]);
+  });
+
+  it('includes dateConditions on each returned entry', async () => {
+    mockSingleSchedule({
+      start: '2024-08-01',
+      amount: -10000,
+      frequency: 'monthly',
+    });
+    const template = {
+      type: 'schedule',
+      name: 'Test Schedule',
+      priority: 0,
+      directive: 'template',
+    } as const;
+
+    const { t } = await createScheduleList(
+      [template],
+      '2024-08-01',
+      defaultCategory,
+      defaultCurrency,
+    );
+
+    expect(t[0].dateConditions).toBeDefined();
+    expect(t[0].dateConditions.value.frequency).toBe('monthly');
   });
 });

--- a/packages/loot-core/src/server/budget/schedule-template.test.ts
+++ b/packages/loot-core/src/server/budget/schedule-template.test.ts
@@ -4,12 +4,15 @@ import { Rule } from '#server/rules';
 import { getRuleForSchedule } from '#server/schedules/app';
 import type { Currency } from '#shared/currencies';
 import type { CategoryEntity } from '#types/models';
+import type { ScheduleTemplate } from '#types/models/templates';
 
 import { isTrackingBudget } from './actions';
 import {
   buildMonthlyOutflow,
   createScheduleList,
   runSchedule,
+  runScheduleForecast,
+  solveMonthlyContribution,
 } from './schedule-template';
 
 vi.mock('#server/db');
@@ -791,5 +794,217 @@ describe('buildMonthlyOutflow', () => {
     expect(outflow[0]).toBe(10000);
     expect(outflow[2]).toBe(15000); // March: 10000 schedule + 5000 unlinked
     expect(outflow[3]).toBe(10000);
+  });
+});
+
+describe('runScheduleForecast', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(db.getAccounts).mockResolvedValue([]);
+    vi.mocked(aqlQuery).mockResolvedValue({ data: [] } as never);
+  });
+
+  it('contributes the exact monthly amount for a single monthly schedule', async () => {
+    const template_lines = [
+      {
+        type: 'schedule',
+        name: 'Rent',
+        priority: 0,
+        directive: 'template',
+      } as const,
+    ];
+    mockSingleSchedule({
+      start: '2024-01-15',
+      amount: -10000,
+      frequency: 'monthly',
+    });
+
+    const result = await runScheduleForecast(
+      template_lines,
+      '2024-01-01',
+      0,
+      0,
+      0,
+      [],
+      defaultCategory,
+      defaultCurrency,
+    );
+
+    expect(result.to_budget).toBe(10000);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it('never projects a negative month-end balance across two schedules sharing a category', async () => {
+    const template_lines = [
+      {
+        type: 'schedule',
+        name: 'Monthly',
+        priority: 0,
+        directive: 'template',
+      } as const,
+      {
+        type: 'schedule',
+        name: 'Yearly',
+        priority: 0,
+        directive: 'template',
+      } as const,
+    ];
+    mockSchedulesByName({
+      Monthly: {
+        spec: { start: '2024-01-15', amount: -10000, frequency: 'monthly' },
+      },
+      Yearly: {
+        spec: { start: '2024-12-15', amount: -60000, frequency: 'yearly' },
+      },
+    });
+
+    const result = await runScheduleForecast(
+      template_lines,
+      '2024-01-01',
+      0,
+      0,
+      0,
+      [],
+      defaultCategory,
+      defaultCurrency,
+    );
+
+    // Re-derive the projection with the returned candidate to check the
+    // postcondition directly, rather than asserting against runSchedule.
+    const { t } = await createScheduleList(
+      template_lines as ScheduleTemplate[],
+      '2024-01-01',
+      defaultCategory,
+      defaultCurrency,
+    );
+    const outflow = await buildMonthlyOutflow(t, '2024-01-01', defaultCategory);
+    let runningBalance = 0;
+    let minBalance = Infinity;
+    for (let i = 0; i < 60; i++) {
+      runningBalance += result.to_budget - outflow[i];
+      minBalance = Math.min(minBalance, runningBalance);
+    }
+    expect(minBalance).toBeGreaterThanOrEqual(0);
+    // And it should be the *minimal* such contribution: one cent less
+    // must produce a negative month somewhere.
+    let runningBalanceMinusOne = 0;
+    let wentNegative = false;
+    for (let i = 0; i < 60; i++) {
+      runningBalanceMinusOne += result.to_budget - 1 - outflow[i];
+      if (runningBalanceMinusOne < 0) wentNegative = true;
+    }
+    expect(wentNegative).toBe(true);
+  });
+
+  it('covers a same-month-due schedule in full immediately rather than smoothing it away', async () => {
+    const template_lines = [
+      {
+        type: 'schedule',
+        name: 'DueNow',
+        priority: 0,
+        directive: 'template',
+      } as const,
+    ];
+    mockSingleSchedule({
+      start: '2024-01-15',
+      amount: -60000,
+      frequency: 'yearly',
+    });
+
+    const result = await runScheduleForecast(
+      template_lines,
+      '2024-01-01',
+      0,
+      0,
+      0,
+      [],
+      defaultCategory,
+      defaultCurrency,
+    );
+
+    expect(result.to_budget).toBe(60000);
+  });
+
+  it('budgets full-flag schedules on top of, and separate from, the forecast', async () => {
+    const template_lines = [
+      {
+        type: 'schedule',
+        name: 'Full',
+        full: true,
+        priority: 0,
+        directive: 'template',
+      } as const,
+      {
+        type: 'schedule',
+        name: 'Smooth',
+        priority: 0,
+        directive: 'template',
+      } as const,
+    ];
+    mockSchedulesByName({
+      Full: {
+        spec: { start: '2024-12-15', amount: -60000, frequency: 'yearly' },
+      },
+      Smooth: {
+        spec: { start: '2024-01-15', amount: -10000, frequency: 'monthly' },
+      },
+    });
+
+    const result = await runScheduleForecast(
+      template_lines,
+      '2024-01-01',
+      0,
+      0,
+      0,
+      [],
+      defaultCategory,
+      defaultCurrency,
+    );
+
+    // Full schedule isn't due this month, so its on-top contribution is 0;
+    // only the smooth monthly schedule contributes.
+    expect(result.to_budget).toBe(10000);
+    expect(result.perScheduleMonthly.get(template_lines[1])).toBe(10000);
+  });
+});
+
+describe('solveMonthlyContribution', () => {
+  it('finds the minimal whole-cent contribution for a single one-time bill', () => {
+    const monthlyOutflow = new Array(60).fill(0);
+    monthlyOutflow[30] = 60000; // one bill, due in month 30
+    const candidate = solveMonthlyContribution(0, monthlyOutflow);
+    // 60000 / 31 months = 1935.48 -> ceil to 1936; verify it actually
+    // covers month 30 and is the minimal such whole-cent amount.
+    expect(candidate * 31).toBeGreaterThanOrEqual(60000);
+    expect((candidate - 1) * 31).toBeLessThan(60000);
+  });
+
+  it('picks the early month with the larger threshold, not the late month with the larger raw balance', () => {
+    // Regression test for the weighting bug the closed form replaces
+    // (see the design spec's Iteration Algorithm > Derivation section).
+    // Month 0 needs 100/cent-month (weight 1); month 59 needs slightly
+    // less per-cent-month but the raw shortfall at any shared candidate
+    // is larger there purely because of the (i+1) weighting. The
+    // correct answer is governed by whichever month's *threshold*
+    // (need / (i+1)) is larger, not whichever month's raw balance is
+    // more negative — here that's month 0.
+    // Month 0's own outflow is 100 (threshold_0 = 100/1 = 100). Month
+    // 59's *cumulative* outflow needs to make threshold_59 = 149, i.e.
+    // cumsum_59 = 149 * 60 = 8940, with month 0's 100 already part of
+    // that cumulative sum.
+    const outflow = new Array(60).fill(0);
+    outflow[0] = 100;
+    outflow[59] = 8940 - 100;
+
+    const candidate = solveMonthlyContribution(0, outflow);
+    expect(candidate).toBe(149); // threshold_59, the true max — not threshold_0 (100)
+
+    let runningBalance = 0;
+    let minBalance = Infinity;
+    for (let i = 0; i < 60; i++) {
+      runningBalance += candidate - outflow[i];
+      minBalance = Math.min(minBalance, runningBalance);
+    }
+    expect(minBalance).toBeGreaterThanOrEqual(0);
   });
 });

--- a/packages/loot-core/src/server/budget/schedule-template.ts
+++ b/packages/loot-core/src/server/budget/schedule-template.ts
@@ -562,13 +562,31 @@ export async function runScheduleForecast(
 
   // Split the single smoothed candidate back out across the smooth
   // schedules that share this category, proportional to each schedule's
-  // own average monthly target (not the 60-month total outflow, which
-  // would understate every schedule's share by a factor of ~60).
-  const totalMonthlyTarget = smoothEntries.reduce((s, c) => s + c.target, 0);
+  // own monthly-equivalent contribution — the same normalization
+  // `runSchedule` already uses (getMonthlyBaseContribution divides a
+  // yearly/weekly/daily target down to a monthly-equivalent amount; using
+  // raw `entry.target` instead would treat a yearly schedule's full
+  // lump-sum as if it were a monthly amount, and would also understate
+  // every schedule's share relative to the 60-month total outflow, which
+  // is a different, larger quantity entirely).
+  const totalMonthlyWeight = smoothEntries.reduce(
+    (s, c) => s + getMonthlyBaseContribution(c),
+    0,
+  );
 
   for (const entry of smoothEntries) {
+    // When the smooth schedules sharing this category net to a zero total
+    // monthly-equivalent weight (e.g. two schedules with offsetting signs),
+    // dividing by zero would yield NaN or +/-Infinity — never valid for a
+    // money-typed map. Fall back to an even split across the entries,
+    // which is always finite.
     const share =
-      Math.round((entry.target / totalMonthlyTarget) * candidate) || 0;
+      totalMonthlyWeight === 0
+        ? Math.round(candidate / smoothEntries.length)
+        : Math.round(
+            (getMonthlyBaseContribution(entry) / totalMonthlyWeight) *
+              candidate,
+          ) || 0;
     perScheduleMonthly.set(
       entry.template,
       (perScheduleMonthly.get(entry.template) ?? 0) + share,

--- a/packages/loot-core/src/server/budget/schedule-template.ts
+++ b/packages/loot-core/src/server/budget/schedule-template.ts
@@ -1,15 +1,18 @@
 // @ts-strict-ignore
 
+import { aqlQuery } from '#server/aql';
 import * as db from '#server/db';
 import { collectFormulasFromActions } from '#server/rules/balanceOfFormula';
 import { getRuleForSchedule } from '#server/schedules/app';
 import { prefetchBalanceOfForTransaction } from '#server/transactions/transaction-rules';
 import type { Currency } from '#shared/currencies';
 import * as monthUtils from '#shared/months';
+import { q } from '#shared/query';
 import {
   extractScheduleConds,
   getDateWithSkippedWeekend,
   getNextDate,
+  getOccurrencesBetween,
 } from '#shared/schedules';
 import { amountToInteger } from '#shared/util';
 import type { CategoryEntity, TransactionEntity } from '#types/models';
@@ -218,6 +221,57 @@ export async function createScheduleList(
     }
   }
   return { t: t.filter(c => c.completed === 0), errors };
+}
+
+const FORECAST_MONTHS = 60;
+
+export async function buildMonthlyOutflow(
+  smoothEntries: ScheduleTemplateTarget[],
+  current_month: string,
+  category: CategoryEntity,
+): Promise<number[]> {
+  const monthlyOutflow = new Array(FORECAST_MONTHS).fill(0);
+  const windowEnd = `${monthUtils.addMonths(current_month, FORECAST_MONTHS)}-01`;
+
+  for (const entry of smoothEntries) {
+    const occurrences = getOccurrencesBetween(
+      entry.dateConditions,
+      current_month,
+      windowEnd,
+    );
+    for (const occurrenceDate of occurrences) {
+      const monthIndex = monthUtils.differenceInCalendarMonths(
+        occurrenceDate,
+        current_month,
+      );
+      if (monthIndex >= 0 && monthIndex < FORECAST_MONTHS) {
+        monthlyOutflow[monthIndex] += entry.target;
+      }
+    }
+  }
+
+  const { data: unlinkedTransactions } = await aqlQuery(
+    q('transactions')
+      .filter({
+        category: category.id,
+        schedule: null,
+        date: { $gte: current_month, $lt: windowEnd },
+      })
+      .select(['amount', 'date']),
+  );
+
+  const sign = category.is_income ? 1 : -1;
+  for (const transaction of unlinkedTransactions) {
+    const monthIndex = monthUtils.differenceInCalendarMonths(
+      transaction.date,
+      current_month,
+    );
+    if (monthIndex >= 0 && monthIndex < FORECAST_MONTHS) {
+      monthlyOutflow[monthIndex] += sign * transaction.amount;
+    }
+  }
+
+  return monthlyOutflow;
 }
 
 function getPayMonthOfTotal(t: ScheduleTemplateTarget[]) {

--- a/packages/loot-core/src/server/budget/schedule-template.ts
+++ b/packages/loot-core/src/server/budget/schedule-template.ts
@@ -246,7 +246,7 @@ export async function buildMonthlyOutflow(
   for (const entry of smoothEntries) {
     const occurrences = getOccurrencesBetween(
       entry.dateConditions,
-      current_month,
+      windowStart,
       windowEnd,
     );
     for (const occurrenceDate of occurrences) {

--- a/packages/loot-core/src/server/budget/schedule-template.ts
+++ b/packages/loot-core/src/server/budget/schedule-template.ts
@@ -489,10 +489,9 @@ export async function runSchedule(
 //   balance[i] = startingBalance + (i + 1) * candidate - cumsum[i]
 // so balance[i] >= 0 for all i  <=>  candidate >= threshold_i for all i,
 // where threshold_i = (cumsum[i] - startingBalance) / (i + 1) does not
-// depend on candidate at all. The answer is simply max_i(threshold_i) —
-// see the design spec's Iteration Algorithm section for the derivation
-// and why an earlier guess-and-correct version of this function was
-// wrong (it operated on each month's raw balance, which is the
+// depend on candidate at all. The answer is simply max_i(threshold_i).
+// An earlier guess-and-correct version of this function was wrong: it
+// operated on each month's raw balance, which is the
 // threshold gap scaled by (i + 1) — a late month's small gap can
 // produce a larger raw balance than an early month's large gap, so
 // picking the extremum of raw balance does not reliably find

--- a/packages/loot-core/src/server/budget/schedule-template.ts
+++ b/packages/loot-core/src/server/budget/schedule-template.ts
@@ -467,3 +467,117 @@ export async function runSchedule(
   }
   return { to_budget, errors, remainder, perScheduleMonthly };
 }
+
+// Pure, synchronous: given a starting balance and a 60-length projected
+// monthly-outflow array (an entry can be negative — an unlinked inflow
+// transaction offsets that month's need), returns the minimal whole-cent
+// monthly contribution that keeps the projected balance non-negative
+// across the whole window.
+//
+// Each month i's balance is affine in `candidate`:
+//   balance[i] = startingBalance + (i + 1) * candidate - cumsum[i]
+// so balance[i] >= 0 for all i  <=>  candidate >= threshold_i for all i,
+// where threshold_i = (cumsum[i] - startingBalance) / (i + 1) does not
+// depend on candidate at all. The answer is simply max_i(threshold_i) —
+// see the design spec's Iteration Algorithm section for the derivation
+// and why an earlier guess-and-correct version of this function was
+// wrong (it operated on each month's raw balance, which is the
+// threshold gap scaled by (i + 1) — a late month's small gap can
+// produce a larger raw balance than an early month's large gap, so
+// picking the extremum of raw balance does not reliably find
+// max_i(threshold_i)).
+export function solveMonthlyContribution(
+  startingBalance: number,
+  monthlyOutflow: number[],
+): number {
+  let candidate = 0;
+  let cumsum = 0;
+
+  for (let i = 0; i < monthlyOutflow.length; i++) {
+    cumsum += monthlyOutflow[i];
+    const threshold = Math.ceil((cumsum - startingBalance) / (i + 1));
+    candidate = Math.max(candidate, threshold);
+  }
+
+  return candidate;
+}
+
+export async function runScheduleForecast(
+  template_lines: Template[],
+  current_month: string,
+  balance: number,
+  last_month_balance: number,
+  to_budget: number,
+  errors: string[],
+  category: CategoryEntity,
+  currency: Currency,
+): Promise<{
+  to_budget: number;
+  errors: string[];
+  perScheduleMonthly: Map<ScheduleTemplate, number>;
+}> {
+  const scheduleTemplates = template_lines.filter(t => t.type === 'schedule');
+  const t = await createScheduleList(
+    scheduleTemplates,
+    current_month,
+    category,
+    currency,
+  );
+  errors = errors.concat(t.errors);
+
+  const fullEntries = t.t.filter(c => c.template.full);
+  const smoothEntries = t.t.filter(c => !c.template.full);
+
+  const perScheduleMonthly = new Map<ScheduleTemplate, number>();
+  // Full-flag schedules keep today's exact runSchedule behavior: they're
+  // budgeted in full only when due this month, never smoothed and never
+  // budgeted ahead of time.
+  const fullContribution = fullEntries.reduce((sum, c) => {
+    const contribution = c.num_months === 0 ? c.target : 0;
+    perScheduleMonthly.set(
+      c.template,
+      (perScheduleMonthly.get(c.template) ?? 0) + contribution,
+    );
+    return sum + contribution;
+  }, 0);
+
+  if (smoothEntries.length === 0) {
+    return {
+      to_budget: to_budget + fullContribution,
+      errors,
+      perScheduleMonthly,
+    };
+  }
+
+  const monthlyOutflow = await buildMonthlyOutflow(
+    smoothEntries,
+    current_month,
+    category,
+  );
+  const forecastStartingBalance = balance - fullContribution;
+  const candidate = solveMonthlyContribution(
+    forecastStartingBalance,
+    monthlyOutflow,
+  );
+
+  // Split the single smoothed candidate back out across the smooth
+  // schedules that share this category, proportional to each schedule's
+  // own average monthly target (not the 60-month total outflow, which
+  // would understate every schedule's share by a factor of ~60).
+  const totalMonthlyTarget = smoothEntries.reduce((s, c) => s + c.target, 0);
+
+  for (const entry of smoothEntries) {
+    const share =
+      Math.round((entry.target / totalMonthlyTarget) * candidate) || 0;
+    perScheduleMonthly.set(
+      entry.template,
+      (perScheduleMonthly.get(entry.template) ?? 0) + share,
+    );
+  }
+
+  return {
+    to_budget: to_budget + fullContribution + candidate,
+    errors,
+    perScheduleMonthly,
+  };
+}

--- a/packages/loot-core/src/server/budget/schedule-template.ts
+++ b/packages/loot-core/src/server/budget/schedule-template.ts
@@ -24,6 +24,14 @@ type ScheduleTemplateTarget = {
   template: ScheduleTemplate;
   name: string;
   target: number;
+  // The un-aggregated amount of a single occurrence of this schedule,
+  // computed before `target` is summed across every occurrence landing
+  // in the schedule's monthly-equivalent aggregation window below. Unlike
+  // `target` (whose value is a monthly-equivalent aggregate that
+  // `runSchedule`/`getMonthlyBaseContribution` depend on), this is the
+  // right value to multiply by an occurrence count elsewhere (e.g.
+  // `buildMonthlyOutflow`, which buckets one entry per occurrence date).
+  perOccurrenceAmount: number;
   next_date_string: string;
   target_interval: number;
   target_frequency: string | undefined;
@@ -154,6 +162,7 @@ export async function createScheduleList(
       t.push({
         template,
         target,
+        perOccurrenceAmount: target,
         next_date_string,
         target_interval,
         target_frequency,
@@ -231,6 +240,7 @@ export async function buildMonthlyOutflow(
   category: CategoryEntity,
 ): Promise<number[]> {
   const monthlyOutflow = new Array(FORECAST_MONTHS).fill(0);
+  const windowStart = monthUtils.firstDayOfMonth(current_month);
   const windowEnd = `${monthUtils.addMonths(current_month, FORECAST_MONTHS)}-01`;
 
   for (const entry of smoothEntries) {
@@ -245,7 +255,7 @@ export async function buildMonthlyOutflow(
         current_month,
       );
       if (monthIndex >= 0 && monthIndex < FORECAST_MONTHS) {
-        monthlyOutflow[monthIndex] += entry.target;
+        monthlyOutflow[monthIndex] += entry.perOccurrenceAmount;
       }
     }
   }
@@ -255,7 +265,8 @@ export async function buildMonthlyOutflow(
       .filter({
         category: category.id,
         schedule: null,
-        date: { $gte: current_month, $lt: windowEnd },
+        'account.offbudget': false,
+        date: { $gte: windowStart, $lt: windowEnd },
       })
       .select(['amount', 'date']),
   );

--- a/packages/loot-core/src/server/budget/schedule-template.ts
+++ b/packages/loot-core/src/server/budget/schedule-template.ts
@@ -28,9 +28,10 @@ type ScheduleTemplateTarget = {
   completed: number;
   full: boolean;
   repeat: boolean;
+  dateConditions: ReturnType<typeof extractScheduleConds>['date'];
 };
 
-async function createScheduleList(
+export async function createScheduleList(
   templates: ScheduleTemplate[],
   current_month: string,
   category: CategoryEntity,
@@ -159,6 +160,7 @@ async function createScheduleList(
         full: template.full === null ? false : template.full,
         repeat: isRepeating,
         name: displayName,
+        dateConditions,
       });
       if (!completed) {
         if (isRepeating) {

--- a/packages/loot-core/src/shared/schedules.test.ts
+++ b/packages/loot-core/src/shared/schedules.test.ts
@@ -839,5 +839,67 @@ describe('schedules', () => {
 
       expect(result).toEqual(['2020-12-25']);
     });
+
+    it('includes a raw occurrence landing before startDay when the weekend adjustment shifts it forward into range', () => {
+      // Weekly on Saturday, skipWeekend + weekendSolveMode: 'after'.
+      // Raw occurrences: 12/5, 12/12, 12/19, 12/26, ...
+      // The raw occurrence on 2020-12-05 sits 2 days before startDay, so a
+      // naive raw-range query would drop it. But its weekend-adjusted date
+      // (2020-12-07, the Monday after) lands exactly on startDay and must
+      // be included.
+      const dateCond = {
+        op: 'isapprox' as const,
+        field: 'date' as const,
+        value: {
+          start: '2020-12-05',
+          interval: 1,
+          frequency: 'weekly' as const,
+          patterns: [],
+          skipWeekend: true,
+          weekendSolveMode: 'after' as const,
+          endMode: 'never' as const,
+          endOccurrences: 1,
+          endDate: '2099-01-01',
+        },
+      };
+
+      const result = getOccurrencesBetween(
+        dateCond,
+        '2020-12-07',
+        '2020-12-12',
+      );
+
+      expect(result).toEqual(['2020-12-07']);
+    });
+
+    it('excludes a raw occurrence landing before endDay when the weekend adjustment shifts it forward out of range', () => {
+      // Same schedule as above. The raw occurrence on 2020-12-12 sits
+      // before endDay, so a naive raw-range query would keep it. But its
+      // weekend-adjusted date (2020-12-14, the Monday after) lands exactly
+      // on the exclusive endDay and must be excluded.
+      const dateCond = {
+        op: 'isapprox' as const,
+        field: 'date' as const,
+        value: {
+          start: '2020-12-05',
+          interval: 1,
+          frequency: 'weekly' as const,
+          patterns: [],
+          skipWeekend: true,
+          weekendSolveMode: 'after' as const,
+          endMode: 'never' as const,
+          endOccurrences: 1,
+          endDate: '2099-01-01',
+        },
+      };
+
+      const result = getOccurrencesBetween(
+        dateCond,
+        '2020-12-05',
+        '2020-12-14',
+      );
+
+      expect(result).toEqual(['2020-12-07']);
+    });
   });
 });

--- a/packages/loot-core/src/shared/schedules.test.ts
+++ b/packages/loot-core/src/shared/schedules.test.ts
@@ -8,6 +8,7 @@ import {
   getHasTransactionsQuery,
   getNextDate,
   getNextDateAfter,
+  getOccurrencesBetween,
   getScheduleOccurrenceMatchStartDate,
   getStatus,
   getUpcomingDays,
@@ -640,6 +641,109 @@ describe('schedules', () => {
       expect(isCustomUpcomingLength('2-week')).toBe(true);
       expect(isCustomUpcomingLength(null)).toBe(false);
       expect(isCustomUpcomingLength(undefined)).toBe(false);
+    });
+  });
+
+  describe('getOccurrencesBetween', () => {
+    it('returns every monthly occurrence within the range', () => {
+      const dateCond = {
+        op: 'is' as const,
+        field: 'date' as const,
+        value: {
+          start: '2024-01-15',
+          interval: 1,
+          frequency: 'monthly' as const,
+          patterns: [],
+          skipWeekend: false,
+          weekendSolveMode: 'before' as const,
+          endMode: 'never' as const,
+          endOccurrences: 1,
+          endDate: '2099-01-01',
+        },
+      };
+      const result = getOccurrencesBetween(
+        dateCond,
+        '2024-01-01',
+        '2024-04-01',
+      );
+      expect(result).toEqual(['2024-01-15', '2024-02-15', '2024-03-15']);
+    });
+
+    it('returns an empty array when the single non-repeating date is outside the range', () => {
+      const dateCond = {
+        op: 'is' as const,
+        field: 'date' as const,
+        value: '2023-06-01',
+      };
+      expect(
+        getOccurrencesBetween(dateCond, '2024-01-01', '2024-04-01'),
+      ).toEqual([]);
+    });
+
+    it('returns the single date when a non-repeating date is inside the range', () => {
+      const dateCond = {
+        op: 'is' as const,
+        field: 'date' as const,
+        value: '2024-02-01',
+      };
+      expect(
+        getOccurrencesBetween(dateCond, '2024-01-01', '2024-04-01'),
+      ).toEqual(['2024-02-01']);
+    });
+
+    it('excludes an occurrence that falls exactly on the exclusive endDay', () => {
+      const dateCond = {
+        op: 'is' as const,
+        field: 'date' as const,
+        value: {
+          start: '2024-01-15',
+          interval: 1,
+          frequency: 'monthly' as const,
+          patterns: [],
+          skipWeekend: false,
+          weekendSolveMode: 'before' as const,
+          endMode: 'never' as const,
+          endOccurrences: 1,
+          endDate: '2099-01-01',
+        },
+      };
+      // The next occurrence after 2024-01-15 is 2024-02-15, which is used
+      // as the (exclusive) endDay here, so it should not be included.
+      const result = getOccurrencesBetween(
+        dateCond,
+        '2024-01-01',
+        '2024-02-15',
+      );
+      expect(result).toEqual(['2024-01-15']);
+    });
+
+    it('returns an empty array without hanging when a recurring schedule ended before the range', () => {
+      const dateCond = {
+        op: 'isapprox' as const,
+        field: 'date' as const,
+        value: {
+          start: '2016-01-25',
+          interval: 1,
+          frequency: 'monthly' as const,
+          patterns: [],
+          skipWeekend: false,
+          weekendSolveMode: 'before' as const,
+          endMode: 'on_date' as const,
+          endOccurrences: 1,
+          endDate: '2016-08-25',
+        },
+      };
+      // getNextDate falls back to the schedule's last-ever occurrence
+      // (2016-08-25) when asked for the next occurrence after the schedule
+      // has ended. getOccurrencesBetween must recognize that stale fallback
+      // date is behind the search cursor and stop, rather than looping
+      // forever re-requesting the same date.
+      const result = getOccurrencesBetween(
+        dateCond,
+        '2016-08-26',
+        '2026-01-01',
+      );
+      expect(result).toEqual([]);
     });
   });
 });

--- a/packages/loot-core/src/shared/schedules.test.ts
+++ b/packages/loot-core/src/shared/schedules.test.ts
@@ -777,5 +777,67 @@ describe('schedules', () => {
 
       expect(result).toEqual(['2020-12-11', '2020-12-18', '2020-12-25']);
     });
+
+    it('includes a raw occurrence landing exactly on the exclusive endDay when the weekend adjustment shifts it backward into range', () => {
+      // Weekly on Saturday, skipWeekend + weekendSolveMode: 'before'.
+      // Raw occurrences: 12/5, 12/12, 12/19, 12/26, ...
+      // The raw occurrence on 2020-12-26 sits exactly on the (exclusive)
+      // endDay, so a naive raw-range query would drop it. But its
+      // weekend-adjusted date (2020-12-25, the Friday before) lands inside
+      // [startDay, endDay) and must be included.
+      const dateCond = {
+        op: 'isapprox' as const,
+        field: 'date' as const,
+        value: {
+          start: '2020-12-05',
+          interval: 1,
+          frequency: 'weekly' as const,
+          patterns: [],
+          skipWeekend: true,
+          weekendSolveMode: 'before' as const,
+          endMode: 'never' as const,
+          endOccurrences: 1,
+          endDate: '2099-01-01',
+        },
+      };
+
+      const result = getOccurrencesBetween(
+        dateCond,
+        '2020-12-20',
+        '2020-12-26',
+      );
+
+      expect(result).toEqual(['2020-12-25']);
+    });
+
+    it('excludes a raw occurrence landing exactly on startDay when the weekend adjustment shifts it backward out of range', () => {
+      // Same schedule as above. The raw occurrence on 2020-12-19 sits
+      // exactly on startDay, so a naive raw-range query would keep it. But
+      // its weekend-adjusted date (2020-12-18, the Friday before) lands
+      // before startDay and must be excluded.
+      const dateCond = {
+        op: 'isapprox' as const,
+        field: 'date' as const,
+        value: {
+          start: '2020-12-05',
+          interval: 1,
+          frequency: 'weekly' as const,
+          patterns: [],
+          skipWeekend: true,
+          weekendSolveMode: 'before' as const,
+          endMode: 'never' as const,
+          endOccurrences: 1,
+          endDate: '2099-01-01',
+        },
+      };
+
+      const result = getOccurrencesBetween(
+        dateCond,
+        '2020-12-19',
+        '2020-12-26',
+      );
+
+      expect(result).toEqual(['2020-12-25']);
+    });
   });
 });

--- a/packages/loot-core/src/shared/schedules.test.ts
+++ b/packages/loot-core/src/shared/schedules.test.ts
@@ -745,5 +745,37 @@ describe('schedules', () => {
       );
       expect(result).toEqual([]);
     });
+
+    it('does not truncate occurrences when weekendSolveMode "before" shifts a date behind the search cursor', () => {
+      // Weekly on Saturday, skipWeekend + weekendSolveMode: 'before' means
+      // every occurrence is reported on the Friday before it. Querying with
+      // startDay set to a raw Saturday occurrence means getNextDate's
+      // adjusted result (the Friday before) lands *behind* the search
+      // cursor even though the schedule hasn't ended and more occurrences
+      // remain — this must not be mistaken for "the schedule ended".
+      const dateCond = {
+        op: 'isapprox' as const,
+        field: 'date' as const,
+        value: {
+          start: '2020-12-05', // a Saturday
+          interval: 1,
+          frequency: 'weekly' as const,
+          patterns: [],
+          skipWeekend: true,
+          weekendSolveMode: 'before' as const,
+          endMode: 'never' as const,
+          endOccurrences: 1,
+          endDate: '2099-01-01',
+        },
+      };
+
+      const result = getOccurrencesBetween(
+        dateCond,
+        '2020-12-05',
+        '2020-12-26',
+      );
+
+      expect(result).toEqual(['2020-12-11', '2020-12-18', '2020-12-25']);
+    });
   });
 });

--- a/packages/loot-core/src/shared/schedules.ts
+++ b/packages/loot-core/src/shared/schedules.ts
@@ -419,6 +419,43 @@ export function scheduleIsRecurring(dateCond: Condition | null) {
   return value.type === 'recur';
 }
 
+export function getOccurrencesBetween(
+  dateCond,
+  startDay: string,
+  endDay: string,
+): string[] {
+  const isRecurring = scheduleIsRecurring(dateCond);
+  const rangeStart = d.startOfDay(monthUtils.parseDate(startDay));
+  const rangeEnd = d.startOfDay(monthUtils.parseDate(endDay));
+
+  if (!isRecurring) {
+    const singleDate =
+      typeof dateCond.value === 'string' ? dateCond.value : null;
+    if (singleDate && singleDate >= startDay && singleDate < endDay) {
+      return [singleDate];
+    }
+    return [];
+  }
+
+  const dates: string[] = [];
+  let day = rangeStart;
+  while (day < rangeEnd) {
+    const nextDate = getNextDate(dateCond, day);
+    if (nextDate === null) break;
+    const nextDateDay = d.startOfDay(monthUtils.parseDate(nextDate));
+    // getNextDate falls back to the schedule's last-ever occurrence when it
+    // finds no occurrence at or after `day` (e.g. a recurring schedule whose
+    // end date is before `day`). That fallback date isn't guaranteed to be
+    // at or after `day`, so treat it as "no more occurrences" rather than
+    // looping forever trying to advance past a date we've already passed.
+    if (nextDateDay < day) break;
+    if (nextDateDay >= rangeEnd) break;
+    if (nextDate >= startDay) dates.push(nextDate);
+    day = d.startOfDay(monthUtils.parseDate(monthUtils.addDays(nextDate, 1)));
+  }
+  return dates;
+}
+
 export type ScheduleStatusType = ReturnType<typeof getStatus>;
 export type ScheduleStatuses = Map<ScheduleEntity['id'], ScheduleStatusType>;
 
@@ -463,32 +500,19 @@ export function computeSchedulePreviewTransactions(
       const isRecurring = scheduleIsRecurring(dateConditions);
 
       const dates = [schedule.next_date];
-      let day = d.startOfDay(monthUtils.parseDate(schedule.next_date));
       if (isRecurring) {
-        while (day <= upcomingPeriodEnd) {
-          const nextDate = getNextDate(dateConditions, day);
-
-          if (nextDate === null) {
-            break;
-          }
-
-          if (
-            d.startOfDay(monthUtils.parseDate(nextDate)) > upcomingPeriodEnd
-          ) {
-            break;
-          }
-
-          if (dates.includes(nextDate)) {
-            day = d.startOfDay(
-              monthUtils.parseDate(monthUtils.addDays(day, 1)),
-            );
-            continue;
-          }
-
-          dates.push(nextDate);
-          day = d.startOfDay(
-            monthUtils.parseDate(monthUtils.addDays(nextDate, 1)),
-          );
+        const day = d.startOfDay(monthUtils.parseDate(schedule.next_date));
+        // getOccurrencesBetween's range is [startDay, endDay) — endDay
+        // exclusive — but upcomingPeriodEnd is meant to be an inclusive
+        // boundary (an occurrence landing exactly on it should be included),
+        // so pass the day after it.
+        const occurrences = getOccurrencesBetween(
+          dateConditions,
+          monthUtils.dayFromDate(day),
+          monthUtils.dayFromDate(monthUtils.addDays(upcomingPeriodEnd, 1)),
+        );
+        for (const occurrence of occurrences) {
+          if (!dates.includes(occurrence)) dates.push(occurrence);
         }
       }
 

--- a/packages/loot-core/src/shared/schedules.ts
+++ b/packages/loot-core/src/shared/schedules.ts
@@ -440,18 +440,31 @@ export function getOccurrencesBetween(
   const dates: string[] = [];
   let day = rangeStart;
   while (day < rangeEnd) {
-    const nextDate = getNextDate(dateCond, day);
-    if (nextDate === null) break;
-    const nextDateDay = d.startOfDay(monthUtils.parseDate(nextDate));
+    const dayStr = monthUtils.dayFromDate(day);
+
+    // Probe the raw, unadjusted occurrence first (mirrors getNextDateAfter).
     // getNextDate falls back to the schedule's last-ever occurrence when it
-    // finds no occurrence at or after `day` (e.g. a recurring schedule whose
-    // end date is before `day`). That fallback date isn't guaranteed to be
-    // at or after `day`, so treat it as "no more occurrences" rather than
-    // looping forever trying to advance past a date we've already passed.
-    if (nextDateDay < day) break;
-    if (nextDateDay >= rangeEnd) break;
-    if (nextDate >= startDay) dates.push(nextDate);
-    day = d.startOfDay(monthUtils.parseDate(monthUtils.addDays(nextDate, 1)));
+    // finds nothing at or after `day` (e.g. a recurring schedule whose end
+    // date is before `day`); that fallback can land before `day`, which is
+    // how we distinguish "the schedule has truly ended" from "there's an
+    // occurrence here, but skipWeekend adjustment moved it backward" — the
+    // weekend-adjusted date alone can't tell the two apart, since a
+    // `weekendSolveMode: 'before'` schedule legitimately produces adjusted
+    // dates that land behind `day` even while occurrences remain.
+    const rawDate = getNextDate(dateCond, day, true);
+    if (rawDate === null || rawDate < dayStr) break;
+
+    const adjustedDate = getNextDate(dateCond, day);
+    if (adjustedDate !== null) {
+      const adjustedDay = d.startOfDay(monthUtils.parseDate(adjustedDate));
+      if (adjustedDay >= rangeEnd) break;
+      if (adjustedDate >= startDay) dates.push(adjustedDate);
+    }
+
+    // Advance past the raw occurrence (not the possibly weekend-shifted
+    // adjusted one) so a `before` adjustment landing behind `day` doesn't
+    // stall the cursor.
+    day = d.startOfDay(monthUtils.parseDate(monthUtils.addDays(rawDate, 1)));
   }
   return dates;
 }

--- a/packages/loot-core/src/shared/schedules.ts
+++ b/packages/loot-core/src/shared/schedules.ts
@@ -419,10 +419,22 @@ export function scheduleIsRecurring(dateCond: Condition | null) {
   return value.type === 'recur';
 }
 
-// Weekend adjustment (getDateWithSkippedWeekend) shifts a raw occurrence by
-// at most 2 days (Saturday -> Monday for 'after', Sunday -> Friday for
-// 'before'). Pad the raw-date query window by more than that so no adjusted
-// occurrence near the edges of [startDay, endDay) can be missed.
+// Two independent effects can put a raw occurrence "in reach" of
+// [startDay, endDay) even though its raw timestamp falls outside the exact,
+// unpadded window — so the raw-date query below must be padded on both ends
+// to compensate for both:
+//   1. Weekend adjustment (getDateWithSkippedWeekend) shifts a raw
+//      occurrence by at most 2 days (Saturday -> Monday for 'after',
+//      Sunday -> Friday for 'before').
+//   2. recurConfigToRSchedule hardcodes `byHourOfDay: [12]`, so every raw
+//      occurrence is timestamped at *noon*, while queryStart/queryEnd below
+//      are computed with `d.startOfDay` (*midnight*). A raw occurrence
+//      dated exactly on endDay therefore has a timestamp (noon) that is
+//      *after* an unpadded, midnight-aligned queryEnd, and would be missed
+//      by the range query even before any weekend shift is considered.
+// Combined, the minimum integer number of days needed is 3 (2 days of
+// weekend shift, plus rounding the extra half-day from the noon offset up
+// to a full day) — pad by exactly that much.
 const WEEKEND_SHIFT_PAD_DAYS = 3;
 
 export function getOccurrencesBetween(

--- a/packages/loot-core/src/shared/schedules.ts
+++ b/packages/loot-core/src/shared/schedules.ts
@@ -419,16 +419,21 @@ export function scheduleIsRecurring(dateCond: Condition | null) {
   return value.type === 'recur';
 }
 
+// Weekend adjustment (getDateWithSkippedWeekend) shifts a raw occurrence by
+// at most 2 days (Saturday -> Monday for 'after', Sunday -> Friday for
+// 'before'). Pad the raw-date query window by more than that so no adjusted
+// occurrence near the edges of [startDay, endDay) can be missed.
+const WEEKEND_SHIFT_PAD_DAYS = 3;
+
 export function getOccurrencesBetween(
   dateCond,
   startDay: string,
   endDay: string,
 ): string[] {
-  const isRecurring = scheduleIsRecurring(dateCond);
-  const rangeStart = d.startOfDay(monthUtils.parseDate(startDay));
-  const rangeEnd = d.startOfDay(monthUtils.parseDate(endDay));
+  const cond = new Condition(dateCond.op, 'date', dateCond.value, null);
+  const value = cond.getValue();
 
-  if (!isRecurring) {
+  if (value.type !== 'recur') {
     const singleDate =
       typeof dateCond.value === 'string' ? dateCond.value : null;
     if (singleDate && singleDate >= startDay && singleDate < endDay) {
@@ -437,34 +442,40 @@ export function getOccurrencesBetween(
     return [];
   }
 
+  // Build the recurrence schedule once — parsing a recurrence rule into an
+  // RSchedule is the dominant cost for sub-monthly schedules over a
+  // multi-year window when done per-occurrence (see task-6-brief.md for the
+  // measured numbers). Pull the whole padded range in a single pass instead
+  // of repeatedly probing one occurrence at a time.
+  const schedule = value.schedule;
+
+  const queryStart = d.startOfDay(
+    monthUtils.parseDate(monthUtils.addDays(startDay, -WEEKEND_SHIFT_PAD_DAYS)),
+  );
+  const queryEnd = d.startOfDay(
+    monthUtils.parseDate(monthUtils.addDays(endDay, WEEKEND_SHIFT_PAD_DAYS)),
+  );
+
+  const rawDates = schedule
+    .occurrences({ start: queryStart, end: queryEnd })
+    .toArray()
+    .map(occurrence => monthUtils.dayFromDate(occurrence.date));
+
+  if (!schedule.data.skipWeekend) {
+    return rawDates.filter(dt => dt >= startDay && dt < endDay);
+  }
+
   const dates: string[] = [];
-  let day = rangeStart;
-  while (day < rangeEnd) {
-    const dayStr = monthUtils.dayFromDate(day);
-
-    // Probe the raw, unadjusted occurrence first (mirrors getNextDateAfter).
-    // getNextDate falls back to the schedule's last-ever occurrence when it
-    // finds nothing at or after `day` (e.g. a recurring schedule whose end
-    // date is before `day`); that fallback can land before `day`, which is
-    // how we distinguish "the schedule has truly ended" from "there's an
-    // occurrence here, but skipWeekend adjustment moved it backward" — the
-    // weekend-adjusted date alone can't tell the two apart, since a
-    // `weekendSolveMode: 'before'` schedule legitimately produces adjusted
-    // dates that land behind `day` even while occurrences remain.
-    const rawDate = getNextDate(dateCond, day, true);
-    if (rawDate === null || rawDate < dayStr) break;
-
-    const adjustedDate = getNextDate(dateCond, day);
-    if (adjustedDate !== null) {
-      const adjustedDay = d.startOfDay(monthUtils.parseDate(adjustedDate));
-      if (adjustedDay >= rangeEnd) break;
-      if (adjustedDate >= startDay) dates.push(adjustedDate);
+  for (const rawDate of rawDates) {
+    const adjustedDate = monthUtils.dayFromDate(
+      getDateWithSkippedWeekend(
+        monthUtils.parseDate(rawDate),
+        schedule.data.weekendSolve,
+      ),
+    );
+    if (adjustedDate >= startDay && adjustedDate < endDay) {
+      dates.push(adjustedDate);
     }
-
-    // Advance past the raw occurrence (not the possibly weekend-shifted
-    // adjusted one) so a `before` adjustment landing behind `day` doesn't
-    // stall the cursor.
-    day = d.startOfDay(monthUtils.parseDate(monthUtils.addDays(rawDate, 1)));
   }
   return dates;
 }

--- a/upcoming-release-notes/schedule-forecast-smoothing.md
+++ b/upcoming-release-notes/schedule-forecast-smoothing.md
@@ -1,0 +1,6 @@
+---
+category: Features
+authors: [MikeBishop]
+---
+
+Budget schedules using a smarter forecast that avoids holding more money than upcoming bills actually need


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

The current algorithm for deciding how much to budget based on a schedule leaves excess money sitting in the category for two reasons:
- The existing category balance isn't being considered to spend down excess
- The cash flow interaction between multiple payments

This PR replaces the monthly-amount computation with a forecast of expenses from the combined schedules and derives the minimum monthly contribution needed to cover all the expected outflows. Worked examples are below.

<!-- If AI tools wrote a significant part of this change, please disclose it here and name the tool you used. See https://actualbudget.org/docs/contributing/ai-usage-policy -->

The code and tests were AI-generated: Claude, using the superpowers skill-set. It was based on my initial algorithm, I have reviewed the code, and my adjustments have been incorporated.

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

There are previous issues in this space -- this directly fixes #6513 and likely #6644. (It could potentially also be used by the requesters of #6030 and #3820 if their templates were reframed as schedules.)

#8824 is a targeted fix within the original algorithm for certain cases; this happens to produce the same result by a different path.

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

~~Currently gated behind a feature flag. To enable:~~

~~1. Flip the flag (packages/loot-core/src/server/budget/category-template-context.ts:48): `export const scheduleForecastConfig = { enabled: true };`~~

2. Run it from the worktree:
```
corepack yarn start          # web, port 3001
# or: corepack yarn start:desktop
```

Looking for maintainer guidance on whether this should be an opt-in subfeature (checkbox in Experimental), an option on the category, or fully replace the existing function.

## Checklist

- [ ] Release notes added (see link above)
- [X] No obvious regressions in affected areas
- [X] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

## Details (AI-generated, edited by human)

New opt-in algorithm (`runScheduleForecast`, gated off by default via `scheduleForecastConfig.enabled = false` in `category-template-context.ts` — `runSchedule` is untouched and remains the default) projects a category's schedule outflows 60 months forward and solves directly for the minimum monthly contribution that never lets the projected balance go negative, instead of summing each schedule's own independent monthly-equivalent.

### Examples

Consider a category with two yearly schedules ($1,200 due March, $600 due September), starting from January.

*(Full scripts + output available on request — omitted here for length. Produced via throwaway test cases added to `schedule-template.test.ts`, run, and reverted.)*

#### Overfunded Category

Suppose the category has $5,000 already banked. Today's algorithm asks for **$150.00/month forever**. Over the next 30 months, monthly contribution stays flat at $150/month indefinitely while the balance sawtooths $4,250–$5,300 forever. That $4,250 will never be used and doesn't need to be in the category to service this schedule.

The forecast recognizes the $5,000 already covers years of both bills and asks for **$70.18/month** — 53% less, both pay every bill on time. Over time, this rises gradually as the surplus is consumed — $70.18 → $83.16 → $96.72 → $107.05 by month 29 — visibly converging back toward the $150 steady rate.

#### Shortfall

Starting from an empty category, the old algorithm wants $466.67/month (each schedule's own catch-up pace, summed independently). This proposal takes $400.00/month, the true joint minimum, through March. Beginning in April, it drops to the $150/month steady-state.

### Performance

This is the trade-off. The new algorithm does genuinely more work than `runSchedule`'s cheap paths, and my first attempt was catastrophic: root-cause profiling found (and fixed, ee30dd947/9df84c8dd) that daily/weekly schedules were up to 101x slower than `runSchedule` before the fix.

This version is still slower, but more tolerably so:

| scenario | old (`runSchedule`) | new (`runScheduleForecast`) | ratio |
|---|---|---|---|
| single monthly schedule | 0.80ms | 3.30ms | 4.1x |
| single yearly schedule | 0.60ms | 0.95ms | 1.6x |
| single weekly (interval 1) | 1.21ms | 8.50ms | 7.0x |
| single daily (interval 1) | 3.54ms | 32.00ms | 9.0x |
| mix: 3 monthly + 2 weekly + 1 daily | 6.84ms | 53.76ms | 7.9x |

This runs in the backend worker (off the render thread), triggered only by an explicit "Apply Budget Template" action per month, not on every render — so the cost is "the apply-action takes longer," not a UI freeze. Still slower than today's algorithm across the board, but the pathological multipliers (47-101x) are gone; remaining cost scales with schedule count and sub-monthly frequency.

All figures reproducible via temporary test additions to `schedule-template.test.ts`/`schedules.test.ts`, run, then reverted.

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 42 | 13.79 MB → 13.79 MB (+229 B) | +0.00%
loot-core | 1 | 4.65 MB → 4.65 MB (+4.46 kB) | +0.09%
api | 2 | 3.86 MB → 3.87 MB (+4.37 kB) | +0.11%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
42 | 13.79 MB → 13.79 MB (+229 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/shared/schedules.ts` | 📈 +229 B (+2.98%) | 7.52 kB → 7.74 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/Value.js | 1.79 MB → 1.79 MB (+229 B) | +0.01%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.68 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/DateSelect.js | 2.38 MB | 0%
static/js/FormulaEditor.js | 767.24 kB | 0%
static/js/ManageRules.js | 71.66 kB | 0%
static/js/NotesTagFormatter.js | 25.94 kB | 0%
static/js/PayeeRuleCountLabel.js | 12.81 kB | 0%
static/js/ReportRouter.js | 1.48 MB | 0%
static/js/ScheduleEditForm.js | 75.41 kB | 0%
static/js/SchedulesTable.js | 171.25 kB | 0%
static/js/TourHost.js | 169.22 kB | 0%
static/js/TourProvider.js | 1.54 kB | 0%
static/js/TransactionEdit.js | 219.59 kB | 0%
static/js/TransactionList.js | 166.98 kB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/ca.js | 170.64 kB | 0%
static/js/client.js | 452.05 kB | 0%
static/js/columns.js | 673.28 kB | 0%
static/js/de.js | 186.5 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/en.js | 258.91 kB | 0%
static/js/es.js | 164.81 kB | 0%
static/js/fr.js | 178.66 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 151.79 kB | 0%
static/js/months.js | 575.1 kB | 0%
static/js/narrow.js | 290.52 kB | 0%
static/js/nb-NO.js | 135.46 kB | 0%
static/js/nl.js | 151.78 kB | 0%
static/js/pl.js | 136.51 kB | 0%
static/js/pt-BR.js | 178.74 kB | 0%
static/js/ru.js | 212.44 kB | 0%
static/js/theme.js | 31.68 kB | 0%
static/js/uk.js | 211.2 kB | 0%
static/js/useFormatList.js | 10.22 kB | 0%
static/js/useLocalPref.js | 97.2 kB | 0%
static/js/useReducedMotion.js | 594 B | 0%
static/js/wide.js | 274.53 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 106.8 kB | 0%
static/js/zh-Hant.js | 130.92 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.65 MB → 4.65 MB (+4.46 kB) | +0.09%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/schedule-template.ts` | 📈 +3.13 kB (+36.43%) | 8.58 kB → 11.71 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/schedules.ts` | 📈 +1.08 kB (+15.97%) | 6.76 kB → 7.84 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/category-template-context.ts` | 📈 +262 B (+1.21%) | 21.22 kB → 21.48 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.DykAjD5P.js | 0 B → 4.65 MB (+4.65 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.CqHqoSL0.js | 4.65 MB → 0 B (-4.65 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.86 MB → 3.87 MB (+4.37 kB) | +0.11%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/schedule-template.ts` | 📈 +3.06 kB (+36.41%) | 8.41 kB → 11.47 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/schedules.ts` | 📈 +1.06 kB (+14.37%) | 7.35 kB → 8.41 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/category-template-context.ts` | 📈 +259 B (+1.25%) | 20.2 kB → 20.45 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.86 MB → 3.87 MB (+4.37 kB) | +0.11%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.16 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->