### PR TITLE
Experimental budget backups on web

### DIFF
--- a/packages/desktop-client/package.json
+++ b/packages/desktop-client/package.json
@@ -16,6 +16,7 @@
       "default": "./src/browser-preload.js"
     },
     "#accounts": "./src/accounts/index.ts",
+    "#backups": "./src/backups/index.ts",
     "#budget": "./src/budget/index.ts",
     "#payees": "./src/payees/index.ts",
     "#queries": "./src/queries/index.ts",
@@ -104,6 +105,7 @@
     "#notes/*": "./src/notes/*.tsx",
     "#accounts/*": "./src/accounts/*.ts",
     "#app/*": "./src/app/*.ts",
+    "#backups/*": "./src/backups/*.ts",
     "#budget/*": "./src/budget/*.ts",
     "#budgetfiles/*": "./src/budgetfiles/*.ts",
     "#modals/*": "./src/modals/*.ts",

--- a/packages/desktop-client/src/backups/backupActions.ts
+++ b/packages/desktop-client/src/backups/backupActions.ts
@@ -1,0 +1,194 @@
+// State-aware actions for the backup feature. These update the external
+// store, persist the chosen destination, and tell other tabs to refresh.
+
+import {
+  getBackupState,
+  getLastBackupAt,
+  resetBackupState,
+  setBackupState,
+  setLastBackupAt,
+} from './backupState';
+import {
+  deleteBackupDestinationRecord,
+  getBackupDestinationRecord,
+  setBackupDestinationRecord,
+} from './destinationStore';
+import { runBackupTo } from './pipeline';
+import { getProvider } from './providers';
+import type {
+  BackupDestinationKind,
+  BackupProviderContext,
+  BackupWriteResult,
+} from './types';
+
+const CHANNEL_NAME = 'actual-backups';
+
+type ChannelMessage = { type: 'changed'; budgetId: string };
+
+let channel: BroadcastChannel | null = null;
+
+function getChannel(): BroadcastChannel | null {
+  if (typeof BroadcastChannel === 'undefined') {
+    return null;
+  }
+  if (!channel) {
+    channel = new BroadcastChannel(CHANNEL_NAME);
+  }
+  return channel;
+}
+
+function notifyOtherTabs(budgetId: string) {
+  getChannel()?.postMessage({
+    type: 'changed',
+    budgetId,
+  } satisfies ChannelMessage);
+}
+
+/**
+ * Re-reads the store when another tab changes the destination or writes a
+ * backup. Returns an unsubscribe function.
+ */
+export function listenForBackupChanges(
+  budgetId: string,
+  onChange: () => void,
+): () => void {
+  const activeChannel = getChannel();
+  if (!activeChannel) {
+    return () => undefined;
+  }
+  const handler = (event: MessageEvent<ChannelMessage>) => {
+    if (event.data?.type === 'changed' && event.data.budgetId === budgetId) {
+      onChange();
+    }
+  };
+  activeChannel.addEventListener('message', handler);
+  return () => activeChannel.removeEventListener('message', handler);
+}
+
+function toIsoString(time: number | null): string | null {
+  return time === null ? null : new Date(time).toISOString();
+}
+
+export async function loadBackupState(
+  context: BackupProviderContext,
+): Promise<void> {
+  const { budgetId } = context;
+  const record = await getBackupDestinationRecord(budgetId);
+  const provider = record ? getProvider(record.kind) : null;
+  const destination =
+    record && provider?.isSupported()
+      ? await provider.restore(record.payload, context)
+      : null;
+
+  setBackupState({
+    budgetId,
+    destination,
+    status: destination ? await destination.getStatus() : 'unset',
+    label: destination?.label ?? null,
+    lastBackupAt: toIsoString(getLastBackupAt(budgetId)),
+  });
+}
+
+export function clearBackupState() {
+  resetBackupState();
+}
+
+/** Must be called from a user gesture. */
+export async function connectDestination(
+  context: BackupProviderContext,
+  kind: BackupDestinationKind,
+): Promise<void> {
+  const provider = getProvider(kind);
+  if (!provider) {
+    throw new Error(`Unknown backup provider: ${kind}`);
+  }
+  if (provider.availability !== 'available') {
+    throw new Error(`Backup provider is not available yet: ${kind}`);
+  }
+
+  const connected = await provider.connect(context);
+  if (!connected) {
+    return;
+  }
+
+  await setBackupDestinationRecord(context.budgetId, {
+    kind,
+    payload: connected.payload,
+    chosenAt: new Date().toISOString(),
+  });
+  setBackupState({
+    budgetId: context.budgetId,
+    destination: connected.destination,
+    status: 'ready',
+    label: connected.destination.label,
+    lastResult: null,
+  });
+  notifyOtherTabs(context.budgetId);
+}
+
+/** Must be called from a user gesture. */
+export async function reconnectDestination(
+  context: BackupProviderContext,
+): Promise<void> {
+  const { destination } = getBackupState();
+  if (!destination) {
+    return;
+  }
+  const status = await destination.reconnect();
+  setBackupState({ status, lastResult: null });
+  notifyOtherTabs(context.budgetId);
+}
+
+export async function forgetDestination(
+  context: BackupProviderContext,
+): Promise<void> {
+  await deleteBackupDestinationRecord(context.budgetId);
+  setBackupState({
+    budgetId: context.budgetId,
+    destination: null,
+    status: 'unset',
+    label: null,
+    lastResult: null,
+  });
+  notifyOtherTabs(context.budgetId);
+}
+
+let inFlightBackup: Promise<BackupWriteResult> | null = null;
+
+/**
+ * Writes a backup for the open budget. Concurrent calls share the same
+ * in-flight write, so the scheduler and a "Back up now" click can never
+ * overlap.
+ */
+export function performBackup(
+  context: BackupProviderContext,
+): Promise<BackupWriteResult> {
+  if (inFlightBackup) {
+    return inFlightBackup;
+  }
+
+  const { destination, status } = getBackupState();
+  if (!destination || status !== 'ready') {
+    return Promise.resolve({ ok: false, reason: 'access-lost' });
+  }
+
+  // Record when the export started rather than when it finished: changes
+  // applied while it ran may not be in the snapshot and must stay pending.
+  const startedAt = Date.now();
+  setBackupState({ isBusy: true });
+  inFlightBackup = runBackupTo(destination)
+    .then(result => {
+      if (result.ok === true) {
+        setLastBackupAt(context.budgetId, startedAt);
+        notifyOtherTabs(context.budgetId);
+      } else if (result.reason === 'access-lost') {
+        setBackupState({ status: 'needs-reconnect' });
+      }
+      setBackupState({ isBusy: false, lastResult: result });
+      return result;
+    })
+    .finally(() => {
+      inFlightBackup = null;
+    });
+  return inFlightBackup;
+}

--- a/packages/desktop-client/src/backups/backupScheduler.test.ts
+++ b/packages/desktop-client/src/backups/backupScheduler.test.ts
@@ -1,0 +1,216 @@
+import {
+  BACKUP_DEBOUNCE_MS,
+  createBackupScheduler,
+  getNextBackupDelay,
+  MIN_BACKUP_INTERVAL_MS,
+} from './backupScheduler';
+
+const NOW = 1_000_000_000;
+
+describe('getNextBackupDelay', () => {
+  it('schedules nothing when access is not granted', () => {
+    expect(
+      getNextBackupDelay({
+        now: NOW,
+        isAllowed: false,
+        lastBackupAt: null,
+        lastChangeAt: NOW,
+        lastAttemptAt: null,
+      }),
+    ).toBeNull();
+  });
+
+  it('waits the debounce before the very first backup', () => {
+    expect(
+      getNextBackupDelay({
+        now: NOW,
+        isAllowed: true,
+        lastBackupAt: null,
+        lastChangeAt: null,
+        lastAttemptAt: null,
+      }),
+    ).toBe(BACKUP_DEBOUNCE_MS);
+  });
+
+  it('schedules nothing when there are no changes since the last backup', () => {
+    expect(
+      getNextBackupDelay({
+        now: NOW,
+        isAllowed: true,
+        lastBackupAt: NOW - 1000,
+        lastChangeAt: NOW - 5000,
+        lastAttemptAt: null,
+      }),
+    ).toBeNull();
+  });
+
+  it('debounces after a change', () => {
+    expect(
+      getNextBackupDelay({
+        now: NOW,
+        isAllowed: true,
+        lastBackupAt: NOW - 2 * MIN_BACKUP_INTERVAL_MS,
+        lastChangeAt: NOW - 10_000,
+        lastAttemptAt: null,
+      }),
+    ).toBe(BACKUP_DEBOUNCE_MS - 10_000);
+  });
+
+  it('enforces the minimum interval since the last backup', () => {
+    const lastBackupAt = NOW - 5 * 60 * 1000;
+    expect(
+      getNextBackupDelay({
+        now: NOW,
+        isAllowed: true,
+        lastBackupAt,
+        lastChangeAt: NOW - 2 * BACKUP_DEBOUNCE_MS,
+        lastAttemptAt: null,
+      }),
+    ).toBe(lastBackupAt + MIN_BACKUP_INTERVAL_MS - NOW);
+  });
+
+  it('backs off after a failed attempt', () => {
+    const lastAttemptAt = NOW - 60_000;
+    expect(
+      getNextBackupDelay({
+        now: NOW,
+        isAllowed: true,
+        lastBackupAt: null,
+        lastChangeAt: NOW - 10 * BACKUP_DEBOUNCE_MS,
+        lastAttemptAt,
+      }),
+    ).toBe(lastAttemptAt + MIN_BACKUP_INTERVAL_MS - NOW);
+  });
+
+  it('never returns a negative delay', () => {
+    expect(
+      getNextBackupDelay({
+        now: NOW,
+        isAllowed: true,
+        lastBackupAt: NOW - 10 * MIN_BACKUP_INTERVAL_MS,
+        lastChangeAt: NOW - 10 * BACKUP_DEBOUNCE_MS,
+        lastAttemptAt: null,
+      }),
+    ).toBe(0);
+  });
+});
+
+describe('createBackupScheduler', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function setup({ isAllowed = true } = {}) {
+    let currentTime = NOW;
+    let lastBackupAt: number | null = null;
+    let lastChangeAt: number | null = null;
+    const runBackup = vi.fn(async () => {
+      lastBackupAt = currentTime;
+    });
+
+    const scheduler = createBackupScheduler({
+      isAllowed: () => isAllowed,
+      getLastBackupAt: () => lastBackupAt,
+      getLastChangeAt: () => lastChangeAt,
+      setLastChangeAt: time => {
+        lastChangeAt = time;
+      },
+      runBackup,
+      now: () => currentTime,
+    });
+
+    async function advance(ms: number) {
+      currentTime += ms;
+      await vi.advanceTimersByTimeAsync(ms);
+    }
+
+    return {
+      scheduler,
+      runBackup,
+      advance,
+      getLastBackupAt: () => lastBackupAt,
+    };
+  }
+
+  it('coalesces a burst of changes into one backup', async () => {
+    const { scheduler, runBackup, advance } = setup();
+    scheduler.reevaluate();
+    await advance(BACKUP_DEBOUNCE_MS);
+    expect(runBackup).toHaveBeenCalledTimes(1);
+
+    scheduler.notifyChange();
+    await advance(1000);
+    scheduler.notifyChange();
+    await advance(1000);
+    scheduler.notifyChange();
+    expect(runBackup).toHaveBeenCalledTimes(1);
+
+    await advance(MIN_BACKUP_INTERVAL_MS);
+    expect(runBackup).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not back up more often than the minimum interval', async () => {
+    const { scheduler, runBackup, advance } = setup();
+    scheduler.reevaluate();
+    await advance(BACKUP_DEBOUNCE_MS);
+    expect(runBackup).toHaveBeenCalledTimes(1);
+
+    scheduler.notifyChange();
+    await advance(MIN_BACKUP_INTERVAL_MS / 2);
+    expect(runBackup).toHaveBeenCalledTimes(1);
+
+    await advance(MIN_BACKUP_INTERVAL_MS / 2);
+    expect(runBackup).toHaveBeenCalledTimes(2);
+  });
+
+  it('does nothing while access is not granted', async () => {
+    const { scheduler, runBackup, advance } = setup({ isAllowed: false });
+    scheduler.reevaluate();
+    scheduler.notifyChange();
+    await advance(10 * MIN_BACKUP_INTERVAL_MS);
+    expect(runBackup).not.toHaveBeenCalled();
+  });
+
+  it('retries a failed backup only after the interval', async () => {
+    let currentTime = NOW;
+    let lastChangeAt: number | null = null;
+    const runBackup = vi.fn(async () => {
+      // Never records a successful backup
+    });
+    const scheduler = createBackupScheduler({
+      isAllowed: () => true,
+      getLastBackupAt: () => null,
+      getLastChangeAt: () => lastChangeAt,
+      setLastChangeAt: time => {
+        lastChangeAt = time;
+      },
+      runBackup,
+      now: () => currentTime,
+    });
+
+    scheduler.reevaluate();
+    currentTime += BACKUP_DEBOUNCE_MS;
+    await vi.advanceTimersByTimeAsync(BACKUP_DEBOUNCE_MS);
+    expect(runBackup).toHaveBeenCalledTimes(1);
+
+    currentTime += MIN_BACKUP_INTERVAL_MS / 2;
+    await vi.advanceTimersByTimeAsync(MIN_BACKUP_INTERVAL_MS / 2);
+    expect(runBackup).toHaveBeenCalledTimes(1);
+
+    currentTime += MIN_BACKUP_INTERVAL_MS / 2;
+    await vi.advanceTimersByTimeAsync(MIN_BACKUP_INTERVAL_MS / 2);
+    expect(runBackup).toHaveBeenCalledTimes(2);
+  });
+
+  it('stops firing after stop()', async () => {
+    const { scheduler, runBackup, advance } = setup();
+    scheduler.reevaluate();
+    scheduler.stop();
+    await advance(10 * MIN_BACKUP_INTERVAL_MS);
+    expect(runBackup).not.toHaveBeenCalled();
+  });
+});

