### PR TITLE
[AI] Support reading secrets from a file with a _FILE environment variable

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -41,18 +41,19 @@ Configuration is resolved in this order (highest priority first):
 
 ### Environment Variables
 
-| Variable               | Description                                           |
-| ---------------------- | ----------------------------------------------------- |
-| `ACTUAL_SERVER_URL`    | URL of the Actual sync server (required)              |
-| `ACTUAL_PASSWORD`      | Server password (required unless using token)         |
-| `ACTUAL_SESSION_TOKEN` | Session token (alternative to password)               |
-| `ACTUAL_SYNC_ID`       | Budget Sync ID (required for most commands)           |
-| `ACTUAL_DATA_DIR`      | Local directory for cached budget data                |
-| `ACTUAL_CACHE_TTL`     | Cache TTL in seconds (default: 60)                    |
-| `ACTUAL_LOCK_TIMEOUT`  | Budget-dir lock wait timeout in seconds (default: 10) |
-| `ACTUAL_NO_LOCK`       | Set to `1` to disable budget-dir locking              |
+| Variable                     | Description                                           |
+| ---------------------------- | ----------------------------------------------------- |
+| `ACTUAL_SERVER_URL`          | URL of the Actual sync server (required)              |
+| `ACTUAL_PASSWORD`            | Server password (required unless using token)         |
+| `ACTUAL_SESSION_TOKEN`       | Session token (alternative to password)               |
+| `ACTUAL_SYNC_ID`             | Budget Sync ID (required for most commands)           |
+| `ACTUAL_DATA_DIR`            | Local directory for cached budget data                |
+| `ACTUAL_CACHE_TTL`           | Cache TTL in seconds (default: 60)                    |
+| `ACTUAL_LOCK_TIMEOUT`        | Budget-dir lock wait timeout in seconds (default: 10) |
+| `ACTUAL_NO_LOCK`             | Set to `1` to disable budget-dir locking              |
+| `ACTUAL_ENCRYPTION_PASSWORD` | Password for end-to-end encrypted budget files        |
 
-Any of these can be read from a file instead by adding `_FILE` to the variable name and pointing it at a file, for example `ACTUAL_PASSWORD_FILE=/run/secrets/actual-password`. Actual reads the file and strips surrounding whitespace. This keeps secrets out of the environment, which is useful with Docker secrets and Kubernetes secret volumes. If both forms are set, the file wins; if the file cannot be read, the command stops with an error instead of continuing without the value.
+The three secrets — `ACTUAL_PASSWORD`, `ACTUAL_SESSION_TOKEN` and `ACTUAL_ENCRYPTION_PASSWORD` — can also be read from a file, by adding `_FILE` to the variable name and pointing it at a file, for example `ACTUAL_PASSWORD_FILE=/run/secrets/actual-password`. Actual reads the file and strips surrounding whitespace. This keeps secrets out of the environment, which is useful with Docker secrets and Kubernetes secret volumes. If both forms are set, the file wins; if the file cannot be read, the command stops with an error instead of continuing without the value.
 
 ### Config File
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -53,7 +53,7 @@ Configuration is resolved in this order (highest priority first):
 | `ACTUAL_NO_LOCK`             | Set to `1` to disable budget-dir locking              |
 | `ACTUAL_ENCRYPTION_PASSWORD` | Password for end-to-end encrypted budget files        |
 
-The three secrets — `ACTUAL_PASSWORD`, `ACTUAL_SESSION_TOKEN` and `ACTUAL_ENCRYPTION_PASSWORD` — can also be read from a file, by adding `_FILE` to the variable name and pointing it at a file, for example `ACTUAL_PASSWORD_FILE=/run/secrets/actual-password`. Actual reads the file and strips surrounding whitespace. This keeps secrets out of the environment, which is useful with Docker secrets and Kubernetes secret volumes. If both forms are set, the file wins; if the file cannot be read, the command stops with an error instead of continuing without the value.
+The three secrets — `ACTUAL_PASSWORD`, `ACTUAL_SESSION_TOKEN` and `ACTUAL_ENCRYPTION_PASSWORD` — can be read from a file instead, by adding `_FILE` to the variable name (for example `ACTUAL_PASSWORD_FILE=/run/secrets/actual-password`). The file wins over the plain variable, and the command stops with an error if it can't be read.
 
 ### Config File
 
@@ -86,7 +86,7 @@ Example `.actualrc.json`:
 }
 ```
 
-**Security:** Avoid storing plaintext passwords in config files (including the `password` key above). If these files do contain passwords, set restrictive permissions (e.g. 600 on Linux), and, if they are in a git repo, add them to `.gitignore`. Prefer environment variables such as `ACTUAL_PASSWORD` or `ACTUAL_SESSION_TOKEN`, or use a session token in config instead of a password. Better still, keep the secret in a file and point `ACTUAL_PASSWORD_FILE` or `ACTUAL_SESSION_TOKEN_FILE` at it. See [Environment Variables](#environment-variables) for details.
+**Security:** Avoid storing plaintext passwords in config files (including the `password` key above). If these files do contain passwords, set restrictive permissions (e.g. 600 on Linux), and, if they are in a git repo, add them to `.gitignore`. Prefer environment variables such as `ACTUAL_PASSWORD` or `ACTUAL_SESSION_TOKEN`, or use a session token in config instead of a password. Better still, use your runtime's built-in support for secrets (e.g. Docker secrets) and point `ACTUAL_PASSWORD_FILE` or `ACTUAL_SESSION_TOKEN_FILE` at the resulting file. See [Environment Variables](#environment-variables) for details.
 
 ### Global Flags
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -52,6 +52,8 @@ Configuration is resolved in this order (highest priority first):
 | `ACTUAL_LOCK_TIMEOUT`  | Budget-dir lock wait timeout in seconds (default: 10) |
 | `ACTUAL_NO_LOCK`       | Set to `1` to disable budget-dir locking              |
 
+Any of these can be read from a file instead by adding `_FILE` to the variable name and pointing it at a file, for example `ACTUAL_PASSWORD_FILE=/run/secrets/actual-password`. Actual reads the file and strips surrounding whitespace. This keeps secrets out of the environment, which is useful with Docker secrets and Kubernetes secret volumes. If both forms are set, the file wins; if the file cannot be read, the command stops with an error instead of continuing without the value.
+
 ### Config File
 
 The CLI uses [cosmiconfig](https://github.com/cosmiconfig/cosmiconfig) for configuration. The config file can be anywhere between the current working directory and your home directory.
@@ -83,7 +85,7 @@ Example `.actualrc.json`:
 }
 ```
 
