### PR TITLE
[WIP] [AI] Do not trim or upper-case a category name that a partial update omits

### DIFF
--- a/packages/loot-core/src/server/budget/app.test.ts
+++ b/packages/loot-core/src/server/budget/app.test.ts
@@ -16,12 +16,12 @@ describe('category-update', () => {
     // caller changing only the group never sends `name`. Trimming it
     // unconditionally raised "Cannot read properties of undefined (reading
     // 'trim')" for every such update.
-    await expect(
-      app.handlers['category-update']({
-        id: 'category-id',
-        group: 'new-group-id',
-      } as Parameters<(typeof app.handlers)['category-update']>[0]),
-    ).resolves.not.toThrow();
+    // A rejection here is the regression; the assertions below prove what
+    // reached the database.
+    await app.handlers['category-update']({
+      id: 'category-id',
+      group: 'new-group-id',
+    } as Parameters<(typeof app.handlers)['category-update']>[0]);
 
     // db.update() writes only the keys it is handed, so `name` must be absent
     // rather than present-and-undefined, which would blank the column.
@@ -31,12 +31,10 @@ describe('category-update', () => {
   });
 
   it('still trims a name when one is supplied', async () => {
-    await expect(
-      app.handlers['category-update']({
-        id: 'category-id',
-        name: '  Groceries  ',
-      } as Parameters<(typeof app.handlers)['category-update']>[0]),
-    ).resolves.not.toThrow();
+    await app.handlers['category-update']({
+      id: 'category-id',
+      name: '  Groceries  ',
+    } as Parameters<(typeof app.handlers)['category-update']>[0]);
 
     const [updated] = vi.mocked(db.updateCategory).mock.calls[0];
     expect(updated).toMatchObject({ name: 'Groceries' });

--- a/packages/loot-core/src/server/budget/app.test.ts
+++ b/packages/loot-core/src/server/budget/app.test.ts
@@ -1,0 +1,44 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import * as db from '#server/db';
+
+import { app } from './app';
+
+vi.mock('#server/db');
+
+describe('category-update', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('does not require a name, since the API types fields as a Partial', async () => {
+    // api/category-update spreads the caller's partial straight through, so a
+    // caller changing only the group never sends `name`. Trimming it
+    // unconditionally raised "Cannot read properties of undefined (reading
+    // 'trim')" for every such update.
+    await expect(
+      app.handlers['category-update']({
+        id: 'category-id',
+        group: 'new-group-id',
+      } as Parameters<(typeof app.handlers)['category-update']>[0]),
+    ).resolves.not.toThrow();
+
+    // db.update() writes only the keys it is handed, so `name` must be absent
+    // rather than present-and-undefined, which would blank the column.
+    const [updated] = vi.mocked(db.updateCategory).mock.calls[0];
+    expect(updated).not.toHaveProperty('name');
+    expect(updated).toMatchObject({ cat_group: 'new-group-id' });
+  });
+
+  it('still trims a name when one is supplied', async () => {
+    await expect(
+      app.handlers['category-update']({
+        id: 'category-id',
+        name: '  Groceries  ',
+      } as Parameters<(typeof app.handlers)['category-update']>[0]),
+    ).resolves.not.toThrow();
+
+    const [updated] = vi.mocked(db.updateCategory).mock.calls[0];
+    expect(updated).toMatchObject({ name: 'Groceries' });
+  });
+});

--- a/packages/loot-core/src/server/budget/app.ts
+++ b/packages/loot-core/src/server/budget/app.ts
@@ -334,7 +334,10 @@ async function updateCategory(category: CategoryEntity): Promise<void> {
     await db.updateCategory(
       categoryModel.toDb({
         ...category,
-        name: category.name.trim(),
+        // The API types `fields` as a Partial, and db.update() only writes the
+        // keys it is given, so a partial that omits `name` must stay omitted
+        // rather than being trimmed into a TypeError.
+        ...(category.name !== undefined && { name: category.name.trim() }),
       }),
     );
   } catch (e) {

--- a/packages/loot-core/src/server/db/index.test.ts
+++ b/packages/loot-core/src/server/db/index.test.ts
@@ -353,9 +353,9 @@ describe('Database', () => {
       // .toUpperCase() on it unconditionally.
       const id = await db.insertCategoryGroup({ name: 'Bills' });
 
-      await expect(
-        db.updateCategoryGroup({ id, is_income: 0, hidden: 1 }),
-      ).resolves.not.toThrow();
+      // A rejection here is the regression; the assertions below prove the
+      // update still landed.
+      await db.updateCategoryGroup({ id, is_income: 0, hidden: 1 });
 
       const group = await db.first<{ hidden: number; name: string }>(
         'SELECT * FROM category_groups WHERE id = ?',

--- a/packages/loot-core/src/server/db/index.test.ts
+++ b/packages/loot-core/src/server/db/index.test.ts
@@ -345,4 +345,33 @@ describe('Database', () => {
     expect(rows.length).toBe(1);
     expect(rows[0].id).toBe('trans1');
   });
+
+  describe('updateCategoryGroup', () => {
+    test('updates a group without a name', async () => {
+      // api/category-group-update forwards the caller's Partial, so hiding a
+      // group sends no name at all. The duplicate-name guard used to call
+      // .toUpperCase() on it unconditionally.
+      const id = await db.insertCategoryGroup({ name: 'Bills' });
+
+      await expect(
+        db.updateCategoryGroup({ id, is_income: 0, hidden: 1 }),
+      ).resolves.not.toThrow();
+
+      const group = await db.first<{ hidden: number; name: string }>(
+        'SELECT * FROM category_groups WHERE id = ?',
+        [id],
+      );
+      expect(group.hidden).toBe(1);
+      expect(group.name).toBe('Bills');
+    });
+
+    test('still rejects a rename onto an existing group', async () => {
+      await db.insertCategoryGroup({ name: 'Bills' });
+      const id = await db.insertCategoryGroup({ name: 'Savings' });
+
+      await expect(
+        db.updateCategoryGroup({ id, is_income: 0, name: 'bills' }),
+      ).rejects.toThrow("'Bills' category group already exists");
+    });
+  });
 });

--- a/packages/loot-core/src/server/db/index.ts
+++ b/packages/loot-core/src/server/db/index.ts
@@ -391,20 +391,25 @@ export async function insertCategoryGroup(
 }
 
 export async function updateCategoryGroup(
-  group: WithRequired<Partial<DbCategoryGroup>, 'id' | 'name' | 'is_income'>,
+  group: WithRequired<Partial<DbCategoryGroup>, 'id' | 'is_income'>,
 ) {
-  const existingGroup = await first<
-    Pick<DbCategoryGroup, 'id' | 'name' | 'hidden'>
-  >(
-    `SELECT id, name, hidden FROM category_groups WHERE UPPER(name) = ? AND id != ? AND tombstone = 0 LIMIT 1`,
-    [group.name.toUpperCase(), group.id],
-  );
-  if (existingGroup) {
-    throw new Error(
-      `A ${
-        existingGroup.hidden ? 'hidden ' : ''
-      }'${existingGroup.name}' category group already exists.`,
+  // An update that does not touch the name cannot introduce a duplicate, and
+  // `name` is genuinely absent on one: api/category-group-update forwards the
+  // caller's Partial, and update() writes only the keys it is given.
+  if (group.name !== undefined) {
+    const existingGroup = await first<
+      Pick<DbCategoryGroup, 'id' | 'name' | 'hidden'>
+    >(
+      `SELECT id, name, hidden FROM category_groups WHERE UPPER(name) = ? AND id != ? AND tombstone = 0 LIMIT 1`,
+      [group.name.toUpperCase(), group.id],
     );
+    if (existingGroup) {
+      throw new Error(
+        `A ${
+          existingGroup.hidden ? 'hidden ' : ''
+        }'${existingGroup.name}' category group already exists.`,
+      );
+    }
   }
   group = categoryGroupModel.validate(group, { update: true });
   return update('category_groups', group);

--- a/upcoming-release-notes/api-update-category-partial.md
+++ b/upcoming-release-notes/api-update-category-partial.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [rawsun007]
+---
+
+Fix `api.updateCategory` and `api.updateCategoryGroup` throwing a TypeError on partial updates that omit the name


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

<!-- If AI tools wrote a significant part of this change, please disclose it here and name the tool you used. See https://actualbudget.org/docs/contributing/ai-usage-policy -->

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

## Checklist

- [ ] Release notes added (see link above)
- [ ] No obvious regressions in affected areas
- [ ] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 42 | 13.53 MB | 0%
loot-core | 1 | 4.63 MB → 4.64 MB (+72 B) | +0.00%
api | 2 | 3.85 MB → 3.85 MB (+70 B) | +0.00%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
42 | 13.53 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.58 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/DateSelect.js | 2.37 MB | 0%
static/js/FormulaEditor.js | 766.35 kB | 0%
static/js/ManageRules.js | 71.66 kB | 0%
static/js/NotesTagFormatter.js | 25.94 kB | 0%
static/js/PayeeRuleCountLabel.js | 12.81 kB | 0%
static/js/ReportRouter.js | 1.44 MB | 0%
static/js/ScheduleEditForm.js | 75.41 kB | 0%
static/js/SchedulesTable.js | 171.25 kB | 0%
static/js/TourHost.js | 169.22 kB | 0%
static/js/TourProvider.js | 1.54 kB | 0%
static/js/TransactionEdit.js | 221.38 kB | 0%
static/js/TransactionList.js | 79.22 kB | 0%
static/js/Value.js | 1.79 MB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/ca.js | 170.64 kB | 0%
static/js/client.js | 452.05 kB | 0%
static/js/columns.js | 673.28 kB | 0%
static/js/de.js | 186.5 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/en.js | 245.91 kB | 0%
static/js/es.js | 164.81 kB | 0%
static/js/fr.js | 179.04 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 151.67 kB | 0%
static/js/months.js | 574.72 kB | 0%
static/js/narrow.js | 290.52 kB | 0%
static/js/nb-NO.js | 135.46 kB | 0%
static/js/nl.js | 151.78 kB | 0%
static/js/pl.js | 136.39 kB | 0%
static/js/pt-BR.js | 178.2 kB | 0%
static/js/ru.js | 212.8 kB | 0%
static/js/theme.js | 31.1 kB | 0%
static/js/uk.js | 201.42 kB | 0%
static/js/useFormatList.js | 10.22 kB | 0%
static/js/useLocalPref.js | 97.2 kB | 0%
static/js/useReducedMotion.js | 594 B | 0%
static/js/wide.js | 274.04 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 106.8 kB | 0%
static/js/zh-Hant.js | 130.92 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.63 MB → 4.64 MB (+72 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/app.ts` | 📈 +35 B (+0.37%) | 9.31 kB → 9.34 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/db/index.ts` | 📈 +37 B (+0.16%) | 22.23 kB → 22.27 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.DY15T4oM.js | 0 B → 4.64 MB (+4.64 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.EDh4AUh5.js | 4.63 MB → 0 B (-4.63 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.85 MB → 3.85 MB (+70 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/app.ts` | 📈 +35 B (+0.37%) | 9.14 kB → 9.17 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/db/index.ts` | 📈 +35 B (+0.15%) | 22.88 kB → 22.91 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.85 MB → 3.85 MB (+70 B) | +0.00%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.16 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->