--- a/packages/desktop-client/src/backups/backupScheduler.ts
+++ b/packages/desktop-client/src/backups/backupScheduler.ts
@@ -1,0 +1,140 @@
+// Decides when the next automatic backup should run. Pure logic with
+// injectable timers so it can be unit tested without React or the DOM.
+
+/** Wait this long after the last change before writing a backup. */
+export const BACKUP_DEBOUNCE_MS = 60 * 1000;
+
+/**
+ * Never write backups closer together than this. Matches the desktop app's
+ * backup interval; the export re-zips the whole database so keep it coarse.
+ */
+export const MIN_BACKUP_INTERVAL_MS = 15 * 60 * 1000;
+
+export type BackupDecisionInput = {
+  now: number;
+  isAllowed: boolean;
+  lastBackupAt: number | null;
+  lastChangeAt: number | null;
+  lastAttemptAt: number | null;
+};
+
+/**
+ * Returns the delay in milliseconds until the next backup attempt, or null
+ * when nothing should be scheduled.
+ */
+export function getNextBackupDelay({
+  now,
+  isAllowed,
+  lastBackupAt,
+  lastChangeAt,
+  lastAttemptAt,
+}: BackupDecisionInput): number | null {
+  if (!isAllowed) {
+    return null;
+  }
+
+  // `lastBackupAt` is the moment the last backup started, so a change
+  // recorded at the same time may not be in it: treat it as pending.
+  const hasPendingChanges =
+    lastBackupAt === null ||
+    (lastChangeAt !== null && lastChangeAt >= lastBackupAt);
+  if (!hasPendingChanges) {
+    return null;
+  }
+
+  const notBefore = Math.max(
+    (lastChangeAt ?? now) + BACKUP_DEBOUNCE_MS,
+    lastBackupAt === null ? 0 : lastBackupAt + MIN_BACKUP_INTERVAL_MS,
+    lastAttemptAt === null ? 0 : lastAttemptAt + MIN_BACKUP_INTERVAL_MS,
+  );
+  return Math.max(0, notBefore - now);
+}
+
+export type BackupSchedulerDeps = {
+  isAllowed: () => boolean;
+  getLastBackupAt: () => number | null;
+  getLastChangeAt: () => number | null;
+  setLastChangeAt: (time: number) => void;
+  runBackup: () => Promise<unknown>;
+  now?: () => number;
+  setTimer?: (callback: () => void, delay: number) => unknown;
+  clearTimer?: (timer: unknown) => void;
+};
+
+export type BackupScheduler = {
+  /** Call after every applied change; debounces the next backup. */
+  notifyChange: () => void;
+  /** Recomputes the timer, e.g. after permission or visibility changes. */
+  reevaluate: () => void;
+  stop: () => void;
+};
+
+export function createBackupScheduler({
+  isAllowed,
+  getLastBackupAt,
+  getLastChangeAt,
+  setLastChangeAt,
+  runBackup,
+  now = () => Date.now(),
+  setTimer = (callback, delay) => setTimeout(callback, delay),
+  clearTimer = timer => clearTimeout(timer as ReturnType<typeof setTimeout>),
+}: BackupSchedulerDeps): BackupScheduler {
+  let timer: unknown = null;
+  let lastAttemptAt: number | null = null;
+  let isRunning = false;
+  let isStopped = false;
+
+  function clearPendingTimer() {
+    if (timer !== null) {
+      clearTimer(timer);
+      timer = null;
+    }
+  }
+
+  async function attempt() {
+    timer = null;
+    if (isRunning || isStopped) {
+      return;
+    }
+    isRunning = true;
+    lastAttemptAt = now();
+    try {
+      await runBackup();
+    } finally {
+      isRunning = false;
+      reevaluate();
+    }
+  }
+
+  function reevaluate() {
+    if (isStopped) {
+      return;
+    }
+    clearPendingTimer();
+    if (isRunning) {
+      return;
+    }
+    const delay = getNextBackupDelay({
+      now: now(),
+      isAllowed: isAllowed(),
+      lastBackupAt: getLastBackupAt(),
+      lastChangeAt: getLastChangeAt(),
+      lastAttemptAt,
+    });
+    if (delay !== null) {
+      timer = setTimer(() => void attempt(), delay);
+    }
+  }
+
+  return {
+    notifyChange() {
+      setLastChangeAt(now());
+      reevaluate();
+    },
+    reevaluate,
+    stop() {
+      isStopped = true;
+      clearPendingTimer();
+    },
+  };
+}