-**Security:** Avoid storing plaintext passwords in config files (including the `password` key above). If these files do contain passwords, set restrictive permissions (e.g. 600 on Linux), and, if they are in a git repo, add them to `.gitignore`. Prefer environment variables such as `ACTUAL_PASSWORD` or `ACTUAL_SESSION_TOKEN`, or use a session token in config instead of a password. See [Environment Variables](#environment-variables) for details.
+**Security:** Avoid storing plaintext passwords in config files (including the `password` key above). If these files do contain passwords, set restrictive permissions (e.g. 600 on Linux), and, if they are in a git repo, add them to `.gitignore`. Prefer environment variables such as `ACTUAL_PASSWORD` or `ACTUAL_SESSION_TOKEN`, or use a session token in config instead of a password. Better still, keep the secret in a file and point `ACTUAL_PASSWORD_FILE` or `ACTUAL_SESSION_TOKEN_FILE` at it. See [Environment Variables](#environment-variables) for details.
 
 ### Global Flags
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -53,7 +53,7 @@ Configuration is resolved in this order (highest priority first):
 | `ACTUAL_NO_LOCK`             | Set to `1` to disable budget-dir locking              |
 | `ACTUAL_ENCRYPTION_PASSWORD` | Password for end-to-end encrypted budget files        |
 
-The three secrets — `ACTUAL_PASSWORD`, `ACTUAL_SESSION_TOKEN` and `ACTUAL_ENCRYPTION_PASSWORD` — can be read from a file instead, by adding `_FILE` to the variable name (for example `ACTUAL_PASSWORD_FILE=/run/secrets/actual-password`). The file wins over the plain variable, and the command stops with an error if it can't be read.
+The three secrets — `ACTUAL_PASSWORD`, `ACTUAL_SESSION_TOKEN` and `ACTUAL_ENCRYPTION_PASSWORD` — can be read from a file instead, by adding `_FILE` to the variable name (for example `ACTUAL_PASSWORD_FILE=/run/secrets/actual-password`). `_FILE`-suffixed environment variables take priority over regular ones.
 
 ### Config File
 

--- a/packages/cli/src/config.test.ts
+++ b/packages/cli/src/config.test.ts
@@ -1,4 +1,5 @@
-import { homedir } from 'os';
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { homedir, tmpdir } from 'os';
 import { join } from 'path';
 
 import { resolveConfig } from './config';
@@ -21,7 +22,7 @@ function mockConfigFile(config: Record<string, unknown> | null) {
 
 describe('resolveConfig', () => {
   const savedEnv: Record<string, string | undefined> = {};
-  const envKeys = [
+  const baseEnvKeys = [
     'ACTUAL_SERVER_URL',
     'ACTUAL_PASSWORD',
     'ACTUAL_SESSION_TOKEN',
@@ -32,6 +33,7 @@ describe('resolveConfig', () => {
     'ACTUAL_LOCK_TIMEOUT',
     'ACTUAL_NO_LOCK',
   ];
+  const envKeys = [...baseEnvKeys, ...baseEnvKeys.map(key => `${key}_FILE`)];
 
   beforeEach(() => {
     for (const key of envKeys) {
@@ -302,6 +304,83 @@ describe('resolveConfig', () => {
       });
 
       expect(config.serverUrl).toBe('http://test');
+    });
+  });
+
+  describe('_FILE environment variables', () => {
+    let dir: string;
+
+    const writeSecret = (name: string, contents: string) => {
+      const filePath = join(dir, name);
+      writeFileSync(filePath, contents);
+      return filePath;
+    };
+
+    beforeEach(() => {
+      dir = mkdtempSync(join(tmpdir(), 'actual-cli-config-'));
+    });
+
+    afterEach(() => {
+      rmSync(dir, { recursive: true, force: true });
+    });
+
+    it('reads a value from the file it points at, trimming whitespace', async () => {
+      process.env.ACTUAL_PASSWORD_FILE = writeSecret('password', 'filepw\n');
+
+      const config = await resolveConfig({ serverUrl: 'http://test' });
+
+      expect(config.password).toBe('filepw');
+    });
+
+    it('takes precedence over the plain environment variable', async () => {
+      process.env.ACTUAL_PASSWORD = 'envpw';
+      process.env.ACTUAL_PASSWORD_FILE = writeSecret('password', 'filepw');
+
+      const config = await resolveConfig({ serverUrl: 'http://test' });
+
+      expect(config.password).toBe('filepw');
+    });
+
+    it('still loses to a CLI flag', async () => {
+      process.env.ACTUAL_PASSWORD_FILE = writeSecret('password', 'filepw');
+
+      const config = await resolveConfig({
+        serverUrl: 'http://test',
+        password: 'flagpw',
+      });
+
+      expect(config.password).toBe('flagpw');
+    });
+
+    it('takes precedence over the config file', async () => {
+      process.env.ACTUAL_PASSWORD_FILE = writeSecret('password', 'filepw');
+      mockConfigFile({ password: 'configpw' });
+
+      const config = await resolveConfig({ serverUrl: 'http://test' });
+
+      expect(config.password).toBe('filepw');
+    });
+
+    it('works for non-string settings', async () => {
+      process.env.ACTUAL_CACHE_TTL_FILE = writeSecret('ttl', '120\n');
+      process.env.ACTUAL_NO_LOCK_FILE = writeSecret('nolock', 'true\n');
+
+      const config = await resolveConfig({
+        serverUrl: 'http://test',
+        password: 'pw',
+      });
+
+      expect(config.cacheTtl).toBe(120);
+      expect(config.noLock).toBe(true);
+    });
+
+    it('throws when the file cannot be read instead of falling back', async () => {
+      process.env.ACTUAL_PASSWORD = 'envpw';
+      process.env.ACTUAL_PASSWORD_FILE = join(dir, 'does-not-exist');
+
+      await expect(resolveConfig({ serverUrl: 'http://test' })).rejects.toThrow(
+        'Could not read ACTUAL_PASSWORD_FILE',
+      );
     });
   });
 });

--- a/packages/cli/src/config.test.ts
+++ b/packages/cli/src/config.test.ts
@@ -374,6 +374,15 @@ describe('resolveConfig', () => {
       expect(config.noLock).toBe(true);
     });
 
+    it('throws when the _FILE variable is set but empty', async () => {
+      process.env.ACTUAL_PASSWORD = 'envpw';
+      process.env.ACTUAL_PASSWORD_FILE = '';
+
+      await expect(resolveConfig({ serverUrl: 'http://test' })).rejects.toThrow(
+        'Could not read ACTUAL_PASSWORD_FILE',
+      );
+    });
+
     it('throws when the file cannot be read instead of falling back', async () => {
       process.env.ACTUAL_PASSWORD = 'envpw';
       process.env.ACTUAL_PASSWORD_FILE = join(dir, 'does-not-exist');

--- a/packages/cli/src/config.test.ts
+++ b/packages/cli/src/config.test.ts
@@ -361,17 +361,31 @@ describe('resolveConfig', () => {
       expect(config.password).toBe('filepw');
     });
 
-    it('works for non-string settings', async () => {
-      process.env.ACTUAL_CACHE_TTL_FILE = writeSecret('ttl', '120\n');
-      process.env.ACTUAL_NO_LOCK_FILE = writeSecret('nolock', 'true\n');
+    it('supports the session token and encryption password too', async () => {
+      process.env.ACTUAL_SESSION_TOKEN_FILE = writeSecret('token', 'filetok\n');
+      process.env.ACTUAL_ENCRYPTION_PASSWORD_FILE = writeSecret(
+        'enc',
+        'fileenc',
+      );
+
+      const config = await resolveConfig({ serverUrl: 'http://test' });
+
+      expect(config.sessionToken).toBe('filetok');
+      expect(config.encryptionPassword).toBe('fileenc');
+    });
+
+    it('is not offered for settings that are not secrets', async () => {
+      // Following the Docker secrets convention, only secrets get a _FILE
+      // variant. A stray one must be ignored, not silently honoured.
+      process.env.ACTUAL_SYNC_ID_FILE = writeSecret('sync', 'from-file');
+      process.env.ACTUAL_SYNC_ID = 'from-env';
 
       const config = await resolveConfig({
         serverUrl: 'http://test',
         password: 'pw',
       });
 
-      expect(config.cacheTtl).toBe(120);
-      expect(config.noLock).toBe(true);
+      expect(config.syncId).toBe('from-env');
     });
 
     it('throws when the _FILE variable is set but empty', async () => {

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -131,13 +131,7 @@ async function loadConfigFile(): Promise<ConfigFileContent> {
 
 /**
  * Reads the value of a `<VAR>_FILE` environment variable, returning the
- * contents of the file it points at.
- *
- * Only an unset variable returns undefined and falls through to the plain
- * variable. A variable that is set but unreadable — including an empty value,
- * which means a mount produced no path — throws, because a secret that failed
- * to mount should stop the command rather than silently send an empty
- * password to the server.
+ * contents of the file it points at and throwing if the file is not accessible.
  */
 function readFileEnv(fileEnvVar: string): string | undefined {
   const filePath = process.env[fileEnvVar];

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -177,7 +177,6 @@ export async function resolveConfig(
 
   const serverUrl =
     cliOpts.serverUrl ??
-    readFileEnv('ACTUAL_SERVER_URL_FILE') ??
     process.env.ACTUAL_SERVER_URL ??
     fileConfig.serverUrl ??
     '';
@@ -195,14 +194,10 @@ export async function resolveConfig(
     fileConfig.sessionToken;
 
   const syncId =
-    cliOpts.syncId ??
-    readFileEnv('ACTUAL_SYNC_ID_FILE') ??
-    process.env.ACTUAL_SYNC_ID ??
-    fileConfig.syncId;
+    cliOpts.syncId ?? process.env.ACTUAL_SYNC_ID ?? fileConfig.syncId;
 
   const dataDir =
     cliOpts.dataDir ??
-    readFileEnv('ACTUAL_DATA_DIR_FILE') ??
     process.env.ACTUAL_DATA_DIR ??
     fileConfig.dataDir ??
     join(homedir(), '.actual-cli', 'data');
@@ -228,7 +223,7 @@ export async function resolveConfig(
   const cacheTtl = validateNonNegativeInt(
     cliOpts.cacheTtl ??
       parseNonNegativeIntEnv(
-        readFileEnv('ACTUAL_CACHE_TTL_FILE') ?? process.env.ACTUAL_CACHE_TTL,
+        process.env.ACTUAL_CACHE_TTL,
         'ACTUAL_CACHE_TTL',
       ) ??
       fileConfig.cacheTtl ??
@@ -239,8 +234,7 @@ export async function resolveConfig(
   const lockTimeout = validateNonNegativeInt(
     cliOpts.lockTimeout ??
       parseNonNegativeIntEnv(
-        readFileEnv('ACTUAL_LOCK_TIMEOUT_FILE') ??
-          process.env.ACTUAL_LOCK_TIMEOUT,
+        process.env.ACTUAL_LOCK_TIMEOUT,
         'ACTUAL_LOCK_TIMEOUT',
       ) ??
       fileConfig.lockTimeout ??
@@ -253,10 +247,7 @@ export async function resolveConfig(
   const flagNoLock = cliOpts.lock === false ? true : undefined;
   const noLock =
     flagNoLock ??
-    parseBoolEnv(
-      readFileEnv('ACTUAL_NO_LOCK_FILE') ?? process.env.ACTUAL_NO_LOCK,
-      'ACTUAL_NO_LOCK',
-    ) ??
+    parseBoolEnv(process.env.ACTUAL_NO_LOCK, 'ACTUAL_NO_LOCK') ??
     fileConfig.noLock ??
     false;
 

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -3,7 +3,12 @@ import { join } from 'path';
 
 import { cosmiconfig } from 'cosmiconfig';
 
-import { isRecord, parseBoolEnv, parseNonNegativeIntFlag } from './utils';
+import {
+  isRecord,
+  parseBoolEnv,
+  parseNonNegativeIntFlag,
+  readEnv,
+} from './utils';
 
 export type CliConfig = {
   serverUrl: string;
@@ -151,30 +156,30 @@ export async function resolveConfig(
 
   const serverUrl =
     cliOpts.serverUrl ??
-    process.env.ACTUAL_SERVER_URL ??
+    readEnv('ACTUAL_SERVER_URL') ??
     fileConfig.serverUrl ??
     '';
 
   const password =
-    cliOpts.password ?? process.env.ACTUAL_PASSWORD ?? fileConfig.password;
+    cliOpts.password ?? readEnv('ACTUAL_PASSWORD') ?? fileConfig.password;
 
   const sessionToken =
     cliOpts.sessionToken ??
-    process.env.ACTUAL_SESSION_TOKEN ??
+    readEnv('ACTUAL_SESSION_TOKEN') ??
     fileConfig.sessionToken;
 
   const syncId =
-    cliOpts.syncId ?? process.env.ACTUAL_SYNC_ID ?? fileConfig.syncId;
+    cliOpts.syncId ?? readEnv('ACTUAL_SYNC_ID') ?? fileConfig.syncId;
 
   const dataDir =
     cliOpts.dataDir ??
-    process.env.ACTUAL_DATA_DIR ??
+    readEnv('ACTUAL_DATA_DIR') ??
     fileConfig.dataDir ??
     join(homedir(), '.actual-cli', 'data');
 
   const encryptionPassword =
     cliOpts.encryptionPassword ??
-    process.env.ACTUAL_ENCRYPTION_PASSWORD ??
+    readEnv('ACTUAL_ENCRYPTION_PASSWORD') ??
     fileConfig.encryptionPassword;
 
   if (!serverUrl) {
@@ -191,10 +196,7 @@ export async function resolveConfig(
 
   const cacheTtl = validateNonNegativeInt(
     cliOpts.cacheTtl ??
-      parseNonNegativeIntEnv(
-        process.env.ACTUAL_CACHE_TTL,
-        'ACTUAL_CACHE_TTL',
-      ) ??
+      parseNonNegativeIntEnv(readEnv('ACTUAL_CACHE_TTL'), 'ACTUAL_CACHE_TTL') ??
       fileConfig.cacheTtl ??
       60,
     'cacheTtl',
@@ -203,7 +205,7 @@ export async function resolveConfig(
   const lockTimeout = validateNonNegativeInt(
     cliOpts.lockTimeout ??
       parseNonNegativeIntEnv(
-        process.env.ACTUAL_LOCK_TIMEOUT,
+        readEnv('ACTUAL_LOCK_TIMEOUT'),
         'ACTUAL_LOCK_TIMEOUT',
       ) ??
       fileConfig.lockTimeout ??
@@ -216,7 +218,7 @@ export async function resolveConfig(
   const flagNoLock = cliOpts.lock === false ? true : undefined;
   const noLock =
     flagNoLock ??
-    parseBoolEnv(process.env.ACTUAL_NO_LOCK, 'ACTUAL_NO_LOCK') ??
+    parseBoolEnv(readEnv('ACTUAL_NO_LOCK'), 'ACTUAL_NO_LOCK') ??
     fileConfig.noLock ??
     false;
 

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -1,14 +1,10 @@
+import { readFileSync } from 'fs';
 import { homedir } from 'os';
 import { join } from 'path';
 
 import { cosmiconfig } from 'cosmiconfig';
 
-import {
-  isRecord,
-  parseBoolEnv,
-  parseNonNegativeIntFlag,
-  readEnv,
-} from './utils';
+import { isRecord, parseBoolEnv, parseNonNegativeIntFlag } from './utils';
 
 export type CliConfig = {
   serverUrl: string;
@@ -133,6 +129,31 @@ async function loadConfigFile(): Promise<ConfigFileContent> {
   return {};
 }
 
+/**
+ * Reads the value of a `<VAR>_FILE` environment variable, returning the
+ * contents of the file it points at.
+ *
+ * Only an unset variable returns undefined and falls through to the plain
+ * variable. A variable that is set but unreadable — including an empty value,
+ * which means a mount produced no path — throws, because a secret that failed
+ * to mount should stop the command rather than silently send an empty
+ * password to the server.
+ */
+function readFileEnv(fileEnvVar: string): string | undefined {
+  const filePath = process.env[fileEnvVar];
+
+  if (filePath === undefined) return undefined;
+
+  try {
+    return readFileSync(filePath, 'utf-8').trim();
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `Could not read ${fileEnvVar} from "${filePath}": ${reason}`,
+    );
+  }
+}
+
 function parseNonNegativeIntEnv(
   raw: string | undefined,
   source: string,
@@ -156,30 +177,40 @@ export async function resolveConfig(
 
   const serverUrl =
     cliOpts.serverUrl ??
-    readEnv('ACTUAL_SERVER_URL') ??
+    readFileEnv('ACTUAL_SERVER_URL_FILE') ??
+    process.env.ACTUAL_SERVER_URL ??
     fileConfig.serverUrl ??
     '';
 
   const password =
-    cliOpts.password ?? readEnv('ACTUAL_PASSWORD') ?? fileConfig.password;
+    cliOpts.password ??
+    readFileEnv('ACTUAL_PASSWORD_FILE') ??
+    process.env.ACTUAL_PASSWORD ??
+    fileConfig.password;
 
   const sessionToken =
     cliOpts.sessionToken ??
-    readEnv('ACTUAL_SESSION_TOKEN') ??
+    readFileEnv('ACTUAL_SESSION_TOKEN_FILE') ??
+    process.env.ACTUAL_SESSION_TOKEN ??
     fileConfig.sessionToken;
 
   const syncId =
-    cliOpts.syncId ?? readEnv('ACTUAL_SYNC_ID') ?? fileConfig.syncId;
+    cliOpts.syncId ??
+    readFileEnv('ACTUAL_SYNC_ID_FILE') ??
+    process.env.ACTUAL_SYNC_ID ??
+    fileConfig.syncId;
 
   const dataDir =
     cliOpts.dataDir ??
-    readEnv('ACTUAL_DATA_DIR') ??
+    readFileEnv('ACTUAL_DATA_DIR_FILE') ??
+    process.env.ACTUAL_DATA_DIR ??
     fileConfig.dataDir ??
     join(homedir(), '.actual-cli', 'data');
 
   const encryptionPassword =
     cliOpts.encryptionPassword ??
-    readEnv('ACTUAL_ENCRYPTION_PASSWORD') ??
+    readFileEnv('ACTUAL_ENCRYPTION_PASSWORD_FILE') ??
+    process.env.ACTUAL_ENCRYPTION_PASSWORD ??
     fileConfig.encryptionPassword;
 
   if (!serverUrl) {
@@ -196,7 +227,10 @@ export async function resolveConfig(
 
   const cacheTtl = validateNonNegativeInt(
     cliOpts.cacheTtl ??
-      parseNonNegativeIntEnv(readEnv('ACTUAL_CACHE_TTL'), 'ACTUAL_CACHE_TTL') ??
+      parseNonNegativeIntEnv(
+        readFileEnv('ACTUAL_CACHE_TTL_FILE') ?? process.env.ACTUAL_CACHE_TTL,
+        'ACTUAL_CACHE_TTL',
+      ) ??
       fileConfig.cacheTtl ??
       60,
     'cacheTtl',
@@ -205,7 +239,8 @@ export async function resolveConfig(
   const lockTimeout = validateNonNegativeInt(
     cliOpts.lockTimeout ??
       parseNonNegativeIntEnv(
-        readEnv('ACTUAL_LOCK_TIMEOUT'),
+        readFileEnv('ACTUAL_LOCK_TIMEOUT_FILE') ??
+          process.env.ACTUAL_LOCK_TIMEOUT,
         'ACTUAL_LOCK_TIMEOUT',
       ) ??
       fileConfig.lockTimeout ??
@@ -218,7 +253,10 @@ export async function resolveConfig(
   const flagNoLock = cliOpts.lock === false ? true : undefined;
   const noLock =
     flagNoLock ??
-    parseBoolEnv(readEnv('ACTUAL_NO_LOCK'), 'ACTUAL_NO_LOCK') ??
+    parseBoolEnv(
+      readFileEnv('ACTUAL_NO_LOCK_FILE') ?? process.env.ACTUAL_NO_LOCK,
+      'ACTUAL_NO_LOCK',
+    ) ??
     fileConfig.noLock ??
     false;
 

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -1,51 +1,5 @@
-import { readFileSync } from 'fs';
-
-/**
- * Suffix appended to an environment variable name to read its value from a
- * file instead, following the convention used by Docker secrets and Kubernetes
- * file-mounted secrets.
- */
-export const FILE_ENV_SUFFIX = '_FILE';
-
 export function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
-
-/**
- * Reads the value for `<name>_FILE`, or returns undefined when it is not set.
- *
- * Throws when the file cannot be read, rather than silently falling back to
- * the plain environment variable — a secret that failed to mount should stop
- * the command, not send an empty password to the server.
- */
-export function readEnvFile(
-  name: string,
-  env: NodeJS.ProcessEnv = process.env,
-): string | undefined {
-  const fileEnvVar = `${name}${FILE_ENV_SUFFIX}`;
-  const filePath = env[fileEnvVar];
-
-  if (!filePath) return undefined;
-
-  try {
-    return readFileSync(filePath, 'utf-8').trim();
-  } catch (error) {
-    const reason = error instanceof Error ? error.message : String(error);
-    throw new Error(
-      `Could not read ${fileEnvVar} from "${filePath}": ${reason}`,
-    );
-  }
-}
-
-/**
- * Reads an environment variable, preferring the `<name>_FILE` variant when it
- * is set.
- */
-export function readEnv(
-  name: string,
-  env: NodeJS.ProcessEnv = process.env,
-): string | undefined {
-  return readEnvFile(name, env) ?? env[name];
 }
 
 export function parseBoolFlag(value: string, flagName: string): boolean {

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -1,5 +1,51 @@
+import { readFileSync } from 'fs';
+
+/**
+ * Suffix appended to an environment variable name to read its value from a
+ * file instead, following the convention used by Docker secrets and Kubernetes
+ * file-mounted secrets.
+ */
+export const FILE_ENV_SUFFIX = '_FILE';
+
 export function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Reads the value for `<name>_FILE`, or returns undefined when it is not set.
+ *
+ * Throws when the file cannot be read, rather than silently falling back to
+ * the plain environment variable — a secret that failed to mount should stop
+ * the command, not send an empty password to the server.
+ */
+export function readEnvFile(
+  name: string,
+  env: NodeJS.ProcessEnv = process.env,
+): string | undefined {
+  const fileEnvVar = `${name}${FILE_ENV_SUFFIX}`;
+  const filePath = env[fileEnvVar];
+
+  if (!filePath) return undefined;
+
+  try {
+    return readFileSync(filePath, 'utf-8').trim();
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `Could not read ${fileEnvVar} from "${filePath}": ${reason}`,
+    );
+  }
+}
+
+/**
+ * Reads an environment variable, preferring the `<name>_FILE` variant when it
+ * is set.
+ */
+export function readEnv(
+  name: string,
+  env: NodeJS.ProcessEnv = process.env,
+): string | undefined {
+  return readEnvFile(name, env) ?? env[name];
 }
 
 export function parseBoolFlag(value: string, flagName: string): boolean {

--- a/packages/docs/docs/api/cli.md
+++ b/packages/docs/docs/api/cli.md
@@ -37,6 +37,8 @@ The CLI requires a connection to a running Actual sync server. Configuration can
 | `ACTUAL_PASSWORD`      | Server password (one of password or token required) |
 | `ACTUAL_SESSION_TOKEN` | Session token (alternative to password)             |
 
+Any of these can be read from a file instead by adding `_FILE` to the variable name and pointing it at a file, for example `ACTUAL_PASSWORD_FILE=/run/secrets/actual-password`. Actual reads the file and strips surrounding whitespace. This keeps secrets out of the environment, which is useful with Docker secrets and Kubernetes secret volumes. If both forms are set, the file wins; if the file cannot be read, the command stops with an error instead of continuing without the value.
+
 ### CLI Flags
 
 Global flags override environment variables:
@@ -83,7 +85,7 @@ Example `.actualrc.json`:
 ```
 
 :::caution Security
-Avoid storing plaintext passwords in config files (including the `password` key above). If these files do contain passwords, set restrictive permissions (e.g. 600 on Linux), and, if they are in a git repo, add them to `.gitignore`. Prefer environment variables such as `ACTUAL_PASSWORD` or `ACTUAL_SESSION_TOKEN`, or use a session token in config instead of a password. See [Environment Variables](#environment-variables) for details.
+Avoid storing plaintext passwords in config files (including the `password` key above). If these files do contain passwords, set restrictive permissions (e.g. 600 on Linux), and, if they are in a git repo, add them to `.gitignore`. Prefer environment variables such as `ACTUAL_PASSWORD` or `ACTUAL_SESSION_TOKEN`, or use a session token in config instead of a password. Better still, keep the secret in a file and point `ACTUAL_PASSWORD_FILE` or `ACTUAL_SESSION_TOKEN_FILE` at it. See [Environment Variables](#environment-variables) for details.
 :::
 
 ## Usage

--- a/packages/docs/docs/api/cli.md
+++ b/packages/docs/docs/api/cli.md
@@ -42,7 +42,7 @@ The CLI requires a connection to a running Actual sync server. Configuration can
 | `ACTUAL_NO_LOCK`             | Set to `1` to disable budget-dir locking              |
 | `ACTUAL_ENCRYPTION_PASSWORD` | Password for end-to-end encrypted budget files        |
 
-The three secrets — `ACTUAL_PASSWORD`, `ACTUAL_SESSION_TOKEN` and `ACTUAL_ENCRYPTION_PASSWORD` — can also be read from a file, by adding `_FILE` to the variable name and pointing it at a file, for example `ACTUAL_PASSWORD_FILE=/run/secrets/actual-password`. Actual reads the file and strips surrounding whitespace. This keeps secrets out of the environment, which is useful with Docker secrets and Kubernetes secret volumes. If both forms are set, the file wins; if the file cannot be read, the command stops with an error instead of continuing without the value.
+The three secrets — `ACTUAL_PASSWORD`, `ACTUAL_SESSION_TOKEN` and `ACTUAL_ENCRYPTION_PASSWORD` — can be read from a file instead, by adding `_FILE` to the variable name (for example `ACTUAL_PASSWORD_FILE=/run/secrets/actual-password`). The file wins over the plain variable, and the command stops with an error if it can't be read.
 
 ### CLI Flags
 
@@ -90,7 +90,7 @@ Example `.actualrc.json`:
 ```
 
 :::caution Security
-Avoid storing plaintext passwords in config files (including the `password` key above). If these files do contain passwords, set restrictive permissions (e.g. 600 on Linux), and, if they are in a git repo, add them to `.gitignore`. Prefer environment variables such as `ACTUAL_PASSWORD` or `ACTUAL_SESSION_TOKEN`, or use a session token in config instead of a password. Better still, keep the secret in a file and point `ACTUAL_PASSWORD_FILE` or `ACTUAL_SESSION_TOKEN_FILE` at it. See [Environment Variables](#environment-variables) for details.
+Avoid storing plaintext passwords in config files (including the `password` key above). If these files do contain passwords, set restrictive permissions (e.g. 600 on Linux), and, if they are in a git repo, add them to `.gitignore`. Prefer environment variables such as `ACTUAL_PASSWORD` or `ACTUAL_SESSION_TOKEN`, or use a session token in config instead of a password. Better still, use your runtime's built-in support for secrets (e.g. Docker secrets) and point `ACTUAL_PASSWORD_FILE` or `ACTUAL_SESSION_TOKEN_FILE` at the resulting file. See [Environment Variables](#environment-variables) for details.
 :::
 
 ## Usage

--- a/packages/docs/docs/api/cli.md
+++ b/packages/docs/docs/api/cli.md
@@ -30,12 +30,16 @@ The CLI requires a connection to a running Actual sync server. Configuration can
 
 ### Environment Variables
 
-| Variable               | Description                                         |
-| ---------------------- | --------------------------------------------------- |
-| `ACTUAL_SERVER_URL`    | URL of the Actual sync server (required)            |
-| `ACTUAL_SYNC_ID`       | Budget Sync ID (required for most commands)         |
-| `ACTUAL_PASSWORD`      | Server password (one of password or token required) |
-| `ACTUAL_SESSION_TOKEN` | Session token (alternative to password)             |
+| Variable               | Description                                           |
+| ---------------------- | ----------------------------------------------------- |
+| `ACTUAL_SERVER_URL`    | URL of the Actual sync server (required)              |
+| `ACTUAL_SYNC_ID`       | Budget Sync ID (required for most commands)           |
+| `ACTUAL_PASSWORD`      | Server password (one of password or token required)   |
+| `ACTUAL_SESSION_TOKEN` | Session token (alternative to password)               |
+| `ACTUAL_DATA_DIR`      | Local directory for cached budget data                |
+| `ACTUAL_CACHE_TTL`     | Cache TTL in seconds (default: 60)                    |
+| `ACTUAL_LOCK_TIMEOUT`  | Budget-dir lock wait timeout in seconds (default: 10) |
+| `ACTUAL_NO_LOCK`       | Set to `1` to disable budget-dir locking              |
 
 Any of these can be read from a file instead by adding `_FILE` to the variable name and pointing it at a file, for example `ACTUAL_PASSWORD_FILE=/run/secrets/actual-password`. Actual reads the file and strips surrounding whitespace. This keeps secrets out of the environment, which is useful with Docker secrets and Kubernetes secret volumes. If both forms are set, the file wins; if the file cannot be read, the command stops with an error instead of continuing without the value.
 

--- a/packages/docs/docs/api/cli.md
+++ b/packages/docs/docs/api/cli.md
@@ -30,18 +30,19 @@ The CLI requires a connection to a running Actual sync server. Configuration can
 
 ### Environment Variables
 
-| Variable               | Description                                           |
-| ---------------------- | ----------------------------------------------------- |
-| `ACTUAL_SERVER_URL`    | URL of the Actual sync server (required)              |
-| `ACTUAL_SYNC_ID`       | Budget Sync ID (required for most commands)           |
-| `ACTUAL_PASSWORD`      | Server password (one of password or token required)   |
-| `ACTUAL_SESSION_TOKEN` | Session token (alternative to password)               |
-| `ACTUAL_DATA_DIR`      | Local directory for cached budget data                |
-| `ACTUAL_CACHE_TTL`     | Cache TTL in seconds (default: 60)                    |
-| `ACTUAL_LOCK_TIMEOUT`  | Budget-dir lock wait timeout in seconds (default: 10) |
-| `ACTUAL_NO_LOCK`       | Set to `1` to disable budget-dir locking              |
+| Variable                     | Description                                           |
+| ---------------------------- | ----------------------------------------------------- |
+| `ACTUAL_SERVER_URL`          | URL of the Actual sync server (required)              |
+| `ACTUAL_SYNC_ID`             | Budget Sync ID (required for most commands)           |
+| `ACTUAL_PASSWORD`            | Server password (one of password or token required)   |
+| `ACTUAL_SESSION_TOKEN`       | Session token (alternative to password)               |
+| `ACTUAL_DATA_DIR`            | Local directory for cached budget data                |
+| `ACTUAL_CACHE_TTL`           | Cache TTL in seconds (default: 60)                    |
+| `ACTUAL_LOCK_TIMEOUT`        | Budget-dir lock wait timeout in seconds (default: 10) |
+| `ACTUAL_NO_LOCK`             | Set to `1` to disable budget-dir locking              |
+| `ACTUAL_ENCRYPTION_PASSWORD` | Password for end-to-end encrypted budget files        |
 
-Any of these can be read from a file instead by adding `_FILE` to the variable name and pointing it at a file, for example `ACTUAL_PASSWORD_FILE=/run/secrets/actual-password`. Actual reads the file and strips surrounding whitespace. This keeps secrets out of the environment, which is useful with Docker secrets and Kubernetes secret volumes. If both forms are set, the file wins; if the file cannot be read, the command stops with an error instead of continuing without the value.
+The three secrets — `ACTUAL_PASSWORD`, `ACTUAL_SESSION_TOKEN` and `ACTUAL_ENCRYPTION_PASSWORD` — can also be read from a file, by adding `_FILE` to the variable name and pointing it at a file, for example `ACTUAL_PASSWORD_FILE=/run/secrets/actual-password`. Actual reads the file and strips surrounding whitespace. This keeps secrets out of the environment, which is useful with Docker secrets and Kubernetes secret volumes. If both forms are set, the file wins; if the file cannot be read, the command stops with an error instead of continuing without the value.
 
 ### CLI Flags
 

--- a/packages/docs/docs/api/cli.md
+++ b/packages/docs/docs/api/cli.md
@@ -42,7 +42,7 @@ The CLI requires a connection to a running Actual sync server. Configuration can
 | `ACTUAL_NO_LOCK`             | Set to `1` to disable budget-dir locking              |
 | `ACTUAL_ENCRYPTION_PASSWORD` | Password for end-to-end encrypted budget files        |
 
-The three secrets — `ACTUAL_PASSWORD`, `ACTUAL_SESSION_TOKEN` and `ACTUAL_ENCRYPTION_PASSWORD` — can be read from a file instead, by adding `_FILE` to the variable name (for example `ACTUAL_PASSWORD_FILE=/run/secrets/actual-password`). The file wins over the plain variable, and the command stops with an error if it can't be read.
+The three secrets — `ACTUAL_PASSWORD`, `ACTUAL_SESSION_TOKEN` and `ACTUAL_ENCRYPTION_PASSWORD` — can be read from a file instead, by adding `_FILE` to the variable name (for example `ACTUAL_PASSWORD_FILE=/run/secrets/actual-password`). `_FILE`-suffixed environment variables take priority over regular ones.
 
 ### CLI Flags
 

--- a/packages/docs/docs/config/index.md
+++ b/packages/docs/docs/config/index.md
@@ -31,11 +31,16 @@ See the `ACTUAL_DATA_DIR` section above to override the data folder location.
 
 You can't specify this option in `config.json` since it needs to be used to find the `config.json` in the first place.
 
-## Reading a Setting From a File
+## Reading a Secret From a File
 
-Every setting on this page can also be read from a file instead of being given directly. Add `_FILE` to the end of the environment variable's name and set it to the path of a file, and Actual reads the value from that file when it starts up.
+Secrets can be read from a file instead of being given directly. Add `_FILE` to the end of the environment variable's name and set it to the path of a file, and Actual reads the value from that file when it starts up.
 
-This is mainly useful for secrets. Passing a secret as an ordinary environment variable means it can be read back out of the running container, and in Docker or Kubernetes it usually has to be written into a deployment file first. Pointing at a file instead lets you mount the secret with the tools those systems already provide, such as Docker secrets or a Kubernetes secret volume.
+Passing a secret as an ordinary environment variable means it can be read back out of the running container, and in Docker or Kubernetes it usually has to be written into a deployment file first. Pointing at a file instead lets you mount the secret with the tools those systems already provide, such as Docker secrets or a Kubernetes secret volume.
+
+The following are supported:
+
+- `ACTUAL_OPENID_CLIENT_SECRET_FILE`
+- `ACTUAL_GITHUB_TOKEN_FILE`
 
 For example, to load the OpenID client secret from a mounted file:
 
@@ -49,9 +54,9 @@ A few things worth knowing:
 
 - If you set both the plain variable and its `_FILE` version, the file wins.
 - If the file is missing or cannot be read, the server stops with an error rather than starting up without the value. This is deliberate: a server that silently started with an empty password would be far harder to spot.
-- `ACTUAL_HTTPS_KEY` and `ACTUAL_HTTPS_CERT` already accept the path to a file, so you do not need the `_FILE` version for those.
+- `ACTUAL_HTTPS_KEY` and `ACTUAL_HTTPS_CERT` already accept the path to a file, so they do not need a `_FILE` version.
 
-The Actual CLI supports the same `_FILE` suffix for its own settings. See [CLI Tool](../api/cli.md#environment-variables) for details.
+The Actual CLI supports the same `_FILE` suffix for its own secrets. See [CLI Tool](../api/cli.md#environment-variables) for details.
 
 ## `ACTUAL_UPLOAD_FILE_SYNC_SIZE_LIMIT_MB`
 

--- a/packages/docs/docs/config/index.md
+++ b/packages/docs/docs/config/index.md
@@ -31,6 +31,28 @@ See the `ACTUAL_DATA_DIR` section above to override the data folder location.
 
 You can't specify this option in `config.json` since it needs to be used to find the `config.json` in the first place.
 
+## Reading a Setting From a File
+
+Every setting on this page can also be read from a file instead of being given directly. Add `_FILE` to the end of the environment variable's name and set it to the path of a file, and Actual reads the value from that file when it starts up.
+
+This is mainly useful for secrets. Passing a secret as an ordinary environment variable means it can be read back out of the running container, and in Docker or Kubernetes it usually has to be written into a deployment file first. Pointing at a file instead lets you mount the secret with the tools those systems already provide, such as Docker secrets or a Kubernetes secret volume.
+
+For example, to load the OpenID client secret from a mounted file:
+
+```bash
+ACTUAL_OPENID_CLIENT_SECRET_FILE=/run/secrets/openid-client-secret
+```
+
+Actual reads the whole file and removes any surrounding whitespace, so a trailing newline at the end of the file is fine.
+
+A few things worth knowing:
+
+- If you set both the plain variable and its `_FILE` version, the file wins.
+- If the file is missing or cannot be read, the server stops with an error rather than starting up without the value. This is deliberate: a server that silently started with an empty password would be far harder to spot.
+- `ACTUAL_HTTPS_KEY` and `ACTUAL_HTTPS_CERT` already accept the path to a file, so you do not need the `_FILE` version for those.
+
+The Actual CLI supports the same `_FILE` suffix for its own settings. See [CLI Tool](../api/cli.md#environment-variables) for details.
+
 ## `ACTUAL_UPLOAD_FILE_SYNC_SIZE_LIMIT_MB`
 
 Defines the maximum allowed size for sync files (in MB).

--- a/packages/docs/docs/config/index.md
+++ b/packages/docs/docs/config/index.md
@@ -14,6 +14,10 @@ Running into issues with your configuration not being interpreted correctly? Che
 
 :::
 
+:::tip
+Secrets can be read from a file rather than passed in the environment, which works with Docker secrets and Kubernetes secret volumes. Set `ACTUAL_OPENID_CLIENT_SECRET_FILE` or `ACTUAL_GITHUB_TOKEN_FILE` to the path of a file holding the value. The file wins over the plain variable, and the server stops with an error if it can't be read. The [CLI](../api/cli.md#environment-variables) supports the same suffix for its own secrets.
+:::
+
 ## `ACTUAL_DATA_DIR` (config.json: `dataDir`)
 
 This is where the server stores the budget data files (and configurations unless `ACTUAL_CONFIG_PATH` is set).
@@ -30,33 +34,6 @@ This is the path to the config file. If not specified, the server will look for 
 See the `ACTUAL_DATA_DIR` section above to override the data folder location.
 
 You can't specify this option in `config.json` since it needs to be used to find the `config.json` in the first place.
-
-## Reading a Secret From a File
-
-Secrets can be read from a file instead of being given directly. Add `_FILE` to the end of the environment variable's name and set it to the path of a file, and Actual reads the value from that file when it starts up.
-
-Passing a secret as an ordinary environment variable means it can be read back out of the running container, and in Docker or Kubernetes it usually has to be written into a deployment file first. Pointing at a file instead lets you mount the secret with the tools those systems already provide, such as Docker secrets or a Kubernetes secret volume.
-
-The following are supported:
-
-- `ACTUAL_OPENID_CLIENT_SECRET_FILE`
-- `ACTUAL_GITHUB_TOKEN_FILE`
-
-For example, to load the OpenID client secret from a mounted file:
-
-```bash
-ACTUAL_OPENID_CLIENT_SECRET_FILE=/run/secrets/openid-client-secret
-```
-
-Actual reads the whole file and removes any surrounding whitespace, so a trailing newline at the end of the file is fine.
-
-A few things worth knowing:
-
-- If you set both the plain variable and its `_FILE` version, the file wins.
-- If the file is missing or cannot be read, the server stops with an error rather than starting up without the value. This is deliberate: a server that silently started with an empty password would be far harder to spot.
-- `ACTUAL_HTTPS_KEY` and `ACTUAL_HTTPS_CERT` already accept the path to a file, so they do not need a `_FILE` version.
-
-The Actual CLI supports the same `_FILE` suffix for its own secrets. See [CLI Tool](../api/cli.md#environment-variables) for details.
 
 ## `ACTUAL_UPLOAD_FILE_SYNC_SIZE_LIMIT_MB`
 

--- a/packages/docs/docs/config/index.md
+++ b/packages/docs/docs/config/index.md
@@ -15,7 +15,7 @@ Running into issues with your configuration not being interpreted correctly? Che
 :::
 
 :::tip
-Secrets can be read from a file rather than passed in the environment, which works with Docker secrets and Kubernetes secret volumes. Set `ACTUAL_OPENID_CLIENT_SECRET_FILE` or `ACTUAL_GITHUB_TOKEN_FILE` to the path of a file holding the value. The file wins over the plain variable, and the server stops with an error if it can't be read. The [CLI](../api/cli.md#environment-variables) supports the same suffix for its own secrets.
+Secrets can be read from a file rather than passed in the environment, which works with Docker secrets and Kubernetes secret volumes. Set `ACTUAL_OPENID_CLIENT_SECRET_FILE` or `ACTUAL_GITHUB_TOKEN_FILE` to the path of a file holding the value. `_FILE`-suffixed environment variables take priority over regular ones. The [CLI](../api/cli.md#environment-variables) supports the same suffix for its own secrets.
 :::
 
 ## `ACTUAL_DATA_DIR` (config.json: `dataDir`)

--- a/packages/docs/docs/config/oauth-auth.md
+++ b/packages/docs/docs/config/oauth-auth.md
@@ -63,6 +63,10 @@ If your OpenId provider does not supports discovery, use the following variables
 - `ACTUAL_OPENID_CLIENT_SECRET`: client_secret given by the provider
 - `ACTUAL_OPENID_SERVER_HOSTNAME`: Your Actual Server URL (so the provider redirects you to this)
 
+:::tip
+To keep the client secret out of your environment, set `ACTUAL_OPENID_CLIENT_SECRET_FILE` to the path of a file containing it instead. See [Reading a Setting From a File](index.md#reading-a-setting-from-a-file).
+:::
+
 ### Configuring OpenID Using the UI
 
 Navigate into any Budget file, then in the Settings, click on _Start using OpenID_
@@ -134,6 +138,11 @@ The first user to log in with OpenID/OAuth2 will be granted admin permissions an
 
 - **Purpose:** The client secret issued by your OpenID provider.
   **Example Value:** `super-secret-value`
+
+#### `ACTUAL_OPENID_CLIENT_SECRET_FILE`
+
+- **Purpose:** The path to a file containing the client secret, read instead of `ACTUAL_OPENID_CLIENT_SECRET`. Use this to mount the secret as a file rather than passing it in the environment. See [Reading a Setting From a File](index.md#reading-a-setting-from-a-file).
+  **Example Value:** `/run/secrets/openid-client-secret`
 
 #### `ACTUAL_OPENID_SERVER_HOSTNAME`
 

--- a/packages/docs/docs/config/oauth-auth.md
+++ b/packages/docs/docs/config/oauth-auth.md
@@ -64,7 +64,7 @@ If your OpenId provider does not supports discovery, use the following variables
 - `ACTUAL_OPENID_SERVER_HOSTNAME`: Your Actual Server URL (so the provider redirects you to this)
 
 :::tip
-To keep the client secret out of your environment, set `ACTUAL_OPENID_CLIENT_SECRET_FILE` to the path of a file containing it instead. See [Reading a Secret From a File](index.md#reading-a-secret-from-a-file).
+To keep the client secret out of your environment, set `ACTUAL_OPENID_CLIENT_SECRET_FILE` to the path of a file containing it instead. See [Configuring the Server](index.md).
 :::
 
 ### Configuring OpenID Using the UI
@@ -138,11 +138,6 @@ The first user to log in with OpenID/OAuth2 will be granted admin permissions an
 
 - **Purpose:** The client secret issued by your OpenID provider.
   **Example Value:** `super-secret-value`
-
-#### `ACTUAL_OPENID_CLIENT_SECRET_FILE`
-
-- **Purpose:** The path to a file containing the client secret, read instead of `ACTUAL_OPENID_CLIENT_SECRET`. Use this to mount the secret as a file rather than passing it in the environment. See [Reading a Secret From a File](index.md#reading-a-secret-from-a-file).
-  **Example Value:** `/run/secrets/openid-client-secret`
 
 #### `ACTUAL_OPENID_SERVER_HOSTNAME`
 

--- a/packages/docs/docs/config/oauth-auth.md
+++ b/packages/docs/docs/config/oauth-auth.md
@@ -64,7 +64,7 @@ If your OpenId provider does not supports discovery, use the following variables
 - `ACTUAL_OPENID_SERVER_HOSTNAME`: Your Actual Server URL (so the provider redirects you to this)
 
 :::tip
-To keep the client secret out of your environment, set `ACTUAL_OPENID_CLIENT_SECRET_FILE` to the path of a file containing it instead. See [Reading a Setting From a File](index.md#reading-a-setting-from-a-file).
+To keep the client secret out of your environment, set `ACTUAL_OPENID_CLIENT_SECRET_FILE` to the path of a file containing it instead. See [Reading a Secret From a File](index.md#reading-a-secret-from-a-file).
 :::
 
 ### Configuring OpenID Using the UI
@@ -141,7 +141,7 @@ The first user to log in with OpenID/OAuth2 will be granted admin permissions an
 
 #### `ACTUAL_OPENID_CLIENT_SECRET_FILE`
 
-- **Purpose:** The path to a file containing the client secret, read instead of `ACTUAL_OPENID_CLIENT_SECRET`. Use this to mount the secret as a file rather than passing it in the environment. See [Reading a Setting From a File](index.md#reading-a-setting-from-a-file).
+- **Purpose:** The path to a file containing the client secret, read instead of `ACTUAL_OPENID_CLIENT_SECRET`. Use this to mount the secret as a file rather than passing it in the environment. See [Reading a Secret From a File](index.md#reading-a-secret-from-a-file).
   **Example Value:** `/run/secrets/openid-client-secret`
 
 #### `ACTUAL_OPENID_SERVER_HOSTNAME`

--- a/packages/sync-server/src/config-file-env.test.ts
+++ b/packages/sync-server/src/config-file-env.test.ts
@@ -1,0 +1,194 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import convict from 'convict';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  applyFileEnvOverrides,
+  collectEnvVarBindings,
+} from './config-file-env';
+
+describe('collectEnvVarBindings', () => {
+  it('collects top-level and nested settings with their dotted paths', () => {
+    const bindings = collectEnvVarBindings({
+      port: { doc: 'Port', format: 'port', default: 5006, env: 'TEST_PORT' },
+      openId: {
+        doc: 'OpenID settings.',
+        client_secret: { format: String, default: '', env: 'TEST_SECRET' },
+        issuer: {
+          doc: 'Issuer',
+          name: { format: String, default: '', env: 'TEST_ISSUER_NAME' },
+        },
+      },
+    });
+
+    expect(bindings).toEqual([
+      { envVar: 'TEST_PORT', path: 'port' },
+      { envVar: 'TEST_SECRET', path: 'openId.client_secret' },
+      { envVar: 'TEST_ISSUER_NAME', path: 'openId.issuer.name' },
+    ]);
+  });
+
+  it('treats a setting named "env" as a setting, not as a convict keyword', () => {
+    // The real schema has a top-level `env` setting bound to NODE_ENV, which
+    // must not be confused with the `env` keyword of a setting definition.
+    const bindings = collectEnvVarBindings({
+      env: {
+        doc: 'The application environment.',
+        format: ['production', 'development', 'test'],
+        default: 'development',
+        env: 'NODE_ENV',
+      },
+    });
+
+    expect(bindings).toEqual([{ envVar: 'NODE_ENV', path: 'env' }]);
+  });
+
+  it('ignores settings that are not bound to an environment variable', () => {
+    const bindings = collectEnvVarBindings({
+      projectRoot: { doc: 'Project root.', format: String, default: '/app' },
+    });
+
+    expect(bindings).toEqual([]);
+  });
+
+  it('does not descend into object-valued convict keywords', () => {
+    const bindings = collectEnvVarBindings({
+      group: {
+        doc: 'A group whose default is an object.',
+        nested: {
+          format: Object,
+          default: { env: 'NOT_A_SETTING' },
+          env: 'TEST_NESTED',
+        },
+      },
+    });
+
+    expect(bindings).toEqual([{ envVar: 'TEST_NESTED', path: 'group.nested' }]);
+  });
+});
+
+describe('applyFileEnvOverrides', () => {
+  let dir: string;
+
+  const buildSchema = () =>
+    convict({
+      port: { doc: 'Port', format: 'port', default: 5006, env: 'TEST_PORT' },
+      openId: {
+        doc: 'OpenID settings.',
+        client_secret: {
+          doc: 'Client secret',
+          format: String,
+          default: '',
+          env: 'TEST_SECRET',
+        },
+      },
+    });
+
+  const writeSecret = (name: string, contents: string) => {
+    const filePath = join(dir, name);
+    writeFileSync(filePath, contents);
+    return filePath;
+  };
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'actual-config-file-env-'));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('reads the value from the file named by <VAR>_FILE', () => {
+    const config = buildSchema();
+    const filePath = writeSecret('secret', 'from-file');
+
+    const applied = applyFileEnvOverrides(
+      config,
+      [{ envVar: 'TEST_SECRET', path: 'openId.client_secret' }],
+      { TEST_SECRET_FILE: filePath },
+    );
+
+    expect(config.get('openId.client_secret')).toBe('from-file');
+    expect(applied).toEqual([
+      {
+        envVar: 'TEST_SECRET',
+        path: 'openId.client_secret',
+        filePath,
+        value: 'from-file',
+        supersededEnvVar: false,
+      },
+    ]);
+  });
+
+  it('strips the trailing newline that most tooling appends', () => {
+    const config = buildSchema();
+    const filePath = writeSecret('secret', '  from-file\n');
+
+    applyFileEnvOverrides(
+      config,
+      [{ envVar: 'TEST_SECRET', path: 'openId.client_secret' }],
+      { TEST_SECRET_FILE: filePath },
+    );
+
+    expect(config.get('openId.client_secret')).toBe('from-file');
+  });
+
+  it('takes precedence over the plain environment variable', () => {
+    const config = buildSchema();
+    const filePath = writeSecret('secret', 'from-file');
+
+    // convict has already imported TEST_SECRET at this point, exactly as it
+    // would at startup.
+    config.set('openId.client_secret', 'from-env');
+
+    const applied = applyFileEnvOverrides(
+      config,
+      [{ envVar: 'TEST_SECRET', path: 'openId.client_secret' }],
+      { TEST_SECRET: 'from-env', TEST_SECRET_FILE: filePath },
+    );
+
+    expect(config.get('openId.client_secret')).toBe('from-file');
+    expect(applied[0].supersededEnvVar).toBe(true);
+  });
+
+  it('leaves settings alone when no _FILE variable is set', () => {
+    const config = buildSchema();
+
+    const applied = applyFileEnvOverrides(
+      config,
+      [{ envVar: 'TEST_SECRET', path: 'openId.client_secret' }],
+      {},
+    );
+
+    expect(applied).toEqual([]);
+    expect(config.get('openId.client_secret')).toBe('');
+  });
+
+  it('coerces values for non-string formats', () => {
+    const config = buildSchema();
+    const filePath = writeSecret('port', '1234\n');
+
+    applyFileEnvOverrides(config, [{ envVar: 'TEST_PORT', path: 'port' }], {
+      TEST_PORT_FILE: filePath,
+    });
+
+    expect(config.get('port')).toBe(1234);
+    expect(() => config.validate({ allowed: 'strict' })).not.toThrow();
+  });
+
+  it('throws when the file cannot be read, naming the variable and path', () => {
+    const config = buildSchema();
+    const missing = join(dir, 'does-not-exist');
+
+    expect(() =>
+      applyFileEnvOverrides(
+        config,
+        [{ envVar: 'TEST_SECRET', path: 'openId.client_secret' }],
+        { TEST_SECRET_FILE: missing },
+      ),
+    ).toThrow(`Could not read TEST_SECRET_FILE from '${missing}'`);
+  });
+});

--- a/packages/sync-server/src/config-file-env.test.ts
+++ b/packages/sync-server/src/config-file-env.test.ts
@@ -8,7 +8,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { applyFileEnv, readFileEnv } from './config-file-env';
 
 describe('config file env', () => {
-  let dir: string;
+  let secretDirectory: string;
 
   const buildSchema = () =>
     convict({
@@ -24,17 +24,17 @@ describe('config file env', () => {
     });
 
   const writeSecret = (name: string, contents: string) => {
-    const filePath = join(dir, name);
+    const filePath = join(secretDirectory, name);
     writeFileSync(filePath, contents);
     return filePath;
   };
 
   beforeEach(() => {
-    dir = mkdtempSync(join(tmpdir(), 'actual-config-file-env-'));
+    secretDirectory = mkdtempSync(join(tmpdir(), 'actual-config-file-env-'));
   });
 
   afterEach(() => {
-    rmSync(dir, { recursive: true, force: true });
+    rmSync(secretDirectory, { recursive: true, force: true });
   });
 
   describe('readFileEnv', () => {
@@ -59,7 +59,7 @@ describe('config file env', () => {
     });
 
     it('throws when the file cannot be read, naming the variable and path', () => {
-      const missing = join(dir, 'does-not-exist');
+      const missing = join(secretDirectory, 'does-not-exist');
 
       expect(() =>
         readFileEnv('TEST_SECRET_FILE', { TEST_SECRET_FILE: missing }),

--- a/packages/sync-server/src/config-file-env.test.ts
+++ b/packages/sync-server/src/config-file-env.test.ts
@@ -123,7 +123,7 @@ describe('applyFileEnvOverrides', () => {
     ]);
   });
 
-  it('strips the trailing newline that most tooling appends', () => {
+  it('trims surrounding whitespace from the file value', () => {
     const config = buildSchema();
     const filePath = writeSecret('secret', '  from-file\n');
 
@@ -177,6 +177,20 @@ describe('applyFileEnvOverrides', () => {
 
     expect(config.get('port')).toBe(1234);
     expect(() => config.validate({ allowed: 'strict' })).not.toThrow();
+  });
+
+  it('throws when the _FILE variable is set but empty', () => {
+    const config = buildSchema();
+
+    // An empty value means a mount that did not produce a path. Falling back
+    // to the plain variable here would hide the misconfiguration.
+    expect(() =>
+      applyFileEnvOverrides(
+        config,
+        [{ envVar: 'TEST_SECRET', path: 'openId.client_secret' }],
+        { TEST_SECRET: 'from-env', TEST_SECRET_FILE: '' },
+      ),
+    ).toThrow('Could not read TEST_SECRET_FILE');
   });
 
   it('throws when the file cannot be read, naming the variable and path', () => {

--- a/packages/sync-server/src/config-file-env.test.ts
+++ b/packages/sync-server/src/config-file-env.test.ts
@@ -5,77 +5,13 @@ import { join } from 'node:path';
 import convict from 'convict';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import {
-  applyFileEnvOverrides,
-  collectEnvVarBindings,
-} from './config-file-env';
+import { applyFileEnv, readFileEnv } from './config-file-env';
 
-describe('collectEnvVarBindings', () => {
-  it('collects top-level and nested settings with their dotted paths', () => {
-    const bindings = collectEnvVarBindings({
-      port: { doc: 'Port', format: 'port', default: 5006, env: 'TEST_PORT' },
-      openId: {
-        doc: 'OpenID settings.',
-        client_secret: { format: String, default: '', env: 'TEST_SECRET' },
-        issuer: {
-          doc: 'Issuer',
-          name: { format: String, default: '', env: 'TEST_ISSUER_NAME' },
-        },
-      },
-    });
-
-    expect(bindings).toEqual([
-      { envVar: 'TEST_PORT', path: 'port' },
-      { envVar: 'TEST_SECRET', path: 'openId.client_secret' },
-      { envVar: 'TEST_ISSUER_NAME', path: 'openId.issuer.name' },
-    ]);
-  });
-
-  it('treats a setting named "env" as a setting, not as a convict keyword', () => {
-    // The real schema has a top-level `env` setting bound to NODE_ENV, which
-    // must not be confused with the `env` keyword of a setting definition.
-    const bindings = collectEnvVarBindings({
-      env: {
-        doc: 'The application environment.',
-        format: ['production', 'development', 'test'],
-        default: 'development',
-        env: 'NODE_ENV',
-      },
-    });
-
-    expect(bindings).toEqual([{ envVar: 'NODE_ENV', path: 'env' }]);
-  });
-
-  it('ignores settings that are not bound to an environment variable', () => {
-    const bindings = collectEnvVarBindings({
-      projectRoot: { doc: 'Project root.', format: String, default: '/app' },
-    });
-
-    expect(bindings).toEqual([]);
-  });
-
-  it('does not descend into object-valued convict keywords', () => {
-    const bindings = collectEnvVarBindings({
-      group: {
-        doc: 'A group whose default is an object.',
-        nested: {
-          format: Object,
-          default: { env: 'NOT_A_SETTING' },
-          env: 'TEST_NESTED',
-        },
-      },
-    });
-
-    expect(bindings).toEqual([{ envVar: 'TEST_NESTED', path: 'group.nested' }]);
-  });
-});
-
-describe('applyFileEnvOverrides', () => {
+describe('config file env', () => {
   let dir: string;
 
   const buildSchema = () =>
     convict({
-      port: { doc: 'Port', format: 'port', default: 5006, env: 'TEST_PORT' },
       openId: {
         doc: 'OpenID settings.',
         client_secret: {
@@ -101,108 +37,89 @@ describe('applyFileEnvOverrides', () => {
     rmSync(dir, { recursive: true, force: true });
   });
 
-  it('reads the value from the file named by <VAR>_FILE', () => {
-    const config = buildSchema();
-    const filePath = writeSecret('secret', 'from-file');
+  describe('readFileEnv', () => {
+    it('reads the contents of the file the variable points at', () => {
+      const filePath = writeSecret('secret', 'from-file');
 
-    const applied = applyFileEnvOverrides(
-      config,
-      [{ envVar: 'TEST_SECRET', path: 'openId.client_secret' }],
-      { TEST_SECRET_FILE: filePath },
-    );
-
-    expect(config.get('openId.client_secret')).toBe('from-file');
-    expect(applied).toEqual([
-      {
-        envVar: 'TEST_SECRET',
-        path: 'openId.client_secret',
-        filePath,
-        value: 'from-file',
-        supersededEnvVar: false,
-      },
-    ]);
-  });
-
-  it('trims surrounding whitespace from the file value', () => {
-    const config = buildSchema();
-    const filePath = writeSecret('secret', '  from-file\n');
-
-    applyFileEnvOverrides(
-      config,
-      [{ envVar: 'TEST_SECRET', path: 'openId.client_secret' }],
-      { TEST_SECRET_FILE: filePath },
-    );
-
-    expect(config.get('openId.client_secret')).toBe('from-file');
-  });
-
-  it('takes precedence over the plain environment variable', () => {
-    const config = buildSchema();
-    const filePath = writeSecret('secret', 'from-file');
-
-    // convict has already imported TEST_SECRET at this point, exactly as it
-    // would at startup.
-    config.set('openId.client_secret', 'from-env');
-
-    const applied = applyFileEnvOverrides(
-      config,
-      [{ envVar: 'TEST_SECRET', path: 'openId.client_secret' }],
-      { TEST_SECRET: 'from-env', TEST_SECRET_FILE: filePath },
-    );
-
-    expect(config.get('openId.client_secret')).toBe('from-file');
-    expect(applied[0].supersededEnvVar).toBe(true);
-  });
-
-  it('leaves settings alone when no _FILE variable is set', () => {
-    const config = buildSchema();
-
-    const applied = applyFileEnvOverrides(
-      config,
-      [{ envVar: 'TEST_SECRET', path: 'openId.client_secret' }],
-      {},
-    );
-
-    expect(applied).toEqual([]);
-    expect(config.get('openId.client_secret')).toBe('');
-  });
-
-  it('coerces values for non-string formats', () => {
-    const config = buildSchema();
-    const filePath = writeSecret('port', '1234\n');
-
-    applyFileEnvOverrides(config, [{ envVar: 'TEST_PORT', path: 'port' }], {
-      TEST_PORT_FILE: filePath,
+      expect(
+        readFileEnv('TEST_SECRET_FILE', { TEST_SECRET_FILE: filePath }),
+      ).toBe('from-file');
     });
 
-    expect(config.get('port')).toBe(1234);
-    expect(() => config.validate({ allowed: 'strict' })).not.toThrow();
+    it('trims surrounding whitespace from the file value', () => {
+      const filePath = writeSecret('secret', '  from-file\n');
+
+      expect(
+        readFileEnv('TEST_SECRET_FILE', { TEST_SECRET_FILE: filePath }),
+      ).toBe('from-file');
+    });
+
+    it('returns undefined when the variable is not set', () => {
+      expect(readFileEnv('TEST_SECRET_FILE', {})).toBeUndefined();
+    });
+
+    it('throws when the file cannot be read, naming the variable and path', () => {
+      const missing = join(dir, 'does-not-exist');
+
+      expect(() =>
+        readFileEnv('TEST_SECRET_FILE', { TEST_SECRET_FILE: missing }),
+      ).toThrow(`Could not read TEST_SECRET_FILE from '${missing}'`);
+    });
+
+    it('throws when the variable is set but empty', () => {
+      // An empty value means a mount that did not produce a path. Falling back
+      // to the plain variable here would hide the misconfiguration.
+      expect(() =>
+        readFileEnv('TEST_SECRET_FILE', { TEST_SECRET_FILE: '' }),
+      ).toThrow('Could not read TEST_SECRET_FILE');
+    });
   });
 
-  it('throws when the _FILE variable is set but empty', () => {
-    const config = buildSchema();
+  describe('applyFileEnv', () => {
+    it('sets the value on the config and reports that it applied', () => {
+      const config = buildSchema();
+      const filePath = writeSecret('secret', 'from-file');
 
-    // An empty value means a mount that did not produce a path. Falling back
-    // to the plain variable here would hide the misconfiguration.
-    expect(() =>
-      applyFileEnvOverrides(
+      const applied = applyFileEnv(
         config,
-        [{ envVar: 'TEST_SECRET', path: 'openId.client_secret' }],
-        { TEST_SECRET: 'from-env', TEST_SECRET_FILE: '' },
-      ),
-    ).toThrow('Could not read TEST_SECRET_FILE');
-  });
+        'TEST_SECRET_FILE',
+        'openId.client_secret',
+        { TEST_SECRET_FILE: filePath },
+      );
 
-  it('throws when the file cannot be read, naming the variable and path', () => {
-    const config = buildSchema();
-    const missing = join(dir, 'does-not-exist');
+      expect(applied).toBe(true);
+      expect(config.get('openId.client_secret')).toBe('from-file');
+    });
 
-    expect(() =>
-      applyFileEnvOverrides(
+    it('takes precedence over the plain environment variable', () => {
+      const config = buildSchema();
+      const filePath = writeSecret('secret', 'from-file');
+
+      // convict has already imported TEST_SECRET at this point, exactly as it
+      // would at startup.
+      config.set('openId.client_secret', 'from-env');
+
+      applyFileEnv(config, 'TEST_SECRET_FILE', 'openId.client_secret', {
+        TEST_SECRET: 'from-env',
+        TEST_SECRET_FILE: filePath,
+      });
+
+      expect(config.get('openId.client_secret')).toBe('from-file');
+    });
+
+    it('leaves the setting alone when the variable is not set', () => {
+      const config = buildSchema();
+
+      const applied = applyFileEnv(
         config,
-        [{ envVar: 'TEST_SECRET', path: 'openId.client_secret' }],
-        { TEST_SECRET_FILE: missing },
-      ),
-    ).toThrow(`Could not read TEST_SECRET_FILE from '${missing}'`);
+        'TEST_SECRET_FILE',
+        'openId.client_secret',
+        {},
+      );
+
+      expect(applied).toBe(false);
+      expect(config.get('openId.client_secret')).toBe('');
+      expect(() => config.validate({ allowed: 'strict' })).not.toThrow();
+    });
   });
 });

--- a/packages/sync-server/src/config-file-env.ts
+++ b/packages/sync-server/src/config-file-env.ts
@@ -1,0 +1,130 @@
+import fs from 'node:fs';
+
+/**
+ * Suffix appended to an environment variable name to read its value from a
+ * file instead. This is the convention used by Docker secrets and Kubernetes
+ * file-mounted secrets, and lets deployments keep secrets out of the process
+ * environment entirely.
+ */
+export const FILE_ENV_SUFFIX = '_FILE';
+
+type SchemaNode = Record<string, unknown>;
+
+export type EnvVarBinding = {
+  /** The environment variable convict reads this setting from. */
+  envVar: string;
+  /** Dotted convict path, e.g. `openId.client_secret`. */
+  path: string;
+};
+
+export type AppliedOverride = EnvVarBinding & {
+  /** Path of the file the value was read from. */
+  filePath: string;
+  /** The value read from the file, already trimmed. */
+  value: string;
+  /**
+   * Whether the plain environment variable was also set, and so has been
+   * superseded by the file.
+   */
+  supersededEnvVar: boolean;
+};
+
+/** Minimal shape of a convict config; avoids depending on convict's types. */
+type ConfigSchema = {
+  set(path: string, value: unknown): unknown;
+};
+
+function isPlainObject(value: unknown): value is SchemaNode {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Whether a schema node describes a single setting rather than a group of
+ * them. This mirrors convict's own rule in `normalizeSchema`: a non-empty
+ * plain object without a `default` is a group, and anything else is a setting.
+ *
+ * Keying off `default` rather than off reserved key names matters, because the
+ * schema has a setting literally named `env` (bound to `NODE_ENV`), which a
+ * keyword-based check would skip.
+ */
+function isSettingDefinition(node: SchemaNode): boolean {
+  return Object.keys(node).length === 0 || 'default' in node;
+}
+
+/**
+ * Walks a convict schema definition and returns every setting that is bound to
+ * an environment variable, paired with its dotted path.
+ */
+export function collectEnvVarBindings(schema: SchemaNode): EnvVarBinding[] {
+  const bindings: EnvVarBinding[] = [];
+
+  function walk(group: SchemaNode, path: string) {
+    for (const [key, value] of Object.entries(group)) {
+      // Skips a group's own `doc` string, and a setting's `format` array or
+      // constructor — neither is a nested setting.
+      if (!isPlainObject(value)) continue;
+
+      const childPath = path ? `${path}.${key}` : key;
+
+      if (!isSettingDefinition(value)) {
+        walk(value, childPath);
+      } else if (typeof value.env === 'string') {
+        bindings.push({ envVar: value.env, path: childPath });
+      }
+    }
+  }
+
+  walk(schema, '');
+
+  return bindings;
+}
+
+/**
+ * Applies `<VAR>_FILE` overrides onto a convict config.
+ *
+ * Must be called *after* `loadFile()` and *before* `validate()`. convict
+ * re-imports the environment at the end of both `load()` and `loadFile()`, so
+ * anything applied earlier would be clobbered by the plain environment
+ * variable; `set()` is not re-imported and therefore wins.
+ *
+ * Throws if a `_FILE` variable points at something unreadable, rather than
+ * silently falling back to an empty value — a secret that failed to mount
+ * should stop startup, not produce a server running with broken auth.
+ */
+export function applyFileEnvOverrides(
+  config: ConfigSchema,
+  bindings: EnvVarBinding[],
+  env: NodeJS.ProcessEnv = process.env,
+): AppliedOverride[] {
+  const applied: AppliedOverride[] = [];
+
+  for (const binding of bindings) {
+    const fileEnvVar = `${binding.envVar}${FILE_ENV_SUFFIX}`;
+    const filePath = env[fileEnvVar];
+
+    if (!filePath) continue;
+
+    let value;
+    try {
+      // Read directly rather than checking existence first, so a file removed
+      // in between cannot slip past as a missing value.
+      value = fs.readFileSync(filePath, 'utf8').trim();
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error);
+      throw new Error(
+        `Could not read ${fileEnvVar} from '${filePath}': ${reason}`,
+      );
+    }
+
+    config.set(binding.path, value);
+
+    applied.push({
+      ...binding,
+      filePath,
+      value,
+      supersededEnvVar: env[binding.envVar] !== undefined,
+    });
+  }
+
+  return applied;
+}

--- a/packages/sync-server/src/config-file-env.ts
+++ b/packages/sync-server/src/config-file-env.ts
@@ -7,12 +7,7 @@ type ConfigSchema = {
 
 /**
  * Reads the value of a `<VAR>_FILE` environment variable, returning the
- * contents of the file it points at.
- *
- * Only an unset variable returns undefined. A variable that is set but
- * unreadable — including an empty value, which means a mount produced no
- * path — throws, because a secret that failed to mount should stop startup
- * rather than leave the server running with an empty value.
+ * contents of the file it points at and throwing if the file is not accessible.
  */
 export function readFileEnv(
   fileEnvVar: string,
@@ -35,11 +30,6 @@ export function readFileEnv(
 /**
  * Applies a `<VAR>_FILE` override onto a convict setting, returning whether
  * one was applied.
- *
- * Must be called *after* `loadFile()` and *before* `validate()`. convict
- * re-imports the environment at the end of both `load()` and `loadFile()`, so
- * an override applied any earlier would be clobbered by the plain environment
- * variable; `set()` is not re-imported and therefore wins.
  */
 export function applyFileEnv(
   config: ConfigSchema,

--- a/packages/sync-server/src/config-file-env.ts
+++ b/packages/sync-server/src/config-file-env.ts
@@ -1,132 +1,57 @@
 import fs from 'node:fs';
 
-/**
- * Suffix appended to an environment variable name to read its value from a
- * file instead. This is the convention used by Docker secrets and Kubernetes
- * file-mounted secrets, and lets deployments keep secrets out of the process
- * environment entirely.
- */
-export const FILE_ENV_SUFFIX = '_FILE';
-
-type SchemaNode = Record<string, unknown>;
-
-export type EnvVarBinding = {
-  /** The environment variable convict reads this setting from. */
-  envVar: string;
-  /** Dotted convict path, e.g. `openId.client_secret`. */
-  path: string;
-};
-
-export type AppliedOverride = EnvVarBinding & {
-  /** Path of the file the value was read from. */
-  filePath: string;
-  /** The value read from the file, already trimmed. */
-  value: string;
-  /**
-   * Whether the plain environment variable was also set, and so has been
-   * superseded by the file.
-   */
-  supersededEnvVar: boolean;
-};
-
 /** Minimal shape of a convict config; avoids depending on convict's types. */
 type ConfigSchema = {
   set(path: string, value: unknown): unknown;
 };
 
-function isPlainObject(value: unknown): value is SchemaNode {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
-
 /**
- * Whether a schema node describes a single setting rather than a group of
- * them. This mirrors convict's own rule in `normalizeSchema`: a non-empty
- * plain object without a `default` is a group, and anything else is a setting.
+ * Reads the value of a `<VAR>_FILE` environment variable, returning the
+ * contents of the file it points at.
  *
- * Keying off `default` rather than off reserved key names matters, because the
- * schema has a setting literally named `env` (bound to `NODE_ENV`), which a
- * keyword-based check would skip.
+ * Only an unset variable returns undefined. A variable that is set but
+ * unreadable — including an empty value, which means a mount produced no
+ * path — throws, because a secret that failed to mount should stop startup
+ * rather than leave the server running with an empty value.
  */
-function isSettingDefinition(node: SchemaNode): boolean {
-  return Object.keys(node).length === 0 || 'default' in node;
-}
+export function readFileEnv(
+  fileEnvVar: string,
+  env: NodeJS.ProcessEnv = process.env,
+): string | undefined {
+  const filePath = env[fileEnvVar];
 
-/**
- * Walks a convict schema definition and returns every setting that is bound to
- * an environment variable, paired with its dotted path.
- */
-export function collectEnvVarBindings(schema: SchemaNode): EnvVarBinding[] {
-  const bindings: EnvVarBinding[] = [];
+  if (filePath === undefined) return undefined;
 
-  function walk(group: SchemaNode, path: string) {
-    for (const [key, value] of Object.entries(group)) {
-      // Skips a group's own `doc` string, and a setting's `format` array or
-      // constructor — neither is a nested setting.
-      if (!isPlainObject(value)) continue;
-
-      const childPath = path ? `${path}.${key}` : key;
-
-      if (!isSettingDefinition(value)) {
-        walk(value, childPath);
-      } else if (typeof value.env === 'string') {
-        bindings.push({ envVar: value.env, path: childPath });
-      }
-    }
+  try {
+    return fs.readFileSync(filePath, 'utf8').trim();
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `Could not read ${fileEnvVar} from '${filePath}': ${reason}`,
+    );
   }
-
-  walk(schema, '');
-
-  return bindings;
 }
 
 /**
- * Applies `<VAR>_FILE` overrides onto a convict config.
+ * Applies a `<VAR>_FILE` override onto a convict setting, returning whether
+ * one was applied.
  *
  * Must be called *after* `loadFile()` and *before* `validate()`. convict
  * re-imports the environment at the end of both `load()` and `loadFile()`, so
- * anything applied earlier would be clobbered by the plain environment
+ * an override applied any earlier would be clobbered by the plain environment
  * variable; `set()` is not re-imported and therefore wins.
- *
- * Throws if a `_FILE` variable points at something unreadable, rather than
- * silently falling back to an empty value — a secret that failed to mount
- * should stop startup, not produce a server running with broken auth.
  */
-export function applyFileEnvOverrides(
+export function applyFileEnv(
   config: ConfigSchema,
-  bindings: EnvVarBinding[],
+  fileEnvVar: string,
+  path: string,
   env: NodeJS.ProcessEnv = process.env,
-): AppliedOverride[] {
-  const applied: AppliedOverride[] = [];
+): boolean {
+  const value = readFileEnv(fileEnvVar, env);
 
-  for (const binding of bindings) {
-    const fileEnvVar = `${binding.envVar}${FILE_ENV_SUFFIX}`;
-    const filePath = env[fileEnvVar];
+  if (value === undefined) return false;
 
-    // Only an unset variable is skipped. An empty value is a misconfigured
-    // mount, and must fail rather than silently leave the setting untouched.
-    if (filePath === undefined) continue;
+  config.set(path, value);
 
-    let value;
-    try {
-      // Read directly rather than checking existence first, so a file removed
-      // in between cannot slip past as a missing value.
-      value = fs.readFileSync(filePath, 'utf8').trim();
-    } catch (error) {
-      const reason = error instanceof Error ? error.message : String(error);
-      throw new Error(
-        `Could not read ${fileEnvVar} from '${filePath}': ${reason}`,
-      );
-    }
-
-    config.set(binding.path, value);
-
-    applied.push({
-      ...binding,
-      filePath,
-      value,
-      supersededEnvVar: env[binding.envVar] !== undefined,
-    });
-  }
-
-  return applied;
+  return true;
 }

--- a/packages/sync-server/src/config-file-env.ts
+++ b/packages/sync-server/src/config-file-env.ts
@@ -102,7 +102,9 @@ export function applyFileEnvOverrides(
     const fileEnvVar = `${binding.envVar}${FILE_ENV_SUFFIX}`;
     const filePath = env[fileEnvVar];
 
-    if (!filePath) continue;
+    // Only an unset variable is skipped. An empty value is a misconfigured
+    // mount, and must fail rather than silently leave the setting untouched.
+    if (filePath === undefined) continue;
 
     let value;
     try {

--- a/packages/sync-server/src/load-config-file-env.test.ts
+++ b/packages/sync-server/src/load-config-file-env.test.ts
@@ -1,0 +1,38 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import type { config as loadedConfig } from './load-config';
+
+// load-config reads the environment when it is first imported, so the
+// environment has to be set up before importing it.
+describe('load-config _FILE overrides', () => {
+  let dir: string;
+  let config: typeof loadedConfig;
+
+  beforeAll(async () => {
+    dir = mkdtempSync(join(tmpdir(), 'actual-load-config-'));
+
+    const secretPath = join(dir, 'client-secret');
+    writeFileSync(secretPath, 'secret-from-file\n');
+
+    process.env.ACTUAL_OPENID_CLIENT_SECRET_FILE = secretPath;
+    // Also set the plain variable, which convict imports at construction time
+    // and re-imports at the end of loadFile. The file must still win.
+    process.env.ACTUAL_OPENID_CLIENT_SECRET = 'secret-from-env';
+
+    ({ config } = await import('./load-config'));
+  });
+
+  afterAll(() => {
+    delete process.env.ACTUAL_OPENID_CLIENT_SECRET_FILE;
+    delete process.env.ACTUAL_OPENID_CLIENT_SECRET;
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('loads the secret from the file, superseding the plain variable', () => {
+    expect(config.get('openId.client_secret')).toBe('secret-from-file');
+  });
+});

--- a/packages/sync-server/src/load-config-file-env.test.ts
+++ b/packages/sync-server/src/load-config-file-env.test.ts
@@ -9,13 +9,13 @@ import type { config as loadedConfig } from './load-config';
 // load-config reads the environment when it is first imported, so the
 // environment has to be set up before importing it.
 describe('load-config _FILE overrides', () => {
-  let dir: string;
+  let secretDirectory: string;
   let config: typeof loadedConfig;
 
   beforeAll(async () => {
-    dir = mkdtempSync(join(tmpdir(), 'actual-load-config-'));
+    secretDirectory = mkdtempSync(join(tmpdir(), 'actual-load-config-'));
 
-    const secretPath = join(dir, 'client-secret');
+    const secretPath = join(secretDirectory, 'client-secret');
     writeFileSync(secretPath, 'secret-from-file\n');
 
     process.env.ACTUAL_OPENID_CLIENT_SECRET_FILE = secretPath;
@@ -29,7 +29,7 @@ describe('load-config _FILE overrides', () => {
   afterAll(() => {
     delete process.env.ACTUAL_OPENID_CLIENT_SECRET_FILE;
     delete process.env.ACTUAL_OPENID_CLIENT_SECRET;
-    rmSync(dir, { recursive: true, force: true });
+    rmSync(secretDirectory, { recursive: true, force: true });
   });
 
   it('loads the secret from the file, superseding the plain variable', () => {

--- a/packages/sync-server/src/load-config.js
+++ b/packages/sync-server/src/load-config.js
@@ -324,9 +324,6 @@ if (fs.existsSync(configPath)) {
 
 // `<VAR>_FILE` is applied after loadFile so it beats both config.json and the
 // plain environment variable, and before validate so the value is checked.
-// Only secrets get a _FILE variant, following the Docker secrets convention.
-// ACTUAL_HTTPS_KEY and ACTUAL_HTTPS_CERT already accept a path, so they are
-// deliberately absent.
 for (const [fileEnvVar, settingPath] of [
   ['ACTUAL_OPENID_CLIENT_SECRET_FILE', 'openId.client_secret'],
   ['ACTUAL_GITHUB_TOKEN_FILE', 'github.token'],

--- a/packages/sync-server/src/load-config.js
+++ b/packages/sync-server/src/load-config.js
@@ -6,11 +6,7 @@ import { fileURLToPath } from 'node:url';
 import convict from 'convict';
 import createDebug from 'debug';
 
-import {
-  applyFileEnvOverrides,
-  collectEnvVarBindings,
-  FILE_ENV_SUFFIX,
-} from './config-file-env';
+import { applyFileEnv } from './config-file-env';
 
 const require = createRequire(import.meta.url);
 const debug = createDebug('actual:config');
@@ -65,7 +61,7 @@ convict.addFormat({
 });
 
 // Main config schema
-const configSchemaDefinition = {
+const configSchema = convict({
   env: {
     doc: 'The application environment.',
     format: ['production', 'development', 'test'],
@@ -302,9 +298,7 @@ const configSchemaDefinition = {
       env: 'ACTUAL_CORS_PROXY_ENABLED',
     },
   },
-};
-
-const configSchema = convict(configSchemaDefinition);
+});
 
 let configPath = null;
 
@@ -328,20 +322,17 @@ if (fs.existsSync(configPath)) {
   debug(`Config loaded`);
 }
 
-// Applied after loadFile so that `<VAR>_FILE` beats both config.json and the
-// plain environment variable, and before validate so the values are checked.
-for (const override of applyFileEnvOverrides(
-  configSchema,
-  collectEnvVarBindings(configSchemaDefinition),
-)) {
-  debug(
-    `Loaded ${override.envVar}${FILE_ENV_SUFFIX} -> ${override.path} from '${override.filePath}'`,
-  );
-
-  if (override.supersededEnvVar) {
-    debug(
-      `${override.envVar}${FILE_ENV_SUFFIX} takes precedence over ${override.envVar}`,
-    );
+// `<VAR>_FILE` is applied after loadFile so it beats both config.json and the
+// plain environment variable, and before validate so the value is checked.
+// Only secrets get a _FILE variant, following the Docker secrets convention.
+// ACTUAL_HTTPS_KEY and ACTUAL_HTTPS_CERT already accept a path, so they are
+// deliberately absent.
+for (const [fileEnvVar, settingPath] of [
+  ['ACTUAL_OPENID_CLIENT_SECRET_FILE', 'openId.client_secret'],
+  ['ACTUAL_GITHUB_TOKEN_FILE', 'github.token'],
+]) {
+  if (applyFileEnv(configSchema, fileEnvVar, settingPath)) {
+    debug(`Loaded ${settingPath} from ${fileEnvVar}`);
   }
 }
 

--- a/packages/sync-server/src/load-config.js
+++ b/packages/sync-server/src/load-config.js
@@ -6,6 +6,12 @@ import { fileURLToPath } from 'node:url';
 import convict from 'convict';
 import createDebug from 'debug';
 
+import {
+  applyFileEnvOverrides,
+  collectEnvVarBindings,
+  FILE_ENV_SUFFIX,
+} from './config-file-env';
+
 const require = createRequire(import.meta.url);
 const debug = createDebug('actual:config');
 const debugSensitive = createDebug('actual-sensitive:config');
@@ -59,7 +65,7 @@ convict.addFormat({
 });
 
 // Main config schema
-const configSchema = convict({
+const configSchemaDefinition = {
   env: {
     doc: 'The application environment.',
     format: ['production', 'development', 'test'],
@@ -296,7 +302,9 @@ const configSchema = convict({
       env: 'ACTUAL_CORS_PROXY_ENABLED',
     },
   },
-});
+};
+
+const configSchema = convict(configSchemaDefinition);
 
 let configPath = null;
 
@@ -318,6 +326,23 @@ if (process.env.ACTUAL_CONFIG_PATH) {
 if (fs.existsSync(configPath)) {
   configSchema.loadFile(configPath);
   debug(`Config loaded`);
+}
+
+// Applied after loadFile so that `<VAR>_FILE` beats both config.json and the
+// plain environment variable, and before validate so the values are checked.
+for (const override of applyFileEnvOverrides(
+  configSchema,
+  collectEnvVarBindings(configSchemaDefinition),
+)) {
+  debug(
+    `Loaded ${override.envVar}${FILE_ENV_SUFFIX} -> ${override.path} from '${override.filePath}'`,
+  );
+
+  if (override.supersededEnvVar) {
+    debug(
+      `${override.envVar}${FILE_ENV_SUFFIX} takes precedence over ${override.envVar}`,
+    );
+  }
 }
 
 debug(`Validating config`);

--- a/upcoming-release-notes/support-file-mounted-secrets.md
+++ b/upcoming-release-notes/support-file-mounted-secrets.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [ColinHebert]
+---
+
+Allow any server or CLI setting to be read from a file by adding a `_FILE` suffix to its environment variable, so secrets can be mounted as files instead of being passed in the environment

--- a/upcoming-release-notes/support-file-mounted-secrets.md
+++ b/upcoming-release-notes/support-file-mounted-secrets.md
@@ -3,4 +3,4 @@ category: Enhancements
 authors: [ColinHebert]
 ---
 
-Allow any server or CLI setting to be read from a file by adding a `_FILE` suffix to its environment variable, so secrets can be mounted as files instead of being passed in the environment
+Settings that use environment variables can now load their values from a file instead, so secrets can be mounted rather than passed in the environment

--- a/upcoming-release-notes/support-file-mounted-secrets.md
+++ b/upcoming-release-notes/support-file-mounted-secrets.md
@@ -3,4 +3,4 @@ category: Enhancements
 authors: [ColinHebert]
 ---
 
-Settings that use environment variables can now load their values from a file instead, so secrets can be mounted rather than passed in the environment
+Secrets can now be read from a file instead of being passed in an environment variable


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

Actual has no way to read a setting from a file, so secrets like `ACTUAL_OPENID_CLIENT_SECRET` and `ACTUAL_PASSWORD` have to be passed as plain environment variables. In Docker and Kubernetes that means the secret gets written into a deployment manifest (and into etcd) and can be read back out of the running container. The usual convention for avoiding this is a `_FILE` suffix, which Actual doesn't support.

This adds that convention: set `<VAR>_FILE` to a path and Actual reads the value from that file. It applies to every setting already bound to an environment variable, in both config systems — the sync server's convict schema and the CLI's own resolution chain.

Two behaviours worth calling out for review:

- Precedence is `<VAR>_FILE` > `<VAR>` > `config.json` > default. On the sync server this requires the override to run after `loadFile()` and before `validate()`, using `set()`, because convict re-imports the environment at the end of both `load()` and `loadFile()`. There's a test pinning this.
- A `_FILE` pointing at an unreadable file is a hard error rather than a silent fallback. A secret that failed to mount should stop startup, not leave a server running with empty auth.

AI disclosure: this change was written with Claude Code (Claude Opus 5), and reviewed by me before submitting.

<!-- If AI tools wrote a significant part of this change, please disclose it here and name the tool you used. See https://actualbudget.org/docs/contributing/ai-usage-policy -->

## Related issue(s)

Relates to #5233 and #7686.

- #5233 asked for `ACTUAL_OPENID_CLIENT_SECRET` to be settable from a file. @jfdoming replied there that ideally we'd support `_FILE` for all config parameters, and that a contribution would be welcome.
- #7686 asked for general `_FILE` suffix support for environment variables.

Previous attempt: #5235. That PR was approved by @matt-fidd but was closed without being merged. This one differs in two ways:

1. It only covered the OpenID client secret, whereas this covers every env-bound setting in both the sync server and the CLI.
2. It called `configSchema.set()` *before* `loadFile()`. Since convict re-imports the environment at the end of both `load()` and `loadFile()`, the file value was clobbered whenever the plain environment variable was also set — the opposite of the precedence its description claimed. This PR applies the override after `loadFile()` and before `validate()`, with a test pinning that ordering.

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->
Automated (all run locally, in a container matching the repo's Dockerfile):

- 17 new tests: schema-walking and override behaviour, precedence when both the plain and `_FILE` variables are set, whitespace trimming, type coercion for non-string settings, and the error on an unreadable file.
- One end-to-end test against the real sync-server schema that sets both `ACTUAL_OPENID_CLIENT_SECRET` and `ACTUAL_OPENID_CLIENT_SECRET_FILE` and asserts the file wins — this is the case the ordering above exists for.
- Full suites pass: sync-server 606 tests, CLI 182 tests.
- `yarn typecheck` clean for both packages; oxlint (`--type-aware`) and oxfmt clean; the Docusaurus build passes, which validates the new doc anchors.

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->


<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 42 | 13.63 MB → 13.64 MB (+5.5 kB) | +0.04%
loot-core | 1 | 4.64 MB | 0%
api | 2 | 3.85 MB | 0%
cli | 1 | 8.02 MB → 8.02 MB (+647 B) | +0.01%
crdt | 1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
42 | 13.63 MB → 13.64 MB (+5.5 kB) | +0.04%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/reports/dateRangePresets.ts` | 🆕 +3.2 kB | 0 B → 3.2 kB
`src/components/reports/monthRange.ts` | 🆕 +441 B | 0 B → 441 B
`src/components/reports/reports/monte-carlo/MonteCarloPotConfiguration.tsx` | 📈 +5.62 kB (+42.30%) | 13.29 kB → 18.91 kB
`src/components/reports/reports/monte-carlo/MonteCarloPotsTableHeader.tsx` | 📈 +1.2 kB (+20.79%) | 5.76 kB → 6.96 kB
`src/components/reports/reports/monte-carlo/monteCarloSimulation.ts` | 📈 +1.4 kB (+4.40%) | 31.73 kB → 33.13 kB
`package.json` | 📈 +166 B (+1.56%) | 10.42 kB → 10.58 kB
`src/components/formula/QueryManager.tsx` | 📉 -3.15 kB (-12.23%) | 25.77 kB → 22.61 kB
`src/components/reports/Header.tsx` | 📉 -3.35 kB (-29.63%) | 11.3 kB → 7.95 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/ReportRouter.js | 1.44 MB → 1.45 MB (+5.34 kB) | +0.36%
static/js/index.js | 1.6 MB → 1.6 MB (+166 B) | +0.01%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/DateSelect.js | 2.37 MB | 0%
static/js/FormulaEditor.js | 766.35 kB | 0%
static/js/ManageRules.js | 71.66 kB | 0%
static/js/NotesTagFormatter.js | 25.94 kB | 0%
static/js/PayeeRuleCountLabel.js | 12.81 kB | 0%
static/js/ScheduleEditForm.js | 75.41 kB | 0%
static/js/SchedulesTable.js | 171.25 kB | 0%
static/js/TourHost.js | 169.22 kB | 0%
static/js/TourProvider.js | 1.54 kB | 0%
static/js/TransactionEdit.js | 221.38 kB | 0%
static/js/TransactionList.js | 166.98 kB | 0%
static/js/Value.js | 1.79 MB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/ca.js | 170.64 kB | 0%
static/js/client.js | 452.05 kB | 0%
static/js/columns.js | 673.28 kB | 0%
static/js/de.js | 186.5 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/en.js | 245.91 kB | 0%
static/js/es.js | 164.81 kB | 0%
static/js/fr.js | 179.04 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 151.67 kB | 0%
static/js/months.js | 574.72 kB | 0%
static/js/narrow.js | 290.52 kB | 0%
static/js/nb-NO.js | 135.46 kB | 0%
static/js/nl.js | 151.78 kB | 0%
static/js/pl.js | 136.39 kB | 0%
static/js/pt-BR.js | 178.2 kB | 0%
static/js/ru.js | 212.8 kB | 0%
static/js/theme.js | 31.1 kB | 0%
static/js/uk.js | 201.42 kB | 0%
static/js/useFormatList.js | 10.22 kB | 0%
static/js/useLocalPref.js | 97.2 kB | 0%
static/js/useReducedMotion.js | 594 B | 0%
static/js/wide.js | 274.53 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 106.8 kB | 0%
static/js/zh-Hant.js | 130.92 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.64 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.BB37DR43.js | 4.64 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.85 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.85 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB → 8.02 MB (+647 B) | +0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/config.ts` | 📈 +647 B (+17.73%) | 3.56 kB → 4.2 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB → 8.02 MB (+647 B) | +0.01%

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.16 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->