### PR TITLE
[WIP] [AI] add transaction rules visibility and management features

### DIFF
--- a/packages/desktop-client/package.json
+++ b/packages/desktop-client/package.json
@@ -75,6 +75,7 @@
     "#components/reports/useDashboardWidgetCopyMenu": "./src/components/reports/useDashboardWidgetCopyMenu.ts",
     "#components/reports/useReport": "./src/components/reports/useReport.ts",
     "#components/reports/util": "./src/components/reports/util.ts",
+    "#components/rules/rule-helpers": "./src/components/rules/rule-helpers.ts",
     "#components/schedules": "./src/components/schedules/index.tsx",
     "#components/schedules/schedule-edit-utils": "./src/components/schedules/schedule-edit-utils.ts",
     "#components/select/getFirstDayOfWeek": "./src/components/select/getFirstDayOfWeek.ts",

--- a/packages/desktop-client/src/components/autocomplete/CategoryAutocomplete.tsx
+++ b/packages/desktop-client/src/components/autocomplete/CategoryAutocomplete.tsx
@@ -168,6 +168,7 @@ type CategoryAutocompleteProps = ComponentProps<
     props: ComponentPropsWithoutRef<typeof CategoryItem>,
   ) => ReactElement<typeof CategoryItem>;
   showHiddenCategories?: boolean;