--- a/packages/desktop-client/src/backups/backupState.ts
+++ b/packages/desktop-client/src/backups/backupState.ts
@@ -1,0 +1,112 @@
+// A tiny external store for the backup feature. Destinations hold
+// non-serialisable objects (directory handles, clients), so this state
+// cannot live in redux; React reads it through `useSyncExternalStore`
+// (see `useBackupDestination`).
+
+import type { LocalPrefs } from '@actual-app/core/types/prefs';
+
+import type {
+  BackupDestination,
+  BackupDestinationStatus,
+  BackupWriteResult,
+} from './types';
+
+export type BackupState = {
+  budgetId: string | null;
+  destination: BackupDestination | null;
+  status: BackupDestinationStatus | 'unset';
+  label: string | null;
+  /** ISO timestamp of the last successful backup, or null. */
+  lastBackupAt: string | null;
+  isBusy: boolean;
+  lastResult: BackupWriteResult | null;
+};
+
+const INITIAL_STATE: BackupState = {
+  budgetId: null,
+  destination: null,
+  status: 'unset',
+  label: null,
+  lastBackupAt: null,
+  isBusy: false,
+  lastResult: null,
+};
+
+let state: BackupState = INITIAL_STATE;
+const listeners = new Set<() => void>();
+
+export function getBackupState(): BackupState {
+  return state;
+}
+
+export function setBackupState(patch: Partial<BackupState>) {
+  state = { ...state, ...patch };
+  for (const listener of listeners) {
+    listener();
+  }
+}
+
+export function resetBackupState() {
+  setBackupState(INITIAL_STATE);
+}
+
+export function subscribeBackupState(listener: () => void) {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+// ── Per-budget timestamps ────────────────────────────────────────────────
+//
+// These are stored the same way `useLocalPref` stores local prefs
+// (`<budgetId>-<prefName>`, JSON encoded) so they are per budget, per
+// device and shared between tabs.
+
+const LAST_BACKUP_PREF = 'backups.lastBackupAt' satisfies keyof LocalPrefs;
+const LAST_CHANGE_PREF = 'backups.lastChangeAt' satisfies keyof LocalPrefs;
+
+function readTimestamp(budgetId: string, prefName: string): number | null {
+  try {
+    const raw = localStorage.getItem(`${budgetId}-${prefName}`);
+    if (!raw) {
+      return null;
+    }
+    const parsed = JSON.parse(raw);
+    const time = typeof parsed === 'string' ? Date.parse(parsed) : NaN;
+    return Number.isNaN(time) ? null : time;
+  } catch {
+    return null;
+  }
+}
+
+function writeTimestamp(budgetId: string, prefName: string, time: number) {
+  try {
+    localStorage.setItem(
+      `${budgetId}-${prefName}`,
+      JSON.stringify(new Date(time).toISOString()),
+    );
+  } catch {
+    // Storage may be unavailable (private mode, quota); the backup itself
+    // still happened, so this is not fatal.
+  }
+}
+
+export function getLastBackupAt(budgetId: string): number | null {
+  return readTimestamp(budgetId, LAST_BACKUP_PREF);
+}
+
+export function setLastBackupAt(budgetId: string, time: number) {
+  writeTimestamp(budgetId, LAST_BACKUP_PREF, time);
+  if (state.budgetId === budgetId) {
+    setBackupState({ lastBackupAt: new Date(time).toISOString() });
+  }
+}
+
+export function getLastChangeAt(budgetId: string): number | null {
+  return readTimestamp(budgetId, LAST_CHANGE_PREF);
+}
+
+export function setLastChangeAt(budgetId: string, time: number) {
+  writeTimestamp(budgetId, LAST_CHANGE_PREF, time);
+}

--- a/packages/desktop-client/src/backups/destinationStore.ts
+++ b/packages/desktop-client/src/backups/destinationStore.ts
@@ -1,0 +1,95 @@
+// Persists the backup destination chosen for each budget. Provider payloads
+// (a directory handle today, tokens or account ids for cloud providers) are
+// structured-cloneable but not JSON-serialisable, so they can only live in
+// IndexedDB. This is a separate, client-owned database: the `actual`
+// database belongs to the loot-core worker and has a fixed schema version.
+
+import type { BackupDestinationKind } from './types';
+
+const DATABASE_NAME = 'actual-client';
+// Bump whenever the object stores change; `onupgradeneeded` only runs when
+// the version is higher than the one already in the browser.
+const DATABASE_VERSION = 2;
+const STORE_NAME = 'backupDestinations';
+const LEGACY_STORE_NAMES = ['backupFolders'];
+
+export type BackupDestinationRecord = {
+  kind: BackupDestinationKind;
+  payload: unknown;
+  chosenAt: string;
+};
+
+let databasePromise: Promise<IDBDatabase> | null = null;
+
+function openDatabase(): Promise<IDBDatabase> {
+  if (!databasePromise) {
+    databasePromise = new Promise<IDBDatabase>((resolve, reject) => {
+      const request = indexedDB.open(DATABASE_NAME, DATABASE_VERSION);
+      request.onupgradeneeded = () => {
+        const database = request.result;
+        for (const legacyName of LEGACY_STORE_NAMES) {
+          if (database.objectStoreNames.contains(legacyName)) {
+            database.deleteObjectStore(legacyName);
+          }
+        }
+        if (!database.objectStoreNames.contains(STORE_NAME)) {
+          database.createObjectStore(STORE_NAME);
+        }
+      };
+      request.onsuccess = () => {
+        const database = request.result;
+        database.onversionchange = () => {
+          database.close();
+          databasePromise = null;
+        };
+        resolve(database);
+      };
+      request.onerror = () => reject(request.error);
+    });
+    databasePromise.catch(() => {
+      databasePromise = null;
+    });
+  }
+  return databasePromise;
+}
+
+function awaitRequest<T>(request: IDBRequest<T>): Promise<T> {
+  return new Promise((resolve, reject) => {
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+export async function getBackupDestinationRecord(
+  budgetId: string,
+): Promise<BackupDestinationRecord | null> {
+  const database = await openDatabase();
+  const store = database
+    .transaction(STORE_NAME, 'readonly')
+    .objectStore(STORE_NAME);
+  const record = await awaitRequest<BackupDestinationRecord | undefined>(
+    store.get(budgetId),
+  );
+  return record ?? null;
+}
+
+export async function setBackupDestinationRecord(
+  budgetId: string,
+  record: BackupDestinationRecord,
+): Promise<void> {
+  const database = await openDatabase();
+  const store = database
+    .transaction(STORE_NAME, 'readwrite')
+    .objectStore(STORE_NAME);
+  await awaitRequest(store.put(record, budgetId));
+}
+
+export async function deleteBackupDestinationRecord(
+  budgetId: string,
+): Promise<void> {
+  const database = await openDatabase();
+  const store = database
+    .transaction(STORE_NAME, 'readwrite')
+    .objectStore(STORE_NAME);
+  await awaitRequest(store.delete(budgetId));
+}

--- a/packages/desktop-client/src/backups/fileSystemAccess.ts
+++ b/packages/desktop-client/src/backups/fileSystemAccess.ts
@@ -1,0 +1,42 @@
+// Type augmentations for the parts of the File System Access API that
+// TypeScript's DOM lib does not ship yet. Only Chromium-based browsers
+// implement these, so `showDirectoryPicker` is declared optional to force
+// feature detection at the call site.
+
+export type FileSystemPermissionMode = 'read' | 'readwrite';
+
+export type FileSystemHandlePermissionDescriptor = {
+  mode?: FileSystemPermissionMode;
+};
+
+export type DirectoryPickerOptions = {
+  id?: string;
+  mode?: FileSystemPermissionMode;
+  startIn?:
+    | FileSystemHandle
+    | 'desktop'
+    | 'documents'
+    | 'downloads'
+    | 'music'
+    | 'pictures'
+    | 'videos';
+};
+
+declare global {
+  // oxlint-disable-next-line typescript/consistent-type-definitions -- global augmentation requires interface
+  interface FileSystemHandle {
+    queryPermission(
+      descriptor?: FileSystemHandlePermissionDescriptor,
+    ): Promise<PermissionState>;
+    requestPermission(
+      descriptor?: FileSystemHandlePermissionDescriptor,
+    ): Promise<PermissionState>;
+  }
+
+  // oxlint-disable-next-line typescript/consistent-type-definitions -- global augmentation requires interface
+  interface Window {
+    showDirectoryPicker?: (
+      options?: DirectoryPickerOptions,
+    ) => Promise<FileSystemDirectoryHandle>;
+  }
+}

--- a/packages/desktop-client/src/backups/index.ts
+++ b/packages/desktop-client/src/backups/index.ts
@@ -1,0 +1,40 @@
+export {
+  clearBackupState,
+  connectDestination,
+  forgetDestination,
+  listenForBackupChanges,
+  loadBackupState,
+  performBackup,
+  reconnectDestination,
+} from './backupActions';
+export {
+  BACKUP_DEBOUNCE_MS,
+  createBackupScheduler,
+  getNextBackupDelay,
+  MIN_BACKUP_INTERVAL_MS,
+} from './backupScheduler';
+export {
+  getBackupState,
+  getLastBackupAt,
+  getLastChangeAt,
+  setLastChangeAt,
+  subscribeBackupState,
+} from './backupState';
+export type { BackupState } from './backupState';
+export { runBackupTo } from './pipeline';
+export {
+  backupProviders,
+  getProvider,
+  getSupportedProviders,
+} from './providers';
+export { createAccessLostError, isAccessLostError } from './types';
+export type {
+  BackupDestination,
+  BackupDestinationKind,
+  BackupDestinationStatus,
+  BackupProvider,
+  BackupProviderAvailability,
+  BackupProviderContext,
+  BackupWriteResult,
+  ConnectedDestination,
+} from './types';

--- a/packages/desktop-client/src/backups/pipeline.test.ts
+++ b/packages/desktop-client/src/backups/pipeline.test.ts
@@ -1,0 +1,124 @@
+import { clearServer, initServer } from '#mocks/connection';
+
+import { runBackupTo } from './pipeline';
+import { createAccessLostError } from './types';
+import type { BackupDestination } from './types';
+
+vi.mock(
+  '@actual-app/core/platform/client/connection',
+  () => import('#mocks/connection'),
+);
+
+function createFakeDestination(
+  existing: Array<{ id: string; date: Date }> = [],
+) {
+  const written: Array<{ name: string; data: Uint8Array }> = [];
+  const destination: BackupDestination = {
+    kind: 'folder',
+    label: 'Backups',
+    getStatus: vi.fn(async () => 'ready' as const),
+    reconnect: vi.fn(async () => 'ready' as const),
+    write: vi.fn(async (name: string, data: Uint8Array) => {
+      written.push({ name, data });
+    }),
+    list: vi.fn(async () => [
+      ...existing,
+      ...written.map(entry => ({ id: entry.name, date: new Date() })),
+    ]),
+    remove: vi.fn(async () => undefined),
+  };
+  return { destination, written };
+}
+
+describe('runBackupTo', () => {
+  afterEach(async () => {
+    await clearServer();
+  });
+
+  it('writes the export under a timestamped name', async () => {
+    const data = new Uint8Array([1, 2, 3]);
+    initServer({ 'export-budget': () => ({ data, warnings: [] }) });
+    const { destination, written } = createFakeDestination();
+
+    const result = await runBackupTo(destination);
+
+    expect(result).toEqual({ ok: true, warnings: [] });
+    expect(written).toHaveLength(1);
+    expect(written[0].name).toMatch(
+      /^\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2}\.zip$/,
+    );
+    expect(written[0].data).toBe(data);
+  });
+
+  it('passes export warnings through', async () => {
+    initServer({
+      'export-budget': () => ({
+        data: new Uint8Array([1]),
+        warnings: ['exceeds-import-size-limit'],
+      }),
+    });
+    const { destination } = createFakeDestination();
+
+    const result = await runBackupTo(destination);
+
+    expect(result).toEqual({
+      ok: true,
+      warnings: ['exceeds-import-size-limit'],
+    });
+  });
+
+  it('prunes old backups after writing', async () => {
+    initServer({
+      'export-budget': () => ({ data: new Uint8Array([1]), warnings: [] }),
+    });
+    // Twelve backups on twelve different past days: only the ten newest
+    // survive, so the two oldest are removed.
+    const { destination } = createFakeDestination(
+      Array.from({ length: 12 }, (_, index) => ({
+        id: `day${index}`,
+        date: new Date(`2016-12-${String(10 + index).padStart(2, '0')}`),
+      })),
+    );
+
+    const result = await runBackupTo(destination);
+
+    expect(result.ok).toBe(true);
+    expect(destination.list).toHaveBeenCalledTimes(1);
+    const removed = vi.mocked(destination.remove).mock.calls.map(([id]) => id);
+    expect(removed.sort()).toEqual(['day0', 'day1', 'day2']);
+  });
+
+  it('does not write anything when the export fails', async () => {
+    initServer({ 'export-budget': () => ({ error: 'internal-error' }) });
+    const { destination } = createFakeDestination();
+
+    const result = await runBackupTo(destination);
+
+    expect(result).toEqual({ ok: false, reason: 'export-failed' });
+    expect(destination.write).not.toHaveBeenCalled();
+  });
+
+  it('reports lost access', async () => {
+    initServer({
+      'export-budget': () => ({ data: new Uint8Array([1]), warnings: [] }),
+    });
+    const { destination } = createFakeDestination();
+    vi.mocked(destination.write).mockRejectedValue(createAccessLostError());
+
+    const result = await runBackupTo(destination);
+
+    expect(result).toMatchObject({ ok: false, reason: 'access-lost' });
+  });
+
+  it('reports other failures as write failures', async () => {
+    initServer({
+      'export-budget': () => ({ data: new Uint8Array([1]), warnings: [] }),
+    });
+    const { destination } = createFakeDestination();
+    vi.mocked(destination.list).mockRejectedValue(new Error('disk full'));
+
+    const result = await runBackupTo(destination);
+
+    expect(result).toMatchObject({ ok: false, reason: 'write-failed' });
+  });
+});

--- a/packages/desktop-client/src/backups/pipeline.ts
+++ b/packages/desktop-client/src/backups/pipeline.ts
@@ -1,0 +1,37 @@
+// The destination-agnostic backup pipeline: export the open budget, write
+// it to the destination, then prune old backups with the same retention
+// rule the desktop app uses.
+
+import { send } from '@actual-app/core/platform/client/connection';
+import {
+  makeBackupFilename,
+  selectBackupsToRemove,
+} from '@actual-app/core/shared/backups';
+
+import { isAccessLostError } from './types';
+import type { BackupDestination, BackupWriteResult } from './types';
+
+export async function runBackupTo(
+  destination: BackupDestination,
+): Promise<BackupWriteResult> {
+  const response = await send('export-budget');
+  if ('error' in response || !response.data) {
+    return { ok: false, reason: 'export-failed' };
+  }
+
+  try {
+    await destination.write(makeBackupFilename(new Date()), response.data);
+
+    const entries = await destination.list();
+    for (const id of selectBackupsToRemove(entries)) {
+      await destination.remove(id);
+    }
+
+    return { ok: true, warnings: response.warnings ?? [] };
+  } catch (error) {
+    if (isAccessLostError(error)) {
+      return { ok: false, reason: 'access-lost', error };
+    }
+    return { ok: false, reason: 'write-failed', error };
+  }
+}

--- a/packages/desktop-client/src/backups/providers/folder.test.ts
+++ b/packages/desktop-client/src/backups/providers/folder.test.ts
@@ -1,0 +1,218 @@
+import { isAccessLostError } from '#backups/types';
+
+import { createFolderDestination, sanitizeFolderName } from './folder';
+
+type FakeFile = { name: string; lastModified: number; contents: unknown[] };
+
+type FakeEntry = {
+  kind: 'file';
+  name: string;
+  getFile: () => Promise<{ lastModified: number }>;
+};
+
+type FakeDirectoryHandle = {
+  kind: 'directory';
+  name: string;
+  queryPermission: ReturnType<typeof vi.fn<() => Promise<PermissionState>>>;
+  requestPermission: ReturnType<typeof vi.fn<() => Promise<PermissionState>>>;
+  removeEntry: ReturnType<typeof vi.fn<(name: string) => Promise<void>>>;
+  getDirectoryHandle: ReturnType<
+    typeof vi.fn<(name: string) => Promise<FakeDirectoryHandle>>
+  >;
+  getFileHandle: ReturnType<typeof vi.fn<(name: string) => Promise<unknown>>>;
+  values: () => AsyncGenerator<FakeEntry>;
+};
+
+type FakeDirectory = {
+  directory: FakeDirectoryHandle;
+  files: Map<string, FakeFile>;
+  subfolders: Map<string, FakeDirectory>;
+};
+
+function createFakeDirectory(
+  name = 'root',
+  existingFiles: FakeFile[] = [],
+): FakeDirectory {
+  const files = new Map(existingFiles.map(file => [file.name, file]));
+  const subfolders = new Map<string, FakeDirectory>();
+
+  const directory: FakeDirectoryHandle = {
+    kind: 'directory',
+    name,
+    queryPermission: vi.fn(async () => 'granted' as const),
+    requestPermission: vi.fn(async () => 'granted' as const),
+    removeEntry: vi.fn(async (fileName: string) => {
+      files.delete(fileName);
+    }),
+    getDirectoryHandle: vi.fn(async (subfolderName: string) => {
+      let subfolder = subfolders.get(subfolderName);
+      if (!subfolder) {
+        subfolder = createFakeDirectory(subfolderName);
+        subfolders.set(subfolderName, subfolder);
+      }
+      return subfolder.directory;
+    }),
+    getFileHandle: vi.fn(async (fileName: string) => {
+      const file: FakeFile = files.get(fileName) ?? {
+        name: fileName,
+        lastModified: Date.now(),
+        contents: [],
+      };
+      files.set(fileName, file);
+      return {
+        kind: 'file' as const,
+        name: fileName,
+        createWritable: async () => ({
+          write: vi.fn(async (chunk: unknown) => {
+            file.contents.push(chunk);
+          }),
+          close: vi.fn(async () => undefined),
+          abort: vi.fn(async () => undefined),
+        }),
+      };
+    }),
+    values: async function* () {
+      for (const file of files.values()) {
+        yield {
+          kind: 'file' as const,
+          name: file.name,
+          getFile: async () => ({ lastModified: file.lastModified }),
+        };
+      }
+    },
+  };
+
+  return { directory, files, subfolders };
+}
+
+function asHandle(directory: FakeDirectoryHandle): FileSystemDirectoryHandle {
+  return directory as unknown as FileSystemDirectoryHandle;
+}
+
+describe('sanitizeFolderName', () => {
+  it('replaces characters that are illegal in folder names', () => {
+    expect(sanitizeFolderName('My/Budget: 2024?')).toBe('My_Budget_ 2024_');
+  });
+
+  it('falls back to a default name', () => {
+    expect(sanitizeFolderName('   ')).toBe('budget');
+    expect(sanitizeFolderName('...')).toBe('budget');
+  });
+});
+
+describe('createFolderDestination', () => {
+  it('uses the folder name as its label', () => {
+    const root = createFakeDirectory('Backups');
+    const destination = createFolderDestination(
+      asHandle(root.directory),
+      'My Budget',
+    );
+    expect(destination.kind).toBe('folder');
+    expect(destination.label).toBe('Backups');
+  });
+
+  it('maps browser permission states to destination statuses', async () => {
+    const root = createFakeDirectory();
+    const destination = createFolderDestination(
+      asHandle(root.directory),
+      'Budget',
+    );
+
+    root.directory.queryPermission.mockResolvedValue('prompt');
+    expect(await destination.getStatus()).toBe('needs-reconnect');
+
+    root.directory.queryPermission.mockResolvedValue('denied');
+    expect(await destination.getStatus()).toBe('denied');
+
+    root.directory.requestPermission.mockResolvedValue('granted');
+    expect(await destination.reconnect()).toBe('ready');
+  });
+
+  it('writes into a subfolder named after the budget', async () => {
+    const root = createFakeDirectory();
+    const destination = createFolderDestination(
+      asHandle(root.directory),
+      'My/Budget',
+    );
+    const data = new Uint8Array([1, 2, 3]);
+
+    await destination.write('2017-01-01_10-00-00.zip', data);
+
+    expect(root.directory.getDirectoryHandle).toHaveBeenCalledWith(
+      'My_Budget',
+      { create: true },
+    );
+    const subfolder = root.subfolders.get('My_Budget');
+    expect(subfolder?.files.get('2017-01-01_10-00-00.zip')?.contents).toEqual([
+      data,
+    ]);
+  });
+
+  it('lists zip files with dates parsed from their names', async () => {
+    const root = createFakeDirectory();
+    const subfolder = createFakeDirectory('Budget', [
+      { name: '2017-01-01_10-00-00.zip', lastModified: 0, contents: [] },
+      { name: 'notes.txt', lastModified: 0, contents: [] },
+      { name: 'other.zip', lastModified: 5000, contents: [] },
+    ]);
+    root.subfolders.set('Budget', subfolder);
+    root.directory.getDirectoryHandle.mockResolvedValue(subfolder.directory);
+    const destination = createFolderDestination(
+      asHandle(root.directory),
+      'Budget',
+    );
+
+    const entries = await destination.list();
+
+    expect(entries).toEqual([
+      {
+        id: '2017-01-01_10-00-00.zip',
+        date: new Date(2017, 0, 1, 10, 0, 0),
+      },
+      { id: 'other.zip', date: new Date(5000) },
+    ]);
+  });
+
+  it('removes entries from the subfolder', async () => {
+    const root = createFakeDirectory();
+    const subfolder = createFakeDirectory('Budget', [
+      { name: 'old.zip', lastModified: 0, contents: [] },
+    ]);
+    root.subfolders.set('Budget', subfolder);
+    root.directory.getDirectoryHandle.mockResolvedValue(subfolder.directory);
+    const destination = createFolderDestination(
+      asHandle(root.directory),
+      'Budget',
+    );
+
+    await destination.remove('old.zip');
+
+    expect(subfolder.directory.removeEntry).toHaveBeenCalledWith('old.zip');
+    expect(subfolder.files.has('old.zip')).toBe(false);
+  });
+
+  it('converts NotAllowedError into the shared access-lost error', async () => {
+    const root = createFakeDirectory();
+    root.directory.getDirectoryHandle.mockRejectedValue(
+      new DOMException('denied', 'NotAllowedError'),
+    );
+    const destination = createFolderDestination(
+      asHandle(root.directory),
+      'Budget',
+    );
+
+    await expect(destination.list()).rejects.toSatisfy(isAccessLostError);
+  });
+
+  it('passes other errors through unchanged', async () => {
+    const root = createFakeDirectory();
+    const error = new Error('disk full');
+    root.directory.getDirectoryHandle.mockRejectedValue(error);
+    const destination = createFolderDestination(
+      asHandle(root.directory),
+      'Budget',
+    );
+
+    await expect(destination.remove('x.zip')).rejects.toBe(error);
+  });
+});

--- a/packages/desktop-client/src/backups/providers/folder.ts
+++ b/packages/desktop-client/src/backups/providers/folder.ts
@@ -1,0 +1,172 @@
+// Backup destination backed by the File System Access API: a folder the
+// user picked on their device. Chromium desktop browsers only.
+
+import { parseBackupFilename } from '@actual-app/core/shared/backups';
+import type { BackupEntry } from '@actual-app/core/shared/backups';
+
+import { createAccessLostError } from '#backups/types';
+import type {
+  BackupDestination,
+  BackupDestinationStatus,
+  BackupProvider,
+  BackupProviderContext,
+} from '#backups/types';
+
+const DIRECTORY_PICKER_ID = 'actual-backups';
+
+export const folderProvider: BackupProvider = {
+  kind: 'folder',
+  availability: 'available',
+
+  isSupported() {
+    return (
+      typeof window !== 'undefined' &&
+      typeof window.showDirectoryPicker === 'function'
+    );
+  },
+
+  async connect(context: BackupProviderContext) {
+    if (!window.showDirectoryPicker) {
+      throw new Error('The File System Access API is not available');
+    }
+
+    let handle: FileSystemDirectoryHandle;
+    try {
+      handle = await window.showDirectoryPicker({
+        id: DIRECTORY_PICKER_ID,
+        mode: 'readwrite',
+        startIn: 'documents',
+      });
+    } catch (error) {
+      if (isDomException(error, 'AbortError')) {
+        return null;
+      }
+      throw error;
+    }
+
+    return {
+      destination: createFolderDestination(handle, context.budgetName),
+      payload: handle,
+    };
+  },
+
+  async restore(payload: unknown, context: BackupProviderContext) {
+    if (!isDirectoryHandle(payload)) {
+      return null;
+    }
+    return createFolderDestination(payload, context.budgetName);
+  },
+};
+
+/**
+ * Backups for a budget go into `<folder>/<budget name>/<timestamp>.zip` so
+ * several budgets can share one backup folder.
+ */
+export function createFolderDestination(
+  handle: FileSystemDirectoryHandle,
+  budgetName: string,
+): BackupDestination {
+  const subfolderName = sanitizeFolderName(budgetName);
+
+  async function getSubfolder(): Promise<FileSystemDirectoryHandle> {
+    return handle.getDirectoryHandle(subfolderName, { create: true });
+  }
+
+  return {
+    kind: 'folder',
+    label: handle.name,
+
+    async getStatus() {
+      return toStatus(await handle.queryPermission({ mode: 'readwrite' }));
+    },
+
+    async reconnect() {
+      return toStatus(await handle.requestPermission({ mode: 'readwrite' }));
+    },
+
+    write: guarded(async (name: string, data: Uint8Array) => {
+      const folder = await getSubfolder();
+      const file = await folder.getFileHandle(name, { create: true });
+      const writable = await file.createWritable();
+      try {
+        // The export arrives from the worker as a plain Uint8Array; TS's
+        // BufferSource type wants an ArrayBuffer-backed view, which it is.
+        await writable.write(data as BufferSource);
+        await writable.close();
+      } catch (error) {
+        await writable.abort().catch(() => undefined);
+        throw error;
+      }
+    }),
+
+    list: guarded(async () => {
+      const folder = await getSubfolder();
+      const entries: BackupEntry[] = [];
+      for await (const entry of folder.values()) {
+        if (entry.kind !== 'file' || !entry.name.endsWith('.zip')) {
+          continue;
+        }
+        const parsedDate = parseBackupFilename(entry.name);
+        const date =
+          parsedDate ??
+          new Date(
+            (await (entry as FileSystemFileHandle).getFile()).lastModified,
+          );
+        entries.push({ id: entry.name, date });
+      }
+      return entries;
+    }),
+
+    remove: guarded(async (id: string) => {
+      const folder = await getSubfolder();
+      await folder.removeEntry(id);
+    }),
+  };
+}
+
+export function sanitizeFolderName(name: string): string {
+  const cleaned = name
+    .replace(/[\\/:*?"<>|]/g, '_')
+    .replace(/[. ]+$/, '')
+    .trim()
+    .slice(0, 100);
+  return cleaned || 'budget';
+}
+
+function toStatus(permission: PermissionState): BackupDestinationStatus {
+  switch (permission) {
+    case 'granted':
+      return 'ready';
+    case 'denied':
+      return 'denied';
+    default:
+      return 'needs-reconnect';
+  }
+}
+
+/** Converts the browser's NotAllowedError into the shared access-lost error. */
+function guarded<Args extends unknown[], Result>(
+  operation: (...args: Args) => Promise<Result>,
+): (...args: Args) => Promise<Result> {
+  return async (...args) => {
+    try {
+      return await operation(...args);
+    } catch (error) {
+      if (isDomException(error, 'NotAllowedError')) {
+        throw createAccessLostError(error);
+      }
+      throw error;
+    }
+  };
+}
+
+function isDirectoryHandle(value: unknown): value is FileSystemDirectoryHandle {
+  return (
+    typeof FileSystemDirectoryHandle !== 'undefined' &&
+    value instanceof FileSystemDirectoryHandle
+  );
+}
+
+function isDomException(error: unknown, name: string): boolean {
+  return error instanceof DOMException && error.name === name;
+}

--- a/packages/desktop-client/src/backups/providers/googleDrive.ts
+++ b/packages/desktop-client/src/backups/providers/googleDrive.ts
@@ -1,0 +1,24 @@
+// Placeholder for backing up to Google Drive. It is listed in the settings
+// UI as "coming soon" so people can see what is planned; nothing here can
+// be connected yet. Replacing this stub with a real adapter means
+// implementing `connect` (OAuth) and `restore` (rebuild a client from the
+// stored payload) and flipping `availability` to 'available'.
+
+import type { BackupProvider } from '#backups/types';
+
+export const googleDriveProvider: BackupProvider = {
+  kind: 'google-drive',
+  availability: 'coming-soon',
+
+  isSupported() {
+    return false;
+  },
+
+  async connect() {
+    throw new Error('Google Drive backups are not available yet');
+  },
+
+  async restore() {
+    return null;
+  },
+};

--- a/packages/desktop-client/src/backups/providers/index.test.ts
+++ b/packages/desktop-client/src/backups/providers/index.test.ts
@@ -1,0 +1,45 @@
+import { folderProvider } from './folder';
+import { googleDriveProvider } from './googleDrive';
+
+import { backupProviders, getProvider, getSupportedProviders } from './index';
+
+describe('backup provider registry', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete window.showDirectoryPicker;
+  });
+
+  it('lists every provider in display order', () => {
+    expect(backupProviders.map(provider => provider.kind)).toEqual([
+      'folder',
+      'google-drive',
+    ]);
+  });
+
+  it('looks providers up by kind', () => {
+    expect(getProvider('folder')).toBe(folderProvider);
+    expect(getProvider('google-drive')).toBe(googleDriveProvider);
+  });
+
+  it('only supports the folder when the browser has a directory picker', () => {
+    expect(getSupportedProviders()).toEqual([]);
+
+    window.showDirectoryPicker = vi.fn();
+    expect(getSupportedProviders()).toEqual([folderProvider]);
+  });
+
+  it('never supports providers that are coming soon', () => {
+    vi.spyOn(googleDriveProvider, 'isSupported').mockReturnValue(true);
+
+    expect(getSupportedProviders()).not.toContain(googleDriveProvider);
+  });
+
+  it('refuses to connect a provider that is coming soon', async () => {
+    await expect(
+      googleDriveProvider.connect({ budgetId: 'b', budgetName: 'Budget' }),
+    ).rejects.toThrow('not available yet');
+    await expect(
+      googleDriveProvider.restore({}, { budgetId: 'b', budgetName: 'Budget' }),
+    ).resolves.toBeNull();
+  });
+});

--- a/packages/desktop-client/src/backups/providers/index.ts
+++ b/packages/desktop-client/src/backups/providers/index.ts
@@ -1,0 +1,27 @@
+import type { BackupDestinationKind, BackupProvider } from '#backups/types';
+
+import { folderProvider } from './folder';
+import { googleDriveProvider } from './googleDrive';
+
+/**
+ * Every provider Actual knows about, in the order the UI lists them. This
+ * includes providers that are not available yet; use
+ * `getSupportedProviders` for the ones that can actually be connected.
+ */
+export const backupProviders: BackupProvider[] = [
+  folderProvider,
+  googleDriveProvider,
+];
+
+/** Providers that are implemented and usable in this browser. */
+export function getSupportedProviders(): BackupProvider[] {
+  return backupProviders.filter(
+    provider => provider.availability === 'available' && provider.isSupported(),
+  );
+}
+
+export function getProvider(
+  kind: BackupDestinationKind,
+): BackupProvider | null {
+  return backupProviders.find(provider => provider.kind === kind) ?? null;
+}

--- a/packages/desktop-client/src/backups/types.ts
+++ b/packages/desktop-client/src/backups/types.ts
@@ -1,0 +1,89 @@
+import type { BackupEntry } from '@actual-app/core/shared/backups';
+
+/** Where backups can be written. Add cloud providers here as they land. */
+export type BackupDestinationKind = 'folder' | 'google-drive';
+
+/**
+ * Whether Actual has implemented a provider at all. Providers marked
+ * `coming-soon` are listed in the UI so people know what is planned, but
+ * can never be connected.
+ */
+export type BackupProviderAvailability = 'available' | 'coming-soon';
+
+export type BackupDestinationStatus =
+  /** Access is granted; backups can be written silently. */
+  | 'ready'
+  /** Access lapsed (new session, revoked token, ...); `reconnect` from a click. */
+  | 'needs-reconnect'
+  /** The user refused access; they have to connect again from scratch. */
+  | 'denied';
+
+export type BackupProviderContext = {
+  budgetId: string;
+  budgetName: string;
+};
+
+/**
+ * A connected place to write backups to. Implementations own the transport
+ * only: no persistence, no UI strings, no scheduling.
+ */
+export type BackupDestination = {
+  kind: BackupDestinationKind;
+  /** Human-readable label: folder name, account email, ... */
+  label: string;
+  getStatus(): Promise<BackupDestinationStatus>;
+  /** Re-acquires access. Must be called from a user gesture. */
+  reconnect(): Promise<BackupDestinationStatus>;
+  write(name: string, data: Uint8Array): Promise<void>;
+  list(): Promise<BackupEntry[]>;
+  remove(id: string): Promise<void>;
+};
+
+export type ConnectedDestination = {
+  destination: BackupDestination;
+  /**
+   * Structured-cloneable data that lets `restore` rebuild the destination
+   * in a later session (a directory handle, tokens, an account id, ...).
+   */
+  payload: unknown;
+};
+
+export type BackupProvider = {
+  kind: BackupDestinationKind;
+  availability: BackupProviderAvailability;
+  /** Whether this browser can use the provider. */
+  isSupported(): boolean;
+  /**
+   * Opens the provider's picker or sign-in flow. Must be called from a user
+   * gesture. Resolves to null when the user cancels.
+   */
+  connect(context: BackupProviderContext): Promise<ConnectedDestination | null>;
+  /** Rebuilds a destination from a stored payload; null if it is unusable. */
+  restore(
+    payload: unknown,
+    context: BackupProviderContext,
+  ): Promise<BackupDestination | null>;
+};
+
+export type BackupWriteResult =
+  | { ok: true; warnings: string[] }
+  | {
+      ok: false;
+      reason: 'export-failed' | 'access-lost' | 'write-failed';
+      error?: unknown;
+    };
+
+const ACCESS_LOST_ERROR_NAME = 'BackupAccessLostError';
+
+/** Thrown by destinations when the user's access has been revoked. */
+export function createAccessLostError(cause?: unknown): Error {
+  const error = new Error('Access to the backup destination was lost', {
+    cause,
+  });
+  error.name = ACCESS_LOST_ERROR_NAME;
+  return error;
+}
+
+export function isAccessLostError(error: unknown): boolean {
+  return error instanceof Error && error.name === ACCESS_LOST_ERROR_NAME;
+}

--- a/packages/desktop-client/src/components/FinancesApp.tsx
+++ b/packages/desktop-client/src/components/FinancesApp.tsx
@@ -12,6 +12,7 @@ import * as undo from '@actual-app/core/platform/client/undo';
 import { getLatestAppVersion, sync } from '#app/appSlice';
 import { ProtectedRoute } from '#auth/ProtectedRoute';
 import { Permissions } from '#auth/types';
+import { useBackupScheduler } from '#hooks/useBackupScheduler';
 import { useGlobalPref } from '#hooks/useGlobalPref';
 import { useLocalPref } from '#hooks/useLocalPref';
 import { useMetaThemeColor } from '#hooks/useMetaThemeColor';
@@ -91,6 +92,7 @@ function RouterBehaviors() {
 export function FinancesApp() {
   const { isNarrowWidth } = useResponsive();
   useMetaThemeColor(theme.mobileViewTheme);
+  useBackupScheduler();
 
   const location = useLocation();
   const dispatch = useDispatch();

--- a/packages/desktop-client/src/components/settings/BackupDestinationList.test.tsx
+++ b/packages/desktop-client/src/components/settings/BackupDestinationList.test.tsx
@@ -1,0 +1,106 @@
+import React from 'react';
+
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import type { BackupProvider } from '#backups';
+
+import { BackupDestinationList } from './BackupDestinationList';
+
+function createProvider(
+  overrides: Partial<BackupProvider> & Pick<BackupProvider, 'kind'>,
+): BackupProvider {
+  return {
+    availability: 'available',
+    isSupported: () => true,
+    connect: async () => null,
+    restore: async () => null,
+    ...overrides,
+  };
+}
+
+const folder = createProvider({ kind: 'folder' });
+const googleDrive = createProvider({
+  kind: 'google-drive',
+  availability: 'coming-soon',
+  isSupported: () => false,
+});
+
+describe('BackupDestinationList', () => {
+  it('offers a connect button for supported providers', async () => {
+    const onConnect = vi.fn();
+    render(
+      <BackupDestinationList
+        providers={[folder, googleDrive]}
+        connectedKind={null}
+        connectedLabel={null}
+        onConnect={onConnect}
+      />,
+    );
+
+    const row = screen.getByTestId('backup-destination-folder');
+    const button = within(row).getByRole('button', {
+      name: 'Choose backup folder',
+    });
+    await userEvent.click(button);
+
+    expect(onConnect).toHaveBeenCalledWith('folder');
+  });
+
+  it('marks providers that are coming soon and offers no button', () => {
+    render(
+      <BackupDestinationList
+        providers={[folder, googleDrive]}
+        connectedKind={null}
+        connectedLabel={null}
+        onConnect={vi.fn()}
+      />,
+    );
+
+    const row = screen.getByTestId('backup-destination-google-drive');
+    expect(within(row).getByText('Google Drive')).toBeInTheDocument();
+    expect(within(row).getByText('Coming soon')).toBeInTheDocument();
+    expect(
+      within(row).getByText('This option is not available yet.'),
+    ).toBeInTheDocument();
+    expect(within(row).queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('offers no button for unsupported providers and explains why', () => {
+    const unsupportedFolder = createProvider({
+      kind: 'folder',
+      isSupported: () => false,
+    });
+    render(
+      <BackupDestinationList
+        providers={[unsupportedFolder]}
+        connectedKind={null}
+        connectedLabel={null}
+        onConnect={vi.fn()}
+      />,
+    );
+
+    const row = screen.getByTestId('backup-destination-folder');
+    expect(within(row).queryByRole('button')).not.toBeInTheDocument();
+    expect(
+      within(row).getByText(/Not supported in this browser/),
+    ).toBeInTheDocument();
+  });
+
+  it('shows the connected provider with its label and a change button', () => {
+    render(
+      <BackupDestinationList
+        providers={[folder, googleDrive]}
+        connectedKind="folder"
+        connectedLabel="Backups"
+        onConnect={vi.fn()}
+      />,
+    );
+
+    const row = screen.getByTestId('backup-destination-folder');
+    expect(within(row).getByText('Connected: Backups')).toBeInTheDocument();
+    expect(
+      within(row).getByRole('button', { name: 'Change folder' }),
+    ).toBeInTheDocument();
+  });
+});

--- a/packages/desktop-client/src/components/settings/BackupDestinationList.tsx
+++ b/packages/desktop-client/src/components/settings/BackupDestinationList.tsx
@@ -1,0 +1,177 @@
+import React from 'react';
+import type { ComponentType, SVGProps } from 'react';
+import { Trans, useTranslation } from 'react-i18next';
+
+import { Button } from '@actual-app/components/button';
+import { SvgCloud, SvgFolder } from '@actual-app/components/icons/v1';
+import { Text } from '@actual-app/components/text';
+import { theme } from '@actual-app/components/theme';
+import { View } from '@actual-app/components/view';
+
+import type { BackupDestinationKind, BackupProvider } from '#backups';
+
+type ProviderCopy = {
+  name: string;
+  description: string;
+  connect: string;
+  change: string;
+  /** Shown instead of a button when this browser cannot use the provider. */
+  unsupportedReason: string;
+  Icon: ComponentType<SVGProps<SVGSVGElement>>;
+};
+
+/**
+ * User-facing copy for each backup provider. Providers themselves carry no
+ * strings, so adding a provider means adding an entry here.
+ */
+function useProviderCopy(): Record<BackupDestinationKind, ProviderCopy> {
+  const { t } = useTranslation();
+  return {
+    folder: {
+      name: t('Folder on this device'),
+      description: t(
+        'Saves backup files to a folder you choose on this device.',
+      ),
+      connect: t('Choose backup folder'),
+      change: t('Change folder'),
+      unsupportedReason: t(
+        'Not supported in this browser. Works in Chrome, Edge and other Chromium-based desktop browsers.',
+      ),
+      Icon: SvgFolder,
+    },
+    'google-drive': {
+      name: t('Google Drive'),
+      description: t('Back up to a folder in your Google Drive.'),
+      connect: t('Connect'),
+      change: t('Change account'),
+      unsupportedReason: t('Not supported in this browser.'),
+      Icon: SvgCloud,
+    },
+  };
+}
+
+type BackupDestinationListProps = {
+  providers: BackupProvider[];
+  connectedKind: BackupDestinationKind | null;
+  connectedLabel: string | null;
+  onConnect: (kind: BackupDestinationKind) => void;
+};
+
+/**
+ * Lists every backup destination Actual knows about, including ones that
+ * are not available in this browser or not built yet, so people can see
+ * what exists and why an option cannot be used.
+ */
+export function BackupDestinationList({
+  providers,
+  connectedKind,
+  connectedLabel,
+  onConnect,
+}: BackupDestinationListProps) {
+  const copy = useProviderCopy();
+  const hasConnection = connectedKind !== null;
+
+  return (
+    <View style={{ gap: 10, width: '100%' }}>
+      {providers.map(provider => {
+        const providerCopy = copy[provider.kind];
+        const isConnected = provider.kind === connectedKind;
+        const isComingSoon = provider.availability === 'coming-soon';
+        const isSupported = !isComingSoon && provider.isSupported();
+
+        return (
+          <View
+            key={provider.kind}
+            data-testid={`backup-destination-${provider.kind}`}
+            style={{
+              flexDirection: 'row',
+              alignItems: 'flex-start',
+              gap: 12,
+              padding: 12,
+              borderRadius: 8,
+              border: '1px solid ' + theme.tableBorder,
+              // Differs from the surrounding Setting background in every theme
+              // (pillBackground vs pillBackgroundLight), unlike tableBackground.
+              backgroundColor: theme.pillBackgroundLight,
+            }}
+          >
+            <providerCopy.Icon
+              width={20}
+              height={20}
+              style={{
+                color: theme.pageTextLight,
+                flexShrink: 0,
+                marginTop: 2,
+              }}
+            />
+            <View style={{ flex: 1, gap: 4, minWidth: 0 }}>
+              <View
+                style={{
+                  flexDirection: 'row',
+                  alignItems: 'center',
+                  flexWrap: 'wrap',
+                  gap: 8,
+                }}
+              >
+                <Text style={{ fontSize: 15, fontWeight: 600 }}>
+                  {providerCopy.name}
+                </Text>
+                {isConnected && (
+                  <Text
+                    style={{
+                      color: theme.noticeTextDark,
+                      fontSize: 13,
+                      fontWeight: 500,
+                    }}
+                  >
+                    {connectedLabel ? (
+                      <Trans>Connected: {{ connectedLabel }}</Trans>
+                    ) : (
+                      <Trans>Connected</Trans>
+                    )}
+                  </Text>
+                )}
+                {isComingSoon && (
+                  <Text
+                    style={{
+                      borderRadius: 999,
+                      backgroundColor: theme.pillBackground,
+                      color: theme.pageText,
+                      fontSize: 12,
+                      fontWeight: 500,
+                      padding: '2px 8px',
+                    }}
+                  >
+                    <Trans>Coming soon</Trans>
+                  </Text>
+                )}
+              </View>
+              <Text style={{ color: theme.pageTextLight, fontSize: 13 }}>
+                {providerCopy.description}
+              </Text>
+              {isComingSoon && (
+                <Text style={{ color: theme.pageTextLight, fontSize: 13 }}>
+                  <Trans>This option is not available yet.</Trans>
+                </Text>
+              )}
+              {!isComingSoon && !isSupported && (
+                <Text style={{ color: theme.warningText, fontSize: 13 }}>
+                  {providerCopy.unsupportedReason}
+                </Text>
+              )}
+            </View>
+            {isSupported && (
+              <Button
+                variant={isConnected || hasConnection ? 'normal' : 'primary'}
+                onPress={() => onConnect(provider.kind)}
+                style={{ flexShrink: 0 }}
+              >
+                {isConnected ? providerCopy.change : providerCopy.connect}
+              </Button>
+            )}
+          </View>
+        );
+      })}
+    </View>
+  );
+}

--- a/packages/desktop-client/src/components/settings/Backups.tsx
+++ b/packages/desktop-client/src/components/settings/Backups.tsx
@@ -1,14 +1,43 @@
-import React from 'react';
-import { Trans } from 'react-i18next';
+import React, { useState } from 'react';
+import { Trans, useTranslation } from 'react-i18next';
 
+import { Block } from '@actual-app/components/block';
+import { Button, ButtonWithLoading } from '@actual-app/components/button';
 import { Text } from '@actual-app/components/text';
+import { theme } from '@actual-app/components/theme';
+import { View } from '@actual-app/components/view';
+import { MAX_BACKUPS } from '@actual-app/core/shared/backups';
+import { isElectron } from '@actual-app/core/shared/environment';
+import type { TransObjectLiteral } from '@actual-app/core/types/util';
+import { format } from 'date-fns';
 
+import { MIN_BACKUP_INTERVAL_MS } from '#backups';
+import { Link } from '#components/common/Link';
+import { useBackupDestination } from '#hooks/useBackupDestination';
+import { useDateFormat } from '#hooks/useDateFormat';
+import { useFeatureFlag } from '#hooks/useFeatureFlag';
+import { useMetadataPref } from '#hooks/useMetadataPref';
+
+import { BackupDestinationList } from './BackupDestinationList';
 import { Setting } from './UI';
 
-export function Backups() {
-  const BACKUP_FREQUENCY_MINS = 15;
-  const MAX_BACKUPS = 10;
+const BACKUP_FREQUENCY_MINS = MIN_BACKUP_INTERVAL_MS / 60 / 1000;
+const BACKUP_DOCS_URL =
+  'https://actualbudget.org/docs/experimental/automatic-backups';
 
+export function Backups() {
+  const isAutomaticBackupsEnabled = useFeatureFlag('automaticBackups');
+
+  if (isElectron()) {
+    return <ElectronBackups />;
+  }
+  if (!isAutomaticBackupsEnabled) {
+    return null;
+  }
+  return <BackupDestinationSettings />;
+}
+
+function ElectronBackups() {
   return (
     <Setting>
       <Text>
@@ -26,6 +55,173 @@ export function Backups() {
           </Trans>
         </p>
       </Text>
+    </Setting>
+  );
+}
+
+function BackupDestinationSettings() {
+  const { t } = useTranslation();
+  const dateFormat = useDateFormat() || 'MM/dd/yyyy';
+  const [encryptKeyId] = useMetadataPref('encryptKeyId');
+  const {
+    destination,
+    status,
+    label,
+    lastBackupAt,
+    isBusy,
+    lastResult,
+    providers,
+    isSupported,
+    connect,
+    reconnect,
+    backupNow,
+    forget,
+  } = useBackupDestination();
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  async function runAction(action: () => Promise<void>) {
+    setActionError(null);
+    try {
+      await action();
+    } catch (error) {
+      console.error('Backup action failed:', error);
+      setActionError(
+        t('Something went wrong with your backup location. Please try again.'),
+      );
+    }
+  }
+
+  const lastBackupLabel = lastBackupAt
+    ? format(new Date(lastBackupAt), `${dateFormat} HH:mm`)
+    : null;
+  const hasDestination = status !== 'unset';
+
+  const warnings = lastResult?.ok ? lastResult.warnings : [];
+  const failureReason =
+    lastResult && lastResult.ok === false ? lastResult.reason : null;
+
+  return (
+    <Setting>
+      <Text>
+        <strong>
+          <Trans>Backups</Trans>
+        </strong>
+        <p>
+          <Trans>
+            Choose where Actual should save automatic backups. A backup is saved
+            shortly after you make changes, at most once every{' '}
+            {{ BACKUP_FREQUENCY_MINS }} minutes, and Actual retains a maximum of{' '}
+            {{ MAX_BACKUPS }} backups at any time.
+          </Trans>
+        </p>
+        {!isSupported && (
+          <p>
+            <Trans>
+              None of these options work in this browser yet. Use{' '}
+              <strong>Export</strong> below to save a copy regularly, or keep
+              your data safe with a sync server or the desktop app.{' '}
+              <Link variant="external" to={BACKUP_DOCS_URL}>
+                Learn more
+              </Link>
+            </Trans>
+          </p>
+        )}
+        {status === 'ready' && (
+          <p>
+            <Trans>
+              Backing up to <strong>{{ label } as TransObjectLiteral}</strong>.
+            </Trans>
+          </p>
+        )}
+        {status === 'needs-reconnect' && (
+          <p>
+            <Trans>
+              Backups to <strong>{{ label } as TransObjectLiteral}</strong> are
+              paused until you allow Actual to access it again. Your browser may
+              ask you to do this once per session.
+            </Trans>
+          </p>
+        )}
+        {status === 'denied' && (
+          <p>
+            <Trans>
+              Access to <strong>{{ label } as TransObjectLiteral}</strong> was
+              denied. Choose a backup location again to continue backing up.
+            </Trans>
+          </p>
+        )}
+        {hasDestination && (
+          <p>
+            {lastBackupLabel ? (
+              <Trans>Last backup: {{ lastBackupLabel }}</Trans>
+            ) : (
+              <Trans>No backup has been made yet.</Trans>
+            )}
+          </p>
+        )}
+      </Text>
+      {hasDestination && encryptKeyId ? (
+        <Text>
+          <Trans>
+            Even though encryption is enabled, backups saved to your backup
+            location will not have any encryption.
+          </Trans>
+        </Text>
+      ) : null}
+      {hasDestination && (
+        <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 10 }}>
+          {status === 'ready' && (
+            <ButtonWithLoading
+              variant="primary"
+              isLoading={isBusy}
+              onPress={() => runAction(backupNow)}
+            >
+              <Trans>Back up now</Trans>
+            </ButtonWithLoading>
+          )}
+          {status === 'needs-reconnect' && (
+            <Button variant="primary" onPress={() => runAction(reconnect)}>
+              <Trans>Resume backups</Trans>
+            </Button>
+          )}
+          <Button onPress={() => runAction(forget)}>
+            <Trans>Stop backing up</Trans>
+          </Button>
+        </View>
+      )}
+      {actionError && (
+        <Block style={{ color: theme.errorText }}>{actionError}</Block>
+      )}
+      {failureReason === 'export-failed' && (
+        <Block style={{ color: theme.errorText }}>
+          <Trans>
+            The last backup failed while exporting your budget. Please report
+            this as a new issue on GitHub.
+          </Trans>
+        </Block>
+      )}
+      {failureReason === 'write-failed' && (
+        <Block style={{ color: theme.errorText }}>
+          <Trans>
+            The last backup could not be written to your backup location. Check
+            that it still exists and has free space.
+          </Trans>
+        </Block>
+      )}
+      {warnings.includes('exceeds-import-size-limit') && (
+        <Block style={{ color: theme.warningText }}>
+          <Trans>
+            Your backups are larger than Actual can safely re-import. You may
+            not be able to restore them.
+          </Trans>
+        </Block>
+      )}
+      <BackupDestinationList
+        providers={providers}
+        connectedKind={destination?.kind ?? null}
+        connectedLabel={label}
+        onConnect={kind => runAction(() => connect(kind))}
+      />
     </Setting>
   );
 }

--- a/packages/desktop-client/src/components/settings/Experimental.tsx
+++ b/packages/desktop-client/src/components/settings/Experimental.tsx
@@ -232,6 +232,9 @@ export function ExperimentalFeatures() {
             >
               <Trans>Monte Carlo Analysis Report</Trans>
             </FeatureToggle>
+            <FeatureToggle flag="automaticBackups">
+              <Trans>Automatic backups (web app)</Trans>
+            </FeatureToggle>
             <FeatureToggle
               flag="enableBanking"
               feedbackLink="https://github.com/actualbudget/actual/issues/7799"

--- a/packages/desktop-client/src/components/settings/index.tsx
+++ b/packages/desktop-client/src/components/settings/index.tsx
@@ -10,7 +10,6 @@ import { theme } from '@actual-app/components/theme';
 import { tokens } from '@actual-app/components/tokens';
 import { View } from '@actual-app/components/view';
 import { listen } from '@actual-app/core/platform/client/connection';
-import { isElectron } from '@actual-app/core/shared/environment';
 import { css } from '@emotion/css';
 
 import { getLatestAppVersion } from '#app/appSlice';
@@ -242,7 +241,7 @@ export function Settings() {
         <AuthSettings />
         <EncryptionSettings />
         <BudgetTypeSettings />
-        {isElectron() && <Backups />}
+        <Backups />
         <ExportBudget />
         <AdvancedToggle>
           <AdvancedAbout />

--- a/packages/desktop-client/src/globals.ts
+++ b/packages/desktop-client/src/globals.ts
@@ -1,1 +1,2 @@
 import '@actual-app/core/typings/window';
+import '#backups/fileSystemAccess';

--- a/packages/desktop-client/src/hooks/useBackupDestination.ts
+++ b/packages/desktop-client/src/hooks/useBackupDestination.ts
@@ -1,0 +1,76 @@
+import { useSyncExternalStore } from 'react';
+
+import { isElectron } from '@actual-app/core/shared/environment';
+
+import {
+  backupProviders,
+  connectDestination,
+  forgetDestination,
+  getBackupState,
+  getSupportedProviders,
+  performBackup,
+  reconnectDestination,
+  subscribeBackupState,
+} from '#backups';
+import type {
+  BackupDestinationKind,
+  BackupProvider,
+  BackupState,
+} from '#backups';
+import { useMetadataPref } from '#hooks/useMetadataPref';
+
+export type UseBackupDestinationResult = BackupState & {
+  /** Every provider Actual lists, including ones not available here or yet. */
+  providers: BackupProvider[];
+  /** Providers that can actually be connected in this browser. */
+  supportedProviders: BackupProvider[];
+  isSupported: boolean;
+  /** Must be called from a user gesture (pickers and sign-in flows need it). */
+  connect: (kind: BackupDestinationKind) => Promise<void>;
+  /** Must be called from a user gesture (permission prompts need it). */
+  reconnect: () => Promise<void>;
+  backupNow: () => Promise<void>;
+  forget: () => Promise<void>;
+};
+
+/**
+ * Read and control the automatic backup destination for the open budget.
+ */
+export function useBackupDestination(): UseBackupDestinationResult {
+  const [budgetId] = useMetadataPref('id');
+  const [budgetName] = useMetadataPref('budgetName');
+  const state = useSyncExternalStore(subscribeBackupState, getBackupState);
+
+  const providers = isElectron() ? [] : backupProviders;
+  const supportedProviders = isElectron() ? [] : getSupportedProviders();
+  const context = budgetId
+    ? { budgetId, budgetName: budgetName ?? 'budget' }
+    : null;
+
+  return {
+    ...state,
+    providers,
+    supportedProviders,
+    isSupported: supportedProviders.length > 0,
+    connect: async kind => {
+      if (context) {
+        await connectDestination(context, kind);
+      }
+    },
+    reconnect: async () => {
+      if (context) {
+        await reconnectDestination(context);
+      }
+    },
+    backupNow: async () => {
+      if (context) {
+        await performBackup(context);
+      }
+    },
+    forget: async () => {
+      if (context) {
+        await forgetDestination(context);
+      }
+    },
+  };
+}

--- a/packages/desktop-client/src/hooks/useBackupScheduler.test.ts
+++ b/packages/desktop-client/src/hooks/useBackupScheduler.test.ts
@@ -1,0 +1,106 @@
+import { renderHook, waitFor } from '@testing-library/react';
+
+import type * as BackupsModule from '#backups';
+import { serverPush } from '#mocks/connection';
+
+import { useBackupScheduler } from './useBackupScheduler';
+
+vi.mock(
+  '@actual-app/core/platform/client/connection',
+  () => import('#mocks/connection'),
+);
+
+const schedulerMocks = vi.hoisted(() => ({
+  notifyChange: vi.fn(),
+  reevaluate: vi.fn(),
+  stop: vi.fn(),
+  createBackupScheduler: vi.fn(),
+  loadBackupState: vi.fn(() => Promise.resolve()),
+  clearBackupState: vi.fn(),
+}));
+
+vi.mock('#backups', async () => {
+  const actual = await vi.importActual<typeof BackupsModule>('#backups');
+  return {
+    ...actual,
+    getSupportedProviders: () => [{ kind: 'folder' }],
+    createBackupScheduler: schedulerMocks.createBackupScheduler,
+    loadBackupState: schedulerMocks.loadBackupState,
+    clearBackupState: schedulerMocks.clearBackupState,
+  };
+});
+
+vi.mock('#hooks/useMetadataPref', () => ({
+  useMetadataPref: (name: string) => [
+    name === 'id' ? 'budget-1' : 'My Budget',
+    vi.fn(),
+  ],
+}));
+
+vi.mock('#hooks/useFeatureFlag', () => ({
+  useFeatureFlag: () => true,
+}));
+
+vi.mock('#hooks/useNavigate', () => ({
+  useNavigate: () => vi.fn(),
+}));
+
+vi.mock('#redux', () => ({
+  useDispatch: () => vi.fn(),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+describe('useBackupScheduler', () => {
+  beforeEach(() => {
+    schedulerMocks.createBackupScheduler.mockReturnValue({
+      notifyChange: schedulerMocks.notifyChange,
+      reevaluate: schedulerMocks.reevaluate,
+      stop: schedulerMocks.stop,
+    });
+
+    // jsdom has no Web Locks; grant the lock immediately.
+    Object.defineProperty(navigator, 'locks', {
+      configurable: true,
+      value: {
+        request: vi.fn((_name: string, callback: () => Promise<void>) =>
+          callback(),
+        ),
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    // @ts-expect-error -- cleaning up the test-only stub
+    delete navigator.locks;
+  });
+
+  it('loads backup state, runs the scheduler and forwards applied changes', async () => {
+    const { unmount } = renderHook(() => useBackupScheduler());
+
+    await waitFor(() =>
+      expect(schedulerMocks.createBackupScheduler).toHaveBeenCalledTimes(1),
+    );
+    expect(schedulerMocks.loadBackupState).toHaveBeenCalledWith({
+      budgetId: 'budget-1',
+      budgetName: 'My Budget',
+    });
+    expect(schedulerMocks.reevaluate).toHaveBeenCalled();
+
+    serverPush('sync-event', { type: 'applied', tables: ['transactions'] });
+    await waitFor(() =>
+      expect(schedulerMocks.notifyChange).toHaveBeenCalledTimes(1),
+    );
+
+    serverPush('sync-event', { type: 'success', tables: ['transactions'] });
+    await Promise.resolve();
+    expect(schedulerMocks.notifyChange).toHaveBeenCalledTimes(1);
+
+    unmount();
+    await waitFor(() => expect(schedulerMocks.stop).toHaveBeenCalledTimes(1));
+    expect(schedulerMocks.clearBackupState).toHaveBeenCalled();
+  });
+});

--- a/packages/desktop-client/src/hooks/useBackupScheduler.ts
+++ b/packages/desktop-client/src/hooks/useBackupScheduler.ts
@@ -1,0 +1,148 @@
+import { useEffect, useEffectEvent } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { listen } from '@actual-app/core/platform/client/connection';
+import { isElectron } from '@actual-app/core/shared/environment';
+
+import {
+  clearBackupState,
+  createBackupScheduler,
+  getBackupState,
+  getLastBackupAt,
+  getLastChangeAt,
+  getSupportedProviders,
+  listenForBackupChanges,
+  loadBackupState,
+  performBackup,
+  setLastChangeAt,
+  subscribeBackupState,
+} from '#backups';
+import { useFeatureFlag } from '#hooks/useFeatureFlag';
+import { useMetadataPref } from '#hooks/useMetadataPref';
+import { useNavigate } from '#hooks/useNavigate';
+import { addNotification } from '#notifications/notificationsSlice';
+import { useDispatch } from '#redux';
+
+const PAUSED_NOTIFICATION_ID = 'backups-paused';
+
+/**
+ * Runs automatic backups to the user's chosen destination while a budget
+ * is open. Every tab loads the backup state so the settings panel can show
+ * it, but only one tab (the holder of a Web Lock) runs the scheduler, and
+ * another tab takes over automatically when it closes.
+ */
+export function useBackupScheduler() {
+  const [budgetId] = useMetadataPref('id');
+  const [budgetName] = useMetadataPref('budgetName');
+  const dispatch = useDispatch();
+  const navigate = useNavigate();
+  const { t } = useTranslation();
+
+  const isAutomaticBackupsEnabled = useFeatureFlag('automaticBackups');
+  const isEnabled =
+    isAutomaticBackupsEnabled &&
+    !isElectron() &&
+    getSupportedProviders().length > 0;
+
+  const runBackup = useEffectEvent(async () => {
+    if (!budgetId) {
+      return;
+    }
+    const result = await performBackup({
+      budgetId,
+      budgetName: budgetName ?? 'budget',
+    });
+    if (result.ok === false && result.reason === 'access-lost') {
+      dispatch(
+        addNotification({
+          notification: {
+            id: PAUSED_NOTIFICATION_ID,
+            type: 'warning',
+            sticky: true,
+            title: t('Automatic backups are paused'),
+            message: t(
+              'Actual lost access to your backup location. Allow access again to keep backing up.',
+            ),
+            button: {
+              title: t('Open settings'),
+              action: () => navigate('/settings'),
+            },
+          },
+        }),
+      );
+    }
+  });
+
+  const loadState = useEffectEvent(async () => {
+    if (budgetId) {
+      await loadBackupState({ budgetId, budgetName: budgetName ?? 'budget' });
+    }
+  });
+
+  useEffect(() => {
+    if (!isEnabled || !budgetId) {
+      return;
+    }
+
+    let isCancelled = false;
+    let releaseLock: (() => void) | null = null;
+    const lockHeld = new Promise<void>(resolve => {
+      releaseLock = resolve;
+    });
+
+    void loadState();
+    const unlistenChanges = listenForBackupChanges(budgetId, () => {
+      void loadState();
+    });
+
+    if ('locks' in navigator) {
+      void navigator.locks.request(`actual-backups:${budgetId}`, async () => {
+        if (isCancelled) {
+          return;
+        }
+
+        // Another tab may have changed the destination while it held the
+        // lock.
+        await loadState();
+
+        const scheduler = createBackupScheduler({
+          isAllowed: () => getBackupState().status === 'ready',
+          getLastBackupAt: () => getLastBackupAt(budgetId),
+          getLastChangeAt: () => getLastChangeAt(budgetId),
+          setLastChangeAt: time => setLastChangeAt(budgetId, time),
+          runBackup,
+        });
+
+        const unlistenSync = listen('sync-event', event => {
+          if (event.type === 'applied') {
+            scheduler.notifyChange();
+          }
+        });
+        const unsubscribeState = subscribeBackupState(() =>
+          scheduler.reevaluate(),
+        );
+        const onVisibilityChange = () => {
+          if (document.visibilityState === 'visible') {
+            scheduler.reevaluate();
+          }
+        };
+        document.addEventListener('visibilitychange', onVisibilityChange);
+
+        scheduler.reevaluate();
+        await lockHeld;
+
+        document.removeEventListener('visibilitychange', onVisibilityChange);
+        unsubscribeState();
+        unlistenSync();
+        scheduler.stop();
+      });
+    }
+
+    return () => {
+      isCancelled = true;
+      releaseLock?.();
+      unlistenChanges();
+      clearBackupState();
+    };
+  }, [budgetId, isEnabled]);
+}

--- a/packages/desktop-client/src/hooks/useFeatureFlag.ts
+++ b/packages/desktop-client/src/hooks/useFeatureFlag.ts
@@ -16,6 +16,7 @@ const DEFAULT_FEATURE_FLAG_STATE: Record<FeatureFlag, boolean> = {
   akahuBankSync: false,
   mobileCalculator: false,
   monteCarloReport: false,
+  automaticBackups: false,
 };
 
 export function useFeatureFlag(name: FeatureFlag): boolean {

--- a/packages/docs/docs-sidebar.js
+++ b/packages/docs/docs-sidebar.js
@@ -216,6 +216,7 @@ const sidebars = {
             'experimental/budget-analysis-report',
             'experimental/monte-carlo-analysis',
             'experimental/sankey-report',
+            'experimental/automatic-backups',
           ],
         },
       ],

--- a/packages/docs/docs/backup-restore/backup.md
+++ b/packages/docs/docs/backup-restore/backup.md
@@ -20,6 +20,10 @@ You can export your data from Actual at any time. To do so:
 
 3. Save the file somewhere on your computer - that is it -- you're done.
 
+## Automatic Backups in the Browser
+
+Actual can also save backups automatically to a folder on your device when you use it in a web browser. This is an experimental feature; see [Automatic Backups](../experimental/automatic-backups.md) for how to turn it on and use it.
+
 ## Manually Creating a Backup From the Desktop App
 
 This will force a backup to be created right now. Do this if you are going to do something that you might want to revert later (and don't want to use [undo](../getting-started/tips-tricks.md#undo-redo)).

--- a/packages/docs/docs/experimental/automatic-backups.md
+++ b/packages/docs/docs/experimental/automatic-backups.md
@@ -1,0 +1,49 @@
+# Automatic Backups
+
+<ExperimentalFeatureWarning />
+
+## What Does This Feature Do?
+
+When you use Actual in a web browser, your budget lives inside the browser's own storage. That storage can be lost if you clear your browsing data, if the browser runs out of space, or if your device breaks. Actual can protect you from this by saving a backup to a folder of your choice on your device, automatically, whenever you make changes.
+
+:::note
+
+Automatic backups need the browser to be able to write to a folder on your device. At the moment only Chromium-based desktop browsers such as Google Chrome, Microsoft Edge, Brave and Opera support this. Firefox, Safari and mobile browsers do not, so the Backups section in Settings explains this and points you to the Export option in Settings instead. If you use one of those browsers, consider a [sync server](../install/index.md) or the desktop app, which keeps its own backups.
+
+:::
+
+## Enabling the Feature
+
+1. Open your budget, then click 'More' > 'Settings'.
+2. Click 'Show advanced settings', then 'Experimental features'.
+3. Turn on **Automatic backups (web app)**.
+
+The **Backups** section now appears in Settings.
+
+## Using Automatic Backups
+
+### Choosing a Backup Folder
+
+1. Open your budget, then click 'More' > 'Settings'.
+2. Scroll down to the **Backups** section, which appears once the feature is enabled. It lists the places Actual can back up to. Find **Folder on this device** and click **Choose backup folder**.
+3. Your browser asks you to pick a folder. Choose (or create) a folder you keep safe, for example one that is synced to cloud storage, and allow Actual to view and edit files in it.
+
+That is it. From now on, Actual saves a backup shortly after you make a change, and never more often than once every 15 minutes. Backups go into a sub-folder named after your budget, as zip files named by date and time, for example `2024-05-18_14-02-11.zip`. Actual keeps up to three backups from today, one backup for each earlier day, and at most ten backups in total. Older ones are deleted automatically.
+
+You can click **Back up now** at any time to save a backup immediately, **Change folder** to pick a different folder, or **Stop backing up** to turn the feature off.
+
+### Allowing Access Again
+
+Browsers only remember folder access for a while. When you come back to Actual in a new browser session, the Backups section may say that backups are paused. Click **Resume backups** and allow access to continue. Google Chrome offers an **Allow on every visit** option in that prompt, which stops it from asking again. If you have installed Actual as an app from your browser, access is remembered automatically.
+
+Actual also shows a notification if it loses access to the folder while you are working, so that you know backups have stopped.
+
+:::caution
+
+Backups saved to your folder are not encrypted, even if you have turned on end-to-end encryption for your budget. Keep the folder somewhere only you can access.
+
+:::
+
+### Restoring an Automatic Backup
+
+Each backup is a normal Actual export, so you can restore it the same way as any exported file. See [Restoring a Backup](../backup-restore/restore.md) for the steps.

--- a/packages/loot-core/src/server/budgetfiles/backups.ts
+++ b/packages/loot-core/src/server/budgetfiles/backups.ts
@@ -9,7 +9,7 @@ import * as sqlite from '#platform/server/sqlite';
 import * as cloudStorage from '#server/cloud-storage';
 import * as prefs from '#server/prefs';
 import { safeUnzip, safeZip } from '#server/util/zip';
-import * as monthUtils from '#shared/months';
+import { makeBackupFilename, selectBackupsToRemove } from '#shared/backups';
 
 // A special backup that represents the latest version of the db that
 // can be reverted to after loading a backup
@@ -78,29 +78,8 @@ export async function getAvailableBackups(id: string): Promise<Backup[]> {
   }));
 }
 
-export async function updateBackups(backups) {
-  const byDay = backups.reduce((groups, backup) => {
-    const day = dateFns.format(backup.date, 'yyyy-MM-dd');
-    groups[day] = groups[day] || [];
-    groups[day].push(backup);
-    return groups;
-  }, {});
-
-  const removed = [];
-  for (const day of Object.keys(byDay)) {
-    const dayBackups = byDay[day];
-    const isToday = day === monthUtils.currentDay();
-    // Allow 3 backups of the current day (so fine-grained edits are
-    // kept around). Otherwise only keep around one backup per day.
-    // And only keep a total of 10 backups.
-    for (const backup of dayBackups.slice(isToday ? 3 : 1)) {
-      removed.push(backup.id);
-    }
-  }
-
-  // Get the list of remaining backups and only keep the latest 10
-  const currentBackups = backups.filter(backup => !removed.includes(backup.id));
-  return removed.concat(currentBackups.slice(10).map(backup => backup.id));
+export async function updateBackups(backups: BackupWithDate[]) {
+  return selectBackupsToRemove(backups);
 }
 
 export async function makeBackup(id: string) {
@@ -113,7 +92,7 @@ export async function makeBackup(id: string) {
     await fs.removeFile(fs.join(fs.getBudgetDir(id), LATEST_BACKUP_FILENAME));
   }
 
-  const backupId = `${dateFns.format(new Date(), 'yyyy-MM-dd_HH-mm-ss')}.zip`;
+  const backupId = makeBackupFilename(new Date());
   const backupPath = fs.join(budgetDir, 'backups', backupId);
 
   if (!(await fs.exists(fs.join(budgetDir, 'backups')))) {

--- a/packages/loot-core/src/shared/backups.test.ts
+++ b/packages/loot-core/src/shared/backups.test.ts
@@ -1,0 +1,96 @@
+import {
+  makeBackupFilename,
+  parseBackupFilename,
+  selectBackupsToRemove,
+} from './backups';
+
+const TODAY = '2017-01-01';
+
+function backup(id: string, iso: string) {
+  return { id, date: new Date(iso) };
+}
+
+describe('selectBackupsToRemove', () => {
+  test('keeps up to three backups on the current day', () => {
+    const removed = selectBackupsToRemove(
+      [
+        backup('b1', '2017-01-01T10:00:00'),
+        backup('b2', '2017-01-01T11:00:00'),
+        backup('b3', '2017-01-01T12:00:00'),
+        backup('b4', '2017-01-01T13:00:00'),
+      ],
+      TODAY,
+    );
+
+    expect(removed).toEqual(['b1']);
+  });
+
+  test('keeps one backup per earlier day', () => {
+    const removed = selectBackupsToRemove(
+      [
+        backup('today1', '2017-01-01T10:00:00'),
+        backup('old1', '2016-12-29T10:00:00'),
+        backup('old2', '2016-12-29T11:00:00'),
+        backup('old3', '2016-12-29T12:00:00'),
+        backup('other', '2016-12-30T09:00:00'),
+      ],
+      TODAY,
+    );
+
+    expect(removed.sort()).toEqual(['old1', 'old2']);
+  });
+
+  test('keeps at most ten backups in total', () => {
+    const backups = Array.from({ length: 12 }, (_, index) =>
+      backup(`day${index}`, `2016-12-${String(20 + index).padStart(2, '0')}`),
+    );
+    // day0 is 2016-12-20 (oldest) ... day11 is 2016-12-31 (newest)
+
+    const removed = selectBackupsToRemove(backups, TODAY);
+
+    expect(removed.sort()).toEqual(['day0', 'day1']);
+  });
+
+  test('does not depend on input order', () => {
+    const ordered = [
+      backup('b1', '2017-01-01T10:00:00'),
+      backup('b2', '2017-01-01T11:00:00'),
+      backup('b3', '2017-01-01T12:00:00'),
+      backup('b4', '2017-01-01T13:00:00'),
+    ];
+    const shuffled = [ordered[2], ordered[0], ordered[3], ordered[1]];
+
+    expect(selectBackupsToRemove(shuffled, TODAY)).toEqual(
+      selectBackupsToRemove(ordered, TODAY),
+    );
+  });
+
+  test('returns nothing when everything fits', () => {
+    const removed = selectBackupsToRemove(
+      [
+        backup('b1', '2017-01-01T10:00:00'),
+        backup('b2', '2016-12-31T10:00:00'),
+      ],
+      TODAY,
+    );
+
+    expect(removed).toEqual([]);
+  });
+});
+
+describe('backup filenames', () => {
+  test('round-trips through make and parse', () => {
+    const date = new Date(2017, 0, 1, 13, 45, 9);
+    const name = makeBackupFilename(date);
+
+    expect(name).toBe('2017-01-01_13-45-09.zip');
+    expect(parseBackupFilename(name)).toEqual(date);
+  });
+
+  test('rejects names that are not backups', () => {
+    expect(parseBackupFilename('db.latest.sqlite')).toBeNull();
+    expect(parseBackupFilename('notes.txt')).toBeNull();
+    expect(parseBackupFilename('2017-01-01.zip')).toBeNull();
+    expect(parseBackupFilename('2017-13-40_99-99-99.zip')).toBeNull();
+  });
+});

--- a/packages/loot-core/src/shared/backups.ts
+++ b/packages/loot-core/src/shared/backups.ts
@@ -1,0 +1,61 @@
+import * as d from 'date-fns';
+
+import * as monthUtils from './months';
+
+export const MAX_BACKUPS = 10;
+export const MAX_BACKUPS_TODAY = 3;
+export const MAX_BACKUPS_PER_PAST_DAY = 1;
+export const BACKUP_FILENAME_DATE_FORMAT = 'yyyy-MM-dd_HH-mm-ss';
+
+export type BackupEntry = { id: string; date: Date };
+
+/**
+ * Decides which backups to delete. Keeps up to 3 backups for the current
+ * day (so fine-grained edits are kept around), one backup per earlier day,
+ * and at most 10 backups in total. Input order does not matter; the newest
+ * backups win. Returns the ids of the backups to remove.
+ */
+export function selectBackupsToRemove(
+  backups: BackupEntry[],
+  today: string = monthUtils.currentDay(),
+): string[] {
+  const sorted = [...backups].sort(
+    (backupA, backupB) => backupB.date.getTime() - backupA.date.getTime(),
+  );
+
+  const byDay = new Map<string, BackupEntry[]>();
+  for (const backup of sorted) {
+    const day = d.format(backup.date, 'yyyy-MM-dd');
+    const dayBackups = byDay.get(day) ?? [];
+    dayBackups.push(backup);
+    byDay.set(day, dayBackups);
+  }
+
+  const removed: string[] = [];
+  for (const [day, dayBackups] of byDay) {
+    const keep = day === today ? MAX_BACKUPS_TODAY : MAX_BACKUPS_PER_PAST_DAY;
+    for (const backup of dayBackups.slice(keep)) {
+      removed.push(backup.id);
+    }
+  }
+
+  const remaining = sorted.filter(backup => !removed.includes(backup.id));
+  return removed.concat(remaining.slice(MAX_BACKUPS).map(backup => backup.id));
+}
+
+export function makeBackupFilename(date: Date): string {
+  return `${d.format(date, BACKUP_FILENAME_DATE_FORMAT)}.zip`;
+}
+
+/**
+ * Parses a filename produced by `makeBackupFilename`. Returns null for
+ * anything else (including the Electron "latest" sqlite marker).
+ */
+export function parseBackupFilename(name: string): Date | null {
+  const match = name.match(/^(\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2})\.zip$/);
+  if (!match) {
+    return null;
+  }
+  const parsed = d.parse(match[1], BACKUP_FILENAME_DATE_FORMAT, new Date());
+  return d.isValid(parsed) ? parsed : null;
+}

--- a/packages/loot-core/src/types/prefs.ts
+++ b/packages/loot-core/src/types/prefs.ts
@@ -11,6 +11,7 @@ export type FeatureFlag =
   | 'sankeyReport'
   | 'akahuBankSync'
   | 'mobileCalculator'
+  | 'automaticBackups'
   | 'monteCarloReport';
 
 /**
@@ -106,6 +107,8 @@ export type LocalPrefs = Partial<{
   sidebarWidth: number;
   'mobile.showSpentColumn': boolean;
   'mobile.bankSyncProvidersCollapsed': boolean;
+  'backups.lastBackupAt': string;
+  'backups.lastChangeAt': string;
 }>;
 
 export type Theme = 'light' | 'dark' | 'auto' | 'midnight' | string;

--- a/upcoming-release-notes/web-backup-folder.md
+++ b/upcoming-release-notes/web-backup-folder.md
@@ -1,0 +1,6 @@
+---
+category: Features
+authors: [MikesGlitch]
+---
+
+Add experimental automatic backups to a folder of your choice when using Actual in Chrome, Edge or other Chromium-based browsers


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

> [!NOTE]
> I'm not sure how I feel about this one due to the fact it's not supported by a lot of browsers, but it's something I've wanted to do for a while. 
> 
> If this wouldn't make it into the core app it could always be a plugin.

## Description

Used AI to help with this.

Adds an experimental option to automatically back up your budget to a folder on your computer when using the web app without a server. You pick a folder once and Actual saves a backup there shortly after you make changes. 

This will only work on chromium based browsers, and only if the browser has allowed it (Brave doesn't by default). 

To enable on brave, go here: `brave://flags` and turn on `File System Access API`

**NOTE:** Firefox don't seem to have any intention of implementing the file access API that's needed for this to work. That's why I've added a (not yet implemented) option to sync with something like google drive. 

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

<!-- If AI tools wrote a significant part of this change, please disclose it here and name the tool you used. See https://actualbudget.org/docs/contributing/ai-usage-policy -->

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

## Testing

**Initial setup:**
<img width="555" height="377" alt="image" src="https://github.com/user-attachments/assets/e67179fe-9699-4aed-892e-c05d27222731" />


**Connected to a directory:**
<img width="546" height="461" alt="image" src="https://github.com/user-attachments/assets/06f4f6af-6c39-4f43-8b3a-fde6329b19c2" />


<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

## Checklist

- [ ] Release notes added (see link above)
- [ ] No obvious regressions in affected areas
- [ ] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 42 | 13.53 MB → 13.56 MB (+38.38 kB) | +0.28%
loot-core | 1 | 4.63 MB → 4.64 MB (+479 B) | +0.01%
api | 2 | 3.85 MB → 3.85 MB (+755 B) | +0.02%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
42 | 13.53 MB → 13.56 MB (+38.38 kB) | +0.28%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/settings/BackupDestinationList.tsx` | 🆕 +6.68 kB | 0 B → 6.68 kB
`src/hooks/useBackupScheduler.ts` | 🆕 +3.71 kB | 0 B → 3.71 kB
`src/backups/backupActions.ts` | 🆕 +3.29 kB | 0 B → 3.29 kB
`src/backups/providers/folder.ts` | 🆕 +2.91 kB | 0 B → 2.91 kB
`src/backups/destinationStore.ts` | 🆕 +1.77 kB | 0 B → 1.77 kB
`src/hooks/useBackupDestination.ts` | 🆕 +1.77 kB | 0 B → 1.77 kB
`src/backups/backupScheduler.ts` | 🆕 +1.72 kB | 0 B → 1.72 kB
`src/backups/backupState.ts` | 🆕 +1.63 kB | 0 B → 1.63 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/backups.ts` | 🆕 +1.26 kB | 0 B → 1.26 kB
`src/backups/pipeline.ts` | 🆕 +705 B | 0 B → 705 B
`src/backups/types.ts` | 🆕 +386 B | 0 B → 386 B
`src/backups/providers/index.ts` | 🆕 +370 B | 0 B → 370 B
`src/backups/providers/googleDrive.ts` | 🆕 +306 B | 0 B → 306 B
`home/runner/work/actual/actual/packages/component-library/src/icons/v1/Cloud.tsx` | 🆕 +890 B | 0 B → 890 B
`home/runner/work/actual/actual/packages/component-library/src/icons/v1/Folder.tsx` | 🆕 +858 B | 0 B → 858 B
`src/components/settings/Backups.tsx` | 📈 +9.89 kB (+753.09%) | 1.31 kB → 11.21 kB
`src/hooks/useFeatureFlag.ts` | 📈 +26 B (+4.35%) | 598 B → 624 B
`src/components/settings/Experimental.tsx` | 📈 +215 B (+2.38%) | 8.82 kB → 9.03 kB
`package.json` | 📈 +76 B (+0.72%) | 10.37 kB → 10.44 kB
`src/components/FinancesApp.tsx` | 📈 +23 B (+0.10%) | 22.73 kB → 22.75 kB
`src/backups/index.ts` |   +0 B (0%) | 0 B → 0 B
`src/components/settings/index.tsx` | 📉 -16 B (-0.15%) | 10.76 kB → 10.75 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/useSyncedPref.js | 0 B → 574.72 kB (+574.72 kB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/months.js | 574.72 kB → 0 B (-574.72 kB) | -100%

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.58 MB → 1.61 MB (+36.65 kB) | +2.27%
static/js/DateSelect.js | 2.37 MB → 2.37 MB (+1.71 kB) | +0.07%
static/js/Value.js | 1.79 MB → 1.79 MB (+26 B) | +0.00%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 766.35 kB | 0%
static/js/ManageRules.js | 71.66 kB | 0%
static/js/NotesTagFormatter.js | 25.94 kB | 0%
static/js/PayeeRuleCountLabel.js | 12.81 kB | 0%
static/js/ReportRouter.js | 1.44 MB | 0%
static/js/ScheduleEditForm.js | 75.41 kB | 0%
static/js/SchedulesTable.js | 171.25 kB | 0%
static/js/TourHost.js | 169.22 kB | 0%
static/js/TourProvider.js | 1.54 kB | 0%
static/js/TransactionEdit.js | 221.38 kB | 0%
static/js/TransactionList.js | 79.22 kB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/ca.js | 170.64 kB | 0%
static/js/client.js | 452.05 kB | 0%
static/js/columns.js | 673.28 kB | 0%
static/js/de.js | 186.5 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/en.js | 245.91 kB | 0%
static/js/es.js | 164.81 kB | 0%
static/js/fr.js | 179.04 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 151.67 kB | 0%
static/js/narrow.js | 290.52 kB | 0%
static/js/nb-NO.js | 135.46 kB | 0%
static/js/nl.js | 151.78 kB | 0%
static/js/pl.js | 136.39 kB | 0%
static/js/pt-BR.js | 178.2 kB | 0%
static/js/ru.js | 212.8 kB | 0%
static/js/theme.js | 31.1 kB | 0%
static/js/uk.js | 201.42 kB | 0%
static/js/useFormatList.js | 10.22 kB | 0%
static/js/useLocalPref.js | 97.2 kB | 0%
static/js/useReducedMotion.js | 594 B | 0%
static/js/wide.js | 274.04 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 106.8 kB | 0%
static/js/zh-Hant.js | 130.92 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.63 MB → 4.64 MB (+479 B) | +0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/shared/backups.ts` | 🆕 +1.02 kB | 0 B → 1.02 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/budgetfiles/backups.ts` | 📉 -567 B (-10.88%) | 5.09 kB → 4.54 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.UFRQlr16.js | 0 B → 4.64 MB (+4.64 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.EDh4AUh5.js | 4.63 MB → 0 B (-4.63 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.85 MB → 3.85 MB (+755 B) | +0.02%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/shared/backups.ts` | 🆕 +1.28 kB | 0 B → 1.28 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/budgetfiles/backups.ts` | 📉 -554 B (-10.92%) | 4.95 kB → 4.41 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.85 MB → 3.85 MB (+755 B) | +0.02%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.16 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->