+  footer?: ReactNode;
 };
 
 export function CategoryAutocomplete({
@@ -180,6 +181,7 @@ export function CategoryAutocomplete({
   renderCategoryItemGroupHeader,
   renderCategoryItem,
   showHiddenCategories,
+  footer,
   ...props
 }: CategoryAutocompleteProps) {
   const { data: { grouped: defaultCategoryGroups } = { grouped: [] } } =
@@ -244,6 +246,7 @@ export function CategoryAutocomplete({
           renderCategoryItem={renderCategoryItem}
           showHiddenItems={showHiddenCategories}
           showBalances={showBalances}
+          footer={footer}
         />
       )}
       {...props}

--- a/packages/desktop-client/src/components/mobile/transactions/TransactionEdit.tsx
+++ b/packages/desktop-client/src/components/mobile/transactions/TransactionEdit.tsx
@@ -21,6 +21,7 @@ import {
   SvgPiggyBank,
   SvgTag,
   SvgTrash,
+  SvgTuning,
   SvgUser,
   SvgWallet,
 } from '@actual-app/components/icons/v1';
@@ -87,6 +88,7 @@ import { useCategories } from '#hooks/useCategories';
 import { useCurrentWordRange } from '#hooks/useCurrentWordRange';
 import { useCursorPosition } from '#hooks/useCursorPosition';
 import { useDateFormat } from '#hooks/useDateFormat';
+import { useFeatureFlag } from '#hooks/useFeatureFlag';
 import { useInputRefValue } from '#hooks/useInputRefValue';
 import { useLocalPref } from '#hooks/useLocalPref';
 import { useLocationPermission } from '#hooks/useLocationPermission';
@@ -100,6 +102,7 @@ import {
 import { useSyncedPref } from '#hooks/useSyncedPref';
 import { useTagCSS } from '#hooks/useTagCSS';
 import { useFilteredTags } from '#hooks/useTags';
+import { useTransactionRuleStatus } from '#hooks/useTransactionRuleStatus';
 import { pushModal } from '#modals/modalsSlice';
 import { addNotification } from '#notifications/notificationsSlice';
 import { useSavePayeeLocationMutation } from '#payees';
@@ -663,6 +666,13 @@ const TransactionEditInner = memo<TransactionEditInnerProps>(
     const { data: { grouped: categoryGroups } = { grouped: [] } } =
       useCategories();
     const noteRef = useRef<HTMLInputElement | null>(null);
+
+    const isTransactionRulesUIEnabled = useFeatureFlag('transactionRulesUI');
+    const { ruleStatus, openEditRule, openCreateRule } =
+      useTransactionRuleStatus(
+        unserializedTransactions[0],
+        isTransactionRulesUIEnabled,
+      );
 
     useEffect(() => {
       if (window.history.length === 1) {
@@ -1393,36 +1403,95 @@ const TransactionEditInner = memo<TransactionEditInnerProps>(
             />
           ))}
 
-          {transaction.amount !== 0 && childTransactions.length === 0 && (
-            <View style={{ alignItems: 'center' }}>
-              <Button
-                variant="bare"
-                isDisabled={!!editingField}
-                style={{
-                  height: 40,
-                  borderWidth: 0,
-                  marginLeft: styles.mobileEditingPadding,
-                  marginRight: styles.mobileEditingPadding,
-                  marginTop: 10,
-                  backgroundColor: 'transparent',
-                }}
-                onPress={() => onSplit(transaction.id)}
-              >
-                <SvgSplit
-                  width={17}
-                  height={17}
-                  style={{ color: theme.formLabelText }}
-                />
-                <Text
+          {childTransactions.length === 0 && (
+            <View
+              style={{
+                flexDirection: 'row',
+                justifyContent: 'center',
+                alignItems: 'center',
+                gap: 16,
+                marginTop: 10,
+                marginLeft: styles.mobileEditingPadding,
+                marginRight: styles.mobileEditingPadding,
+              }}
+            >
+              {transaction.amount !== 0 && (
+                <Button
+                  variant="bare"
+                  isDisabled={!!editingField}
                   style={{
-                    marginLeft: 5,
-                    userSelect: 'none',
-                    color: theme.formLabelText,
+                    height: 40,
+                    borderWidth: 0,
+                    backgroundColor: 'transparent',
+                  }}
+                  onPress={() => onSplit(transaction.id)}
+                >
+                  <SvgSplit
+                    width={17}
+                    height={17}
+                    style={{ color: theme.formLabelText }}
+                  />
+                  <Text
+                    style={{
+                      marginLeft: 5,
+                      userSelect: 'none',
+                      color: theme.formLabelText,
+                    }}
+                  >
+                    <Trans>Split</Trans>
+                  </Text>
+                </Button>
+              )}
+
+              {isTransactionRulesUIEnabled && (
+                <Button
+                  variant="bare"
+                  isDisabled={!!editingField}
+                  style={{
+                    height: 40,
+                    borderWidth: 0,
+                    backgroundColor: 'transparent',
+                  }}
+                  onPress={() => {
+                    if (ruleStatus?.categorizingRule) {
+                      openEditRule(ruleStatus.categorizingRule);
+                    } else if (unserializedTransactions[0]) {
+                      openCreateRule(unserializedTransactions[0]);
+                    }
                   }}
                 >
-                  <Trans>Split</Trans>
-                </Text>
-              </Button>
+                  <SvgTuning
+                    width={17}
+                    height={17}
+                    style={{
+                      color: ruleStatus?.isCategorizedByRule
+                        ? theme.pageTextPositive
+                        : ruleStatus?.isOverridden
+                          ? theme.warningText
+                          : theme.formLabelText,
+                    }}
+                  />
+                  <Text
+                    style={{
+                      marginLeft: 5,
+                      userSelect: 'none',
+                      color: ruleStatus?.isCategorizedByRule
+                        ? theme.pageTextPositive
+                        : ruleStatus?.isOverridden
+                          ? theme.warningText
+                          : theme.formLabelText,
+                    }}
+                  >
+                    {ruleStatus?.isCategorizedByRule ? (
+                      <Trans>Rule Active</Trans>
+                    ) : ruleStatus?.isOverridden ? (
+                      <Trans>Rule (Overridden)</Trans>
+                    ) : (
+                      <Trans>Create Rule</Trans>
+                    )}
+                  </Text>
+                </Button>
+              )}
             </View>
           )}
 

--- a/packages/desktop-client/src/components/rules/rule-helpers.ts
+++ b/packages/desktop-client/src/components/rules/rule-helpers.ts
@@ -1,0 +1,61 @@
+import type {
+  NewRuleEntity,
+  RuleActionEntity,
+  RuleConditionEntity,
+  TransactionEntity,
+} from '@actual-app/core/types/models';
+
+export function createCategoryRuleFromTransaction(
+  transaction: TransactionEntity,
+  options: { includeAmount?: boolean } = {},
+): NewRuleEntity {
+  const conditions: RuleConditionEntity[] = [];
+
+  if (transaction.imported_payee) {
+    conditions.push({
+      field: 'imported_payee',
+      op: 'is',
+      value: transaction.imported_payee,
+      type: 'string',
+    });
+  } else if (transaction.payee) {
+    conditions.push({
+      field: 'payee',
+      op: 'is',
+      value: transaction.payee,
+      type: 'id',
+    });
+  }
+
+  if (options.includeAmount && transaction.amount != null) {
+    conditions.push({
+      field: 'amount',
+      op: 'isapprox',
+      value: transaction.amount,
+      type: 'number',
+    });
+  }
+
+  const actions: RuleActionEntity[] = [];
+  if (transaction.category) {
+    actions.push({
+      op: 'set',
+      field: 'category',
+      value: transaction.category,
+      type: 'id',
+    });
+  }
+
+  return {
+    stage: null,
+    conditionsOp: 'and',
+    conditions:
+      conditions.length > 0
+        ? conditions
+        : [{ field: 'payee', op: 'is', value: '', type: 'id' }],
+    actions:
+      actions.length > 0
+        ? actions
+        : [{ op: 'set', field: 'category', value: '', type: 'id' }],
+  };
+}

--- a/packages/desktop-client/src/components/settings/Experimental.tsx
+++ b/packages/desktop-client/src/components/settings/Experimental.tsx
@@ -165,6 +165,12 @@ export function ExperimentalFeatures() {
       primaryAction={
         expanded ? (
           <View style={{ gap: '1em' }}>
+            <FeatureToggle flag="transactionRulesUI">
+              <Trans>
+                Transaction rule visibility and actions in create/edit (Desktop
+                & Mobile)
+              </Trans>
+            </FeatureToggle>
             <FeatureToggle flag="goalTemplatesEnabled">
               <Trans>Goal templates</Trans>
             </FeatureToggle>

--- a/packages/desktop-client/src/components/transactions/TransactionsTable.tsx
+++ b/packages/desktop-client/src/components/transactions/TransactionsTable.tsx
@@ -29,6 +29,7 @@ import {
   SvgArrowDown,
   SvgArrowUp,
   SvgCheveronDown,
+  SvgTuning,
 } from '@actual-app/components/icons/v1';
 import {
   SvgAlertTriangle,
@@ -44,6 +45,7 @@ import {
 import { Popover } from '@actual-app/components/popover';
 import { styles } from '@actual-app/components/styles';
 import { Text } from '@actual-app/components/text';
+import { TextOneLine } from '@actual-app/components/text-one-line';
 import { theme } from '@actual-app/components/theme';
 import { Tooltip } from '@actual-app/components/tooltip';
 import { View } from '@actual-app/components/view';
@@ -124,6 +126,7 @@ import type {
   OnDragChangeCallback,
   OnDropCallback,
 } from '#hooks/useDragDrop';
+import { useFeatureFlag } from '#hooks/useFeatureFlag';
 import { useLocalPref } from '#hooks/useLocalPref';
 import { useMergedRefs } from '#hooks/useMergedRefs';
 import { usePrevious } from '#hooks/usePrevious';
@@ -134,6 +137,7 @@ import { SheetNameProvider } from '#hooks/useSheetName';
 import { useSplitsExpanded } from '#hooks/useSplitsExpanded';
 import type { SplitsExpandedContextValue } from '#hooks/useSplitsExpanded';
 import { useSyncedPref } from '#hooks/useSyncedPref';
+import { useTransactionRuleStatus } from '#hooks/useTransactionRuleStatus';
 import { pushModal } from '#modals/modalsSlice';
 import { NotesTagFormatter } from '#notes/NotesTagFormatter';
 import { addNotification } from '#notifications/notificationsSlice';
@@ -1375,6 +1379,12 @@ const Transaction = memo(function Transaction({
 
   const runningBalance = !isTemporaryId(id) ? balance : balance + amount;
 
+  const isTransactionRulesUIEnabled = useFeatureFlag('transactionRulesUI');
+  const { ruleStatus, openEditRule, openCreateRule } = useTransactionRuleStatus(
+    transaction,
+    isTransactionRulesUIEnabled,
+  );
+
   // Ok this entire logic is a dirty, dirty hack.. but let me explain.
   // Problem: the split-error Popover (which has the buttons to distribute/add split)
   // renders before schedules are added to the table. After schedules finally load
@@ -1931,6 +1941,99 @@ const Transaction = memo(function Transaction({
                 onUpdate('category', value);
               }
             }}
+            unexposedContent={({ value, formatter }) => {
+              const label = formatter
+                ? formatter(value ?? '')
+                : String(value || '');
+              const hasRule =
+                isTransactionRulesUIEnabled && ruleStatus?.categorizingRule;
+              const isRuleApplied =
+                isTransactionRulesUIEnabled && ruleStatus?.isCategorizedByRule;
+              const isOverridden =
+                isTransactionRulesUIEnabled && ruleStatus?.isOverridden;
+
+              return (
+                <View
+                  style={{
+                    flexDirection: 'row',
+                    alignItems: 'center',
+                    justifyContent: 'space-between',
+                    width: '100%',
+                    overflow: 'hidden',
+                  }}
+                >
+                  <TextOneLine style={{ flex: 1, minWidth: 0 }}>
+                    {label}
+                  </TextOneLine>
+
+                  {hasRule && (
+                    <Tooltip
+                      content={
+                        <View style={{ padding: 8, maxWidth: 300, gap: 6 }}>
+                          <Text style={{ fontWeight: 600 }}>
+                            {isRuleApplied ? (
+                              <Trans>Categorized by rule</Trans>
+                            ) : (
+                              <Trans>Rule Overridden</Trans>
+                            )}
+                          </Text>
+                          {ruleStatus.ruleSummary && (
+                            <Text
+                              style={{
+                                fontSize: 11,
+                                color: theme.pageTextSubdued,
+                              }}
+                            >
+                              {ruleStatus.ruleSummary}
+                            </Text>
+                          )}
+                          <Button
+                            variant="primary"
+                            style={{
+                              height: 24,
+                              padding: '2px 8px',
+                              fontSize: 11,
+                              alignSelf: 'flex-start',
+                              marginTop: 2,
+                            }}
+                            onPress={() => {
+                              if (ruleStatus?.categorizingRule) {
+                                openEditRule(ruleStatus.categorizingRule);
+                              }
+                            }}
+                          >
+                            <Trans>Edit Rule</Trans>
+                          </Button>
+                        </View>
+                      }
+                      placement="bottom start"
+                      triggerProps={{ delay: 300, isDisabled: !selected }}
+                    >
+                      <View
+                        style={{
+                          marginLeft: 4,
+                          flexShrink: 0,
+                          cursor: selected ? 'pointer' : 'default',
+                          color: isRuleApplied
+                            ? theme.pageTextPositive
+                            : isOverridden
+                              ? theme.warningText
+                              : theme.pageTextSubdued,
+                        }}
+                        onClick={e => {
+                          if (selected && ruleStatus?.categorizingRule) {
+                            e.stopPropagation();
+                            openEditRule(ruleStatus.categorizingRule);
+                          }
+                        }}
+                      >
+                        <SvgTuning width={13} height={13} />
+                      </View>
+                    </Tooltip>
+                  )}
+                </View>
+              );
+            }}
           >
             {({
               onBlur,
@@ -1958,6 +2061,60 @@ const Transaction = memo(function Transaction({
                   onUpdate={onUpdate}
                   onSelect={onSave}
                   showHiddenCategories={showHiddenCategories}
+                  footer={
+                    isTransactionRulesUIEnabled ? (
+                      <View
+                        style={{
+                          padding: '6px 10px',
+                          borderTop: `1px solid ${theme.menuBorder}`,
+                          backgroundColor: theme.menuBackground,
+                        }}
+                      >
+                        <Button
+                          variant="bare"
+                          style={{
+                            flexDirection: 'row',
+                            alignItems: 'center',
+                            gap: 6,
+                            color: theme.pageText,
+                            fontSize: 12,
+                            padding: '4px 8px',
+                            borderRadius: 4,
+                            width: '100%',
+                            justifyContent: 'flex-start',
+                          }}
+                          onPress={() => {
+                            if (ruleStatus?.categorizingRule) {
+                              openEditRule(ruleStatus.categorizingRule);
+                            } else {
+                              openCreateRule(transaction);
+                            }
+                          }}
+                        >
+                          <SvgTuning
+                            width={13}
+                            height={13}
+                            style={{
+                              color: ruleStatus?.categorizingRule
+                                ? ruleStatus.isCategorizedByRule
+                                  ? theme.pageTextPositive
+                                  : theme.warningText
+                                : theme.pageTextSubdued,
+                            }}
+                          />
+                          <Text>
+                            {ruleStatus?.categorizingRule ? (
+                              <Trans>Edit rule for this transaction...</Trans>
+                            ) : (
+                              <Trans>
+                                Create rule from this transaction...
+                              </Trans>
+                            )}
+                          </Text>
+                        </Button>
+                      </View>
+                    ) : undefined
+                  }
                 />
               </SheetNameProvider>
             )}

--- a/packages/desktop-client/src/hooks/useFeatureFlag.ts
+++ b/packages/desktop-client/src/hooks/useFeatureFlag.ts
@@ -16,6 +16,7 @@ const DEFAULT_FEATURE_FLAG_STATE: Record<FeatureFlag, boolean> = {
   akahuBankSync: false,
   mobileCalculator: false,
   monteCarloReport: false,
+  transactionRulesUI: false,
 };
 
 export function useFeatureFlag(name: FeatureFlag): boolean {

--- a/packages/desktop-client/src/hooks/useTransactionRuleStatus.ts
+++ b/packages/desktop-client/src/hooks/useTransactionRuleStatus.ts
@@ -1,0 +1,99 @@
+import { useCallback, useEffect, useState } from 'react';
+
+import { send } from '@actual-app/core/platform/client/connection';
+import type { TransactionRuleStatus } from '@actual-app/core/server/transactions/transaction-rules';
+import type {
+  RuleEntity,
+  TransactionEntity,
+} from '@actual-app/core/types/models';
+
+import { createCategoryRuleFromTransaction } from '#components/rules/rule-helpers';
+import { pushModal } from '#modals/modalsSlice';
+import { useDispatch } from '#redux';
+
+export type { TransactionRuleStatus };
+
+export function useTransactionRuleStatus(
+  transaction: TransactionEntity | null | undefined,
+  enabled: boolean = true,
+) {
+  const dispatch = useDispatch();
+  const [ruleStatus, setRuleStatus] = useState<TransactionRuleStatus | null>(
+    null,
+  );
+  const [isLoading, setIsLoading] = useState(false);
+
+  const checkStatus = useCallback(async () => {
+    if (!enabled || !transaction) {
+      setRuleStatus(null);
+      return;
+    }
+
+    // Need at least a payee or imported_payee to match category rules
+    if (!transaction.payee && !transaction.imported_payee) {
+      setRuleStatus(null);
+      return;
+    }
+
+    setIsLoading(true);
+    try {
+      const res = await send('rule-check-transaction', { transaction });
+      setRuleStatus(res);
+    } catch (e) {
+      console.error('Failed to check transaction rules', e);
+      setRuleStatus(null);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [enabled, transaction]);
+
+  useEffect(() => {
+    void checkStatus();
+  }, [checkStatus]);
+
+  const openEditRule = useCallback(
+    (rule: RuleEntity) => {
+      dispatch(
+        pushModal({
+          modal: {
+            name: 'edit-rule',
+            options: {
+              rule,
+              onSave: () => {
+                void checkStatus();
+              },
+            },
+          },
+        }),
+      );
+    },
+    [dispatch, checkStatus],
+  );
+
+  const openCreateRule = useCallback(
+    (trans: TransactionEntity) => {
+      dispatch(
+        pushModal({
+          modal: {
+            name: 'edit-rule',
+            options: {
+              rule: createCategoryRuleFromTransaction(trans),
+              onSave: () => {
+                void checkStatus();
+              },
+            },
+          },
+        }),
+      );
+    },
+    [dispatch, checkStatus],
+  );
+
+  return {
+    ruleStatus,
+    isLoading,
+    refresh: checkStatus,
+    openEditRule,
+    openCreateRule,
+  };
+}

--- a/packages/loot-core/src/server/rules/app.ts
+++ b/packages/loot-core/src/server/rules/app.ts
@@ -79,6 +79,8 @@ export type RulesHandlers = {
   'rules-get': typeof getRules;
   'rule-get': typeof getRule;
   'rules-run': typeof runRules;
+  'rule-check-transaction': typeof checkTransactionRules;
+  'rules-check-transactions': typeof checkTransactionsRules;
 };
 
 // Expose functions to the client
@@ -94,6 +96,8 @@ app.method('rule-add-payee-rename', mutator(addRulePayeeRename));
 app.method('rules-get', getRules);
 app.method('rule-get', getRule);
 app.method('rules-run', runRules);
+app.method('rule-check-transaction', checkTransactionRules);
+app.method('rules-check-transactions', checkTransactionsRules);
 
 async function ruleValidate(
   rule: Partial<RuleEntity>,
@@ -190,4 +194,20 @@ async function runRules({
   transaction: TransactionEntity;
 }): Promise<TransactionEntity> {
   return rules.runRules(transaction);
+}
+
+async function checkTransactionRules({
+  transaction,
+}: {
+  transaction: TransactionEntity;
+}): Promise<rules.TransactionRuleStatus> {
+  return rules.checkTransactionRules(transaction);
+}
+
+async function checkTransactionsRules({
+  transactions,
+}: {
+  transactions: TransactionEntity[];
+}): Promise<Record<string, rules.TransactionRuleStatus>> {
+  return rules.checkTransactionsRules(transactions);
 }

--- a/packages/loot-core/src/server/transactions/transaction-rules.test.ts
+++ b/packages/loot-core/src/server/transactions/transaction-rules.test.ts
@@ -5,6 +5,8 @@ import { loadMappings } from '#server/db/mappings';
 import { q } from '#shared/query';
 
 import {
+  checkTransactionRules,
+  checkTransactionsRules,
   conditionsToAQL,
   deleteRule,
   getProbableCategory,
@@ -1303,6 +1305,107 @@ describe('Learning categories', () => {
     const [rule] = getRules();
     expect(rule.conditions[0].field).toBe('imported_payee');
     expect(rule.actions[0].field).toBe('payee');
+  });
+
+  describe('Rule inspection and categorization status', () => {
+    it('detects when a transaction is categorized by an active rule', async () => {
+      await db.insertWithUUID('payees', { id: 'p1', name: 'Coffee Shop' });
+      await db.insertWithUUID('categories', { id: 'c1', name: 'Dining Out' });
+      await db.insertWithUUID('categories', { id: 'c2', name: 'Groceries' });
+
+      await db.insertWithUUID('rules', {
+        stage: null,
+        conditions_op: 'and',
+        conditions: JSON.stringify([
+          { op: 'is', field: 'payee', value: 'p1', type: 'id' },
+        ]),
+        actions: JSON.stringify([
+          { op: 'set', field: 'category', value: 'c1', type: 'id' },
+        ]),
+      });
+
+      await loadRules();
+
+      // Case 1: Transaction matches rule and is categorized as c1
+      const resApplied = await checkTransactionRules({
+        id: 't1',
+        account: 'a1',
+        payee: 'p1',
+        category: 'c1',
+        amount: -500,
+        date: '2026-09-01',
+      });
+      expect(resApplied.status).toBe('applied');
+      expect(resApplied.isCategorizedByRule).toBe(true);
+      expect(resApplied.isOverridden).toBe(false);
+      expect(resApplied.ruleCategoryId).toBe('c1');
+      expect(resApplied.categorizingRule).not.toBeNull();
+      expect(resApplied.categorizingRule.actions[0].value).toBe('c1');
+
+      // Case 2: Transaction matches rule, but has empty category (will-apply)
+      const resWillApply = await checkTransactionRules({
+        id: 't2',
+        account: 'a1',
+        payee: 'p1',
+        category: null,
+        amount: -500,
+        date: '2026-09-01',
+      });
+      expect(resWillApply.status).toBe('will-apply');
+      expect(resWillApply.isCategorizedByRule).toBe(false);
+      expect(resWillApply.isOverridden).toBe(false);
+      expect(resWillApply.ruleCategoryId).toBe('c1');
+
+      // Case 3: User manually changed category to c2 (overridden)
+      const resOverridden = await checkTransactionRules({
+        id: 't3',
+        account: 'a1',
+        payee: 'p1',
+        category: 'c2',
+        amount: -500,
+        date: '2026-09-01',
+      });
+      expect(resOverridden.status).toBe('overridden');
+      expect(resOverridden.isCategorizedByRule).toBe(false);
+      expect(resOverridden.isOverridden).toBe(true);
+      expect(resOverridden.ruleCategoryId).toBe('c1');
+
+      // Case 4: No rule for this payee
+      const resNone = await checkTransactionRules({
+        id: 't4',
+        account: 'a1',
+        payee: 'p_unknown',
+        category: 'c2',
+        amount: -500,
+        date: '2026-09-01',
+      });
+      expect(resNone.status).toBe('none');
+      expect(resNone.isCategorizedByRule).toBe(false);
+      expect(resNone.isOverridden).toBe(false);
+      expect(resNone.categorizingRule).toBeNull();
+
+      // Case 5: Batch check
+      const batchRes = await checkTransactionsRules([
+        {
+          id: 't1',
+          account: 'a1',
+          payee: 'p1',
+          category: 'c1',
+          amount: -500,
+          date: '2026-09-01',
+        },
+        {
+          id: 't3',
+          account: 'a1',
+          payee: 'p1',
+          category: 'c2',
+          amount: -500,
+          date: '2026-09-01',
+        },
+      ]);
+      expect(batchRes['t1'].isCategorizedByRule).toBe(true);
+      expect(batchRes['t3'].isOverridden).toBe(true);
+    });
   });
 
   // TODO: write tests for split transactions

--- a/packages/loot-core/src/server/transactions/transaction-rules.ts
+++ b/packages/loot-core/src/server/transactions/transaction-rules.ts
@@ -402,6 +402,150 @@ export async function runRules(
   return await finalizeTransactionForRules(finalTrans);
 }
 
+export type TransactionRuleStatus = {
+  categorizingRule: RuleEntity | null;
+  status: 'applied' | 'will-apply' | 'overridden' | 'none';
+  isCategorizedByRule: boolean;
+  isOverridden: boolean;
+  ruleCategoryId: string | null;
+  ruleSummary: string | null;
+  matchedRules: RuleEntity[];
+};
+
+export async function checkTransactionRules(
+  trans: TransactionEntity,
+  accounts: Map<string, db.DbAccount> | null = null,
+): Promise<TransactionRuleStatus> {
+  await ensureFormulaPreferencesLoaded();
+
+  let accountsMap: Map<string, db.DbAccount> = null;
+  if (accounts === null) {
+    accountsMap = new Map(
+      (await db.getAccounts()).map(account => [account.id, account]),
+    );
+  } else {
+    accountsMap = accounts;
+  }
+
+  const finalTrans = await prepareTransactionForRules(
+    { ...trans },
+    accountsMap,
+  );
+
+  let scheduleRuleID = '';
+  if (trans.schedule != null) {
+    const ruleId = await getRuleIdFromScheduleId(trans.schedule);
+    if (ruleId != null) {
+      scheduleRuleID = ruleId;
+    }
+  }
+
+  const RuleIdsLinkedToSchedules =
+    await getAllRuleIdsFromSchedules(scheduleRuleID);
+
+  const rules = rankRules(
+    fastSetMerge(
+      firstcharIndexer.getApplicableRules(trans),
+      payeeIndexer.getApplicableRules(trans),
+    ),
+  );
+
+  const formulaStrings = rules.flatMap(rule =>
+    collectFormulasFromActions(rule.actions),
+  );
+  finalTrans._balanceOfPrefetched = await prefetchBalanceOfForTransaction(
+    finalTrans,
+    accountsMap,
+    formulaStrings,
+  );
+
+  let categorizingRule: RuleEntity | null = null;
+  let ruleCategoryId: string | null = null;
+  const matchedRules: RuleEntity[] = [];
+
+  for (let i = 0; i < rules.length; i++) {
+    const currentRule = rules[i];
+    let matched = false;
+
+    if (scheduleRuleID !== '') {
+      if (currentRule.id === scheduleRuleID) {
+        matched = true;
+      } else if (RuleIdsLinkedToSchedules.includes(currentRule.id)) {
+        continue;
+      } else {
+        matched = currentRule.evalConditions(finalTrans);
+      }
+    } else {
+      matched = currentRule.evalConditions(finalTrans);
+    }
+
+    if (matched) {
+      matchedRules.push(currentRule.serialize());
+
+      for (const action of currentRule.actions) {
+        if (action.field === 'category' && action.op === 'set') {
+          categorizingRule = currentRule.serialize();
+          ruleCategoryId = String(action.value);
+        }
+      }
+    }
+  }
+
+  let status: TransactionRuleStatus['status'] = 'none';
+  if (categorizingRule != null && ruleCategoryId != null) {
+    if (trans.category === ruleCategoryId) {
+      status = 'applied';
+    } else if (!trans.category) {
+      status = 'will-apply';
+    } else {
+      status = 'overridden';
+    }
+  }
+
+  let ruleSummary: string | null = null;
+  if (categorizingRule && categorizingRule.conditions.length > 0) {
+    ruleSummary = categorizingRule.conditions
+      .map(c => {
+        const valStr =
+          typeof c.value === 'object' && c.value !== null
+            ? JSON.stringify(c.value)
+            : String(c.value ?? '');
+        return `${String(c.field)} ${String(c.op)} ${valStr}`;
+      })
+      .join(', ');
+  }
+
+  return {
+    categorizingRule,
+    status,
+    isCategorizedByRule: status === 'applied',
+    isOverridden: status === 'overridden',
+    ruleCategoryId,
+    ruleSummary,
+    matchedRules,
+  };
+}
+
+export async function checkTransactionsRules(
+  transactions: TransactionEntity[],
+): Promise<Record<string, TransactionRuleStatus>> {
+  if (!transactions || transactions.length === 0) {
+    return {};
+  }
+
+  const accounts: db.DbAccount[] = await db.getAccounts();
+  const accountsMap = new Map(accounts.map(account => [account.id, account]));
+
+  const results: Record<string, TransactionRuleStatus> = {};
+  for (const trans of transactions) {
+    const status = await checkTransactionRules(trans, accountsMap);
+    if (trans.id) {
+      results[trans.id] = status;
+    }
+  }
+  return results;
+}
+
 function conditionSpecialCases(cond: Condition | null): Condition | null {
   if (!cond) {
     return cond;

--- a/packages/loot-core/src/types/prefs.ts
+++ b/packages/loot-core/src/types/prefs.ts
@@ -11,7 +11,8 @@ export type FeatureFlag =
   | 'sankeyReport'
   | 'akahuBankSync'
   | 'mobileCalculator'
-  | 'monteCarloReport';
+  | 'monteCarloReport'
+  | 'transactionRulesUI';
 
 /**
  * Cross-device preferences. These sync across devices when they are changed.

--- a/upcoming-release-notes/transaction-rules-visibility.md
+++ b/upcoming-release-notes/transaction-rules-visibility.md
@@ -1,0 +1,6 @@
+---
+category: Features
+authors: [Tim3Ds]
+---
+
+Add rule visibility indicator and intentional rule creation to transactions


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->
## Description
When creating and editing transactions in Actual Budget, it was previously unclear whether a transaction was categorized automatically by an active rule or manually assigned. Furthermore, there was no intuitive way to quickly inspect, edit, or intentionally create a rule directly from the transaction register or mobile transaction edit view.
This PR introduces rule visibility and intentional rule creation, safely guarded behind the experimental feature flag `transactionRulesUI`:
1. **Rule Visibility Indicator**:
   - Categorized transactions in the register display a subtle tuning icon (`SvgTuning`) next to the category.
   - Distinct visual states:
     - **Active Rule (`theme.pageTextPositive`)**: The category matches an active rule.
     - **Rule Overridden (`theme.warningText`)**: A rule matched this transaction, but the category was overridden.
   - An interactive tooltip displays rule conditions and an "Edit Rule" button only when the row is selected to prevent scroll lag.
2. **Intentional Rule Creation & Editing**:
   - **Desktop Category Dropdown**: The autocomplete list includes a dedicated action footer to either **"Edit rule for this transaction..."** (if a rule exists) or **"Create rule from this transaction..."** (if no rule exists).
   - **Mobile Edit Screen**: Displays an intentional rule button right next to the `Split` button below the Category field with identical height and styling ("Create Rule", "Rule Active", or "Rule (Overridden)").
   - Pre-populates conditions from the transaction's payee and sets the category action using Actual's native `EditRuleModal`.
3. **In-Memory Core Evaluation**:
   - Evaluates rule application via `firstcharIndexer` and `payeeIndexer` in memory without requiring database schema migrations.
### AI Disclosure
This feature was developed with the assistance of Google Antigravity. All generated code, tests, and formatting were self-reviewed and verified against repo standards (`CODE_REVIEW_GUIDELINES.md`, strict TypeScript, oxfmt, oxlint).
## Related issue(s)
<!-- e.g. Fixes #123, Relates to #456 -->
## Testing
### Automated Tests
- Ran unit test suite for transaction rules evaluation:
  ```bash
  yarn workspace @actual-app/core run vitest --run src/server/transactions/transaction-rules.test.ts

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 42 | 13.63 MB → 13.64 MB (+8.85 kB) | +0.06%
loot-core | 1 | 4.64 MB → 4.64 MB (+3.16 kB) | +0.07%
api | 2 | 3.85 MB → 3.85 MB (+3.09 kB) | +0.08%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
42 | 13.63 MB → 13.64 MB (+8.85 kB) | +0.06%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/hooks/useTransactionRuleStatus.ts` | 🆕 +1.45 kB | 0 B → 1.45 kB
`src/components/rules/rule-helpers.ts` | 🆕 +1 kB | 0 B → 1 kB
`src/components/transactions/TransactionsTable.tsx` | 📈 +4.42 kB (+4.72%) | 93.56 kB → 97.97 kB
`src/hooks/useFeatureFlag.ts` | 📈 +28 B (+4.52%) | 620 B → 648 B
`src/components/settings/Experimental.tsx` | 📈 +263 B (+2.85%) | 9.01 kB → 9.27 kB
`src/components/mobile/transactions/TransactionEdit.tsx` | 📈 +1.6 kB (+2.59%) | 61.82 kB → 63.42 kB
`package.json` | 📈 +77 B (+0.72%) | 10.42 kB → 10.49 kB
`src/components/autocomplete/CategoryAutocomplete.tsx` | 📈 +19 B (+0.18%) | 10.38 kB → 10.4 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/TransactionList.js | 166.98 kB → 171.4 kB (+4.42 kB) | +2.65%
static/js/Value.js | 1.79 MB → 1.79 MB (+2.5 kB) | +0.14%
static/js/TransactionEdit.js | 221.38 kB → 222.99 kB (+1.6 kB) | +0.72%
static/js/index.js | 1.6 MB → 1.6 MB (+340 B) | +0.02%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/DateSelect.js | 2.37 MB | 0%
static/js/FormulaEditor.js | 766.35 kB | 0%
static/js/ManageRules.js | 71.66 kB | 0%
static/js/NotesTagFormatter.js | 25.94 kB | 0%
static/js/PayeeRuleCountLabel.js | 12.81 kB | 0%
static/js/ReportRouter.js | 1.44 MB | 0%
static/js/ScheduleEditForm.js | 75.41 kB | 0%
static/js/SchedulesTable.js | 171.25 kB | 0%
static/js/TourHost.js | 169.22 kB | 0%
static/js/TourProvider.js | 1.54 kB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/ca.js | 170.64 kB | 0%
static/js/client.js | 452.05 kB | 0%
static/js/columns.js | 673.28 kB | 0%
static/js/de.js | 186.5 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/en.js | 245.91 kB | 0%
static/js/es.js | 164.81 kB | 0%
static/js/fr.js | 179.04 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 151.67 kB | 0%
static/js/months.js | 574.72 kB | 0%
static/js/narrow.js | 290.52 kB | 0%
static/js/nb-NO.js | 135.46 kB | 0%
static/js/nl.js | 151.78 kB | 0%
static/js/pl.js | 136.39 kB | 0%
static/js/pt-BR.js | 178.2 kB | 0%
static/js/ru.js | 212.8 kB | 0%
static/js/theme.js | 31.1 kB | 0%
static/js/uk.js | 201.42 kB | 0%
static/js/useFormatList.js | 10.22 kB | 0%
static/js/useLocalPref.js | 97.2 kB | 0%
static/js/useReducedMotion.js | 594 B | 0%
static/js/wide.js | 274.53 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 106.8 kB | 0%
static/js/zh-Hant.js | 130.92 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.64 MB → 4.64 MB (+3.16 kB) | +0.07%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/transactions/transaction-rules.ts` | 📈 +2.82 kB (+12.59%) | 22.36 kB → 25.18 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/rules/app.ts` | 📈 +349 B (+11.70%) | 2.91 kB → 3.25 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.BDejhS2f.js | 0 B → 4.64 MB (+4.64 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.BB37DR43.js | 4.64 MB → 0 B (-4.64 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.85 MB → 3.85 MB (+3.09 kB) | +0.08%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/transactions/transaction-rules.ts` | 📈 +2.75 kB (+12.27%) | 22.45 kB → 25.2 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/rules/app.ts` | 📈 +341 B (+11.69%) | 2.85 kB → 3.18 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.85 MB → 3.85 MB (+3.09 kB) | +0.08%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.16 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->