### PR TITLE
[AI] Expose parent transaction fields to split rule formulas

### DIFF
--- a/packages/desktop-client/src/components/formula/formulaBadgeRanges.ts
+++ b/packages/desktop-client/src/components/formula/formulaBadgeRanges.ts
@@ -93,6 +93,10 @@ const transactionNamedExpressionBadges: Record<string, string> = {
   reconciled: 'reconciled',
   balance: 'balance',
   parent_amount: 'parent_amount',
+  parent_notes: 'parent_notes',
+  parent_imported_payee: 'parent_imported_payee',
+  parent_payee: 'parent_payee',
+  parent_account: 'parent_account',
 };
 
 const queryNameFunctions = new Set([

--- a/packages/desktop-client/src/components/formula/formulaCatalog.ts
+++ b/packages/desktop-client/src/components/formula/formulaCatalog.ts
@@ -1456,6 +1456,42 @@ export function getRuleFieldCompletions(): Completion[] {
         'The amount of the parent transaction in cents in split transactions.\n\nExample: =(parent_amount / 100) * .05',
       ),
     },
+    {
+      label: 'parent_notes',
+      type: 'variable',
+      section: ruleFieldSection,
+      boost: 5,
+      info: t(
+        'Notes of the parent transaction in split rules. Empty when absent.',
+      ),
+    },
+    {
+      label: 'parent_imported_payee',
+      type: 'variable',
+      section: ruleFieldSection,
+      boost: 5,
+      info: t(
+        'Imported payee text of the parent transaction in split rules. Empty when absent.',
+      ),
+    },
+    {
+      label: 'parent_payee',
+      type: 'variable',
+      section: ruleFieldSection,
+      boost: 5,
+      info: t(
+        'Payee ID of the parent transaction in split rules. Empty when absent.',
+      ),
+    },
+    {
+      label: 'parent_account',
+      type: 'variable',
+      section: ruleFieldSection,
+      boost: 5,
+      info: t(
+        'Account ID of the parent transaction in split rules. Empty when absent.',
+      ),
+    },
   ];
 }
 

--- a/packages/loot-core/src/server/accounts/split-formula-import.test.ts
+++ b/packages/loot-core/src/server/accounts/split-formula-import.test.ts
@@ -1,0 +1,168 @@
+import * as db from '#server/db';
+import { loadMappings } from '#server/db/mappings';
+import { createSchedule } from '#server/schedules/app';
+import { insertRule, loadRules } from '#server/transactions/transaction-rules';
+
+import { reconcileTransactions } from './sync';
+
+beforeEach(async () => {
+  await global.emptyDatabase()();
+  await loadMappings();
+  await loadRules();
+});
+
+test('import keeps one parent, matches its schedule and transfers only the formula split', async () => {
+  await db.insertAccount({ id: 'source', name: 'Source', offbudget: 0 });
+  await db.insertAccount({
+    id: 'destination',
+    name: 'Destination',
+    offbudget: 1,
+  });
+  await db.insertPayee({
+    id: 'transfer-source',
+    name: '',
+    transfer_acct: 'source',
+  });
+  await db.insertPayee({
+    id: 'transfer-destination',
+    name: '',
+    transfer_acct: 'destination',
+  });
+  await db.insertPayee({ id: 'bank', name: 'Bank' });
+  await db.insertCategoryGroup({ id: 'group', name: 'Expenses', is_income: 0 });
+  await db.insertCategory({
+    id: 'category',
+    name: 'Payment',
+    cat_group: 'group',
+    is_income: 0,
+  });
+
+  const schedule = await createSchedule({
+    schedule: { name: 'Payment', posts_transaction: false },
+    conditions: [
+      { field: 'account', op: 'is', value: 'source' },
+      { field: 'amount', op: 'isapprox', value: -3000 },
+      {
+        field: 'date',
+        op: 'isapprox',
+        value: { start: '2024-01-15', frequency: 'monthly', patterns: [] },
+      },
+      { field: 'notes', op: 'contains', value: 'ITEM:' },
+    ],
+  });
+  await insertRule({
+    stage: 'pre',
+    conditionsOp: 'and',
+    conditions: [
+      { field: 'account', op: 'is', value: 'source' },
+      { field: 'notes', op: 'contains', value: 'ITEM:' },
+    ],
+    actions: [
+      {
+        op: 'set-split-amount',
+        value: null,
+        options: {
+          splitIndex: 1,
+          method: 'formula',
+          formula:
+            '=-VALUE(MID(parent_notes, SEARCH("ITEM: ", parent_notes)+6, SEARCH("USD", parent_notes, SEARCH("ITEM: ", parent_notes))-SEARCH("ITEM: ", parent_notes)-6))',
+        },
+      },
+      {
+        op: 'set',
+        field: 'payee',
+        value: 'transfer-destination',
+        options: { splitIndex: 1 },
+      },
+      {
+        op: 'set',
+        field: 'category',
+        value: 'category',
+        options: { splitIndex: 1 },
+      },
+      {
+        op: 'set-split-amount',
+        value: null,
+        options: { splitIndex: 2, method: 'remainder' },
+      },
+      { op: 'set', field: 'payee', value: 'bank', options: { splitIndex: 2 } },
+      {
+        op: 'set',
+        field: 'category',
+        value: 'category',
+        options: { splitIndex: 2 },
+      },
+    ],
+  });
+
+  const imported = {
+    date: '2024-01-15',
+    amount: -3000,
+    imported_id: 'bank-import-id',
+    notes: 'Payment in USD: ITEM: 25.50USD FEE: 4.50USD',
+    imported_payee: 'Imported bank',
+    cleared: true,
+  };
+  await reconcileTransactions('source', [imported]);
+  const read = () =>
+    db.all<db.DbViewTransactionInternal>(
+      'SELECT * FROM v_transactions_internal',
+    );
+  const rows = await read();
+  const parent = rows.find(row => row.is_parent);
+  if (!parent) throw new Error('Missing split parent');
+  expect(parent).toMatchObject({
+    account: 'source',
+    imported_id: imported.imported_id,
+    notes: imported.notes,
+    imported_payee: imported.imported_payee,
+    amount: -3000,
+    cleared: 1,
+    schedule,
+  });
+  const children = rows.filter(row => row.parent_id === parent.id);
+  expect(children).toHaveLength(2);
+  expect(children).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        amount: -2550,
+        payee: 'transfer-destination',
+        category: 'category',
+        cleared: 1,
+      }),
+      expect.objectContaining({
+        amount: -450,
+        payee: 'bank',
+        category: 'category',
+        cleared: 1,
+      }),
+    ]),
+  );
+  expect(children.reduce((sum, row) => sum + row.amount, 0)).toBe(
+    parent.amount,
+  );
+  const destination = rows.filter(row => row.account === 'destination');
+  expect(destination).toHaveLength(1);
+  expect(destination[0]).toMatchObject({
+    amount: 2550,
+    transfer_id: children.find(row => row.amount === -2550)?.id,
+  });
+  expect(rows).toHaveLength(4);
+
+  // A repeated bank import must preserve identity and not create another transfer.
+  await reconcileTransactions('source', [imported]);
+  const reimported = await read();
+  expect(reimported.map(row => row.id).sort()).toEqual(
+    rows.map(row => row.id).sort(),
+  );
+  expect(reimported.find(row => row.id === parent.id)).toMatchObject({
+    imported_id: imported.imported_id,
+    notes: imported.notes,
+    schedule,
+  });
+  expect(
+    reimported
+      .filter(row => row.account === 'destination')
+      .reduce((sum, row) => sum + row.amount, 0),
+  ).toBe(2550);
+});

--- a/packages/loot-core/src/server/rules/action.ts
+++ b/packages/loot-core/src/server/rules/action.ts
@@ -343,6 +343,11 @@ export class Action {
         } else {
           cellValue = fieldValues[key];
         }
+        // Parent text is data, even when it looks like a spreadsheet formula,
+        // date or number. The apostrophe is HyperFormula's literal-text escape.
+        if (key.startsWith('parent_') && typeof cellValue === 'string') {
+          cellValue = `'${cellValue}`;
+        }
         hfInstance.addNamedExpression(key, cellValue);
       }
       hfInstance.setCellContents({ sheet: sheetId, col: 0, row: 0 }, [

--- a/packages/loot-core/src/server/rules/rule.ts
+++ b/packages/loot-core/src/server/rules/rule.ts
@@ -43,7 +43,16 @@ function execSplitActions(actions: Action[], transaction) {
       const { data } = addSplitTransaction(newTransactions, transaction.id);
       newTransactions = data;
     }
+    // Keep parent data separate from the child fields changed by split actions.
     newTransactions[splitTransactionIndex].parent_amount = transaction.amount;
+    newTransactions[splitTransactionIndex].parent_notes =
+      transaction.notes ?? '';
+    newTransactions[splitTransactionIndex].parent_imported_payee =
+      transaction.imported_payee ?? '';
+    newTransactions[splitTransactionIndex].parent_payee =
+      transaction.payee ?? '';
+    newTransactions[splitTransactionIndex].parent_account =
+      transaction.account ?? '';
     newTransactions[splitTransactionIndex].balance = transaction.balance;
     newTransactions[splitTransactionIndex]._balanceOfPrefetched =
       transaction._balanceOfPrefetched;

--- a/packages/loot-core/src/server/rules/split-parent-context.test.ts
+++ b/packages/loot-core/src/server/rules/split-parent-context.test.ts
@@ -1,0 +1,121 @@
+import { finalizeTransactionForRules } from '#server/transactions/transaction-rules';
+
+import { Rule } from './rule';
+
+function splitRule(formula: string) {
+  return new Rule({
+    conditionsOp: 'and',
+    conditions: [{ field: 'amount', op: 'lt', value: 0 }],
+    actions: [
+      {
+        op: 'set',
+        field: 'notes',
+        value: 'child notes',
+        options: { splitIndex: 1 },
+      },
+      {
+        op: 'set-split-amount',
+        field: 'amount',
+        value: 0,
+        options: { splitIndex: 1, method: 'formula', formula },
+      },
+      {
+        op: 'set-split-amount',
+        field: 'amount',
+        value: 0,
+        options: { splitIndex: 2, method: 'remainder' },
+      },
+    ],
+  });
+}
+
+const parent = {
+  id: 'parent',
+  account: 'source-account',
+  payee: 'source-payee',
+  amount: -3000,
+  notes: 'ITEM: 25.50USD FEE: 4.50USD',
+  imported_payee: 'Imported bank',
+  imported_id: 'bank-id',
+  cleared: true,
+  schedule: 'schedule-id',
+  date: '2024-01-15',
+};
+
+describe('split parent formula context', () => {
+  test('keeps parent_amount in cents', () => {
+    expect(
+      splitRule('=INTEGER_TO_AMOUNT(parent_amount) / 2').exec(parent),
+    ).toMatchObject({
+      subtransactions: [{ amount: -1500 }, { amount: -1500 }],
+    });
+  });
+
+  test('reads parent notes independently of child notes', () => {
+    expect(
+      splitRule('=IF(parent_notes="' + parent.notes + '", -1, -2)').exec(
+        parent,
+      ),
+    ).toMatchObject({
+      subtransactions: [
+        { amount: -100, notes: 'child notes' },
+        { amount: -2900 },
+      ],
+    });
+  });
+
+  test('parses a decimal amount from parent notes using native functions', async () => {
+    const result = splitRule(
+      '=-VALUE(MID(parent_notes, SEARCH("ITEM: ", parent_notes)+6, SEARCH("USD", parent_notes, SEARCH("ITEM: ", parent_notes))-SEARCH("ITEM: ", parent_notes)-6))',
+    ).apply(parent);
+    expect(result).toMatchObject({
+      ...parent,
+      payee: null,
+      is_parent: true,
+      subtransactions: [{ amount: -2550 }, { amount: -450 }],
+    });
+    const finalized = await finalizeTransactionForRules(result);
+    for (const transaction of [finalized, ...finalized.subtransactions]) {
+      expect(
+        Object.keys(transaction).filter(key => key.startsWith('parent_')),
+      ).toEqual(transaction.is_child ? ['parent_id'] : []);
+    }
+  });
+
+  test.each([
+    'parent_imported_payee',
+    'parent_payee',
+    'parent_account',
+  ] as const)('exposes %s without overwriting child fields', field => {
+    const original = {
+      parent_imported_payee: parent.imported_payee,
+      parent_payee: parent.payee,
+      parent_account: parent.account,
+    };
+    expect(
+      splitRule(`=IF(${field}="${original[field]}", -1, -2)`).exec(parent),
+    ).toMatchObject({
+      subtransactions: [{ amount: -100 }, { amount: -2900 }],
+    });
+  });
+
+  test.each(['=1+1', '00123', '2024-01-15', "'quoted"])(
+    'treats parent text %s literally',
+    notes => {
+      expect(
+        splitRule(`=IF(parent_notes="${notes}", -1, -2)`).exec({
+          ...parent,
+          notes,
+        }),
+      ).toMatchObject({
+        subtransactions: [{ amount: -100 }, { amount: -2900 }],
+      });
+    },
+  );
+
+  test('absent parent text is empty', () => {
+    expect(
+      splitRule('=IF(parent_notes="", -1, -2)').exec({ amount: -300 }),
+    ).toMatchObject({ subtransactions: [{ amount: -100 }, { amount: -200 }] });
+  });
+});

--- a/packages/loot-core/src/server/transactions/transaction-rules.ts
+++ b/packages/loot-core/src/server/transactions/transaction-rules.ts
@@ -1005,6 +1005,10 @@ export type TransactionForRules = TransactionEntity & {
   /** The transaction's category's group id; see prepareTransactionForRules */
   category_group?: string;
   parent_amount?: number;
+  parent_notes?: string;
+  parent_imported_payee?: string;
+  parent_payee?: string;
+  parent_account?: string;
   /** Prefetched cent balances for BALANCE_OF("…") in rule formulas; cleared in finalize */
   _balanceOfPrefetched?: Map<string, number>;
 };
@@ -1197,8 +1201,16 @@ export async function finalizeTransactionForRules(
     delete trans._balanceOfPrefetched;
   }
 
-  if ('parent_amount' in trans) {
-    delete trans.parent_amount;
+  for (const field of [
+    'parent_amount',
+    'parent_notes',
+    'parent_imported_payee',
+    'parent_payee',
+    'parent_account',
+  ] as const) {
+    if (field in trans) {
+      delete trans[field];
+    }
   }
 
   if (trans.subtransactions?.length) {
@@ -1211,8 +1223,16 @@ export async function finalizeTransactionForRules(
         delete stx._balanceOfPrefetched;
       }
 
-      if ('parent_amount' in stx) {
-        delete stx.parent_amount;
+      for (const field of [
+        'parent_amount',
+        'parent_notes',
+        'parent_imported_payee',
+        'parent_payee',
+        'parent_account',
+      ] as const) {
+        if (field in stx) {
+          delete stx[field];
+        }
       }
     });
   }

--- a/upcoming-release-notes/split-parent-formula-context.md
+++ b/upcoming-release-notes/split-parent-formula-context.md
@@ -1,0 +1,6 @@
+---
+category: Features
+authors: [krzysztofwojt]
+---
+
+Allow split rule formulas to read the parent transaction's notes, imported payee, payee, and account.

--- a/upcoming-release-notes/split-parent-formula-context.md
+++ b/upcoming-release-notes/split-parent-formula-context.md
@@ -1,5 +1,5 @@
 ---
-category: Features
+category: Enhancements
 authors: [krzysztofwojt]
 ---
 


### PR DESCRIPTION
**Note:** Code generated with GPT-6 Astra, but reviewed by me.

## Description

Split amount formulas can access `parent_amount`, but cannot read the parent transaction's notes or other text fields. This prevents rules from splitting an imported transaction using amounts recorded in its description.

This change extends the existing parent context passed to split formulas with:

- `parent_notes`
- `parent_imported_payee`
- `parent_payee`
- `parent_account`

`parent_payee` and `parent_account` contain the parent's IDs, consistent with the corresponding transaction fields. Existing `parent_amount` behavior is preserved.

For example, a split formula can extract `25.50` from parent notes containing `ITEM: 25.50 FEE: 4.50`, assign `-25.50` to one split, and let a remainder action allocate the rest. The implementation is general and contains no use-case-specific logic.

The new fields are exposed in the formula editor and removed during transaction finalization. Text values are passed to the formula engine as literals.

AI disclosure: The implementation and tests were developed with OpenAI Codex. This description was reviewed, edited, and approved by the contributor before submission.

## Related issue(s)

This builds on #6414 and addresses the [reported inability to access parent notes in split rules](https://github.com/actualbudget/actual/issues/5949#issuecomment-4531174562).

## Testing

Added coverage for:

- Existing `parent_amount` behavior and the new parent fields.
- Extracting a numeric amount from parent notes.
- Literal handling of text values.
- Removal of temporary parent context.
- Native import with formula splits, remainder allocation, transfer handling, schedule linking, and preservation of imported transaction metadata.

Relevant rules, formulas, transaction, API, and editor test suites pass.

## Checklist

- [x] Release notes added
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 42 | 13.7 MB → 13.78 MB (+82.51 kB) | +0.59%
loot-core | 1 | 4.64 MB → 4.65 MB (+9.77 kB) | +0.21%
api | 2 | 3.85 MB → 3.86 MB (+9.65 kB) | +0.24%
cli | 1 | 8.02 MB → 8.02 MB (+306 B) | +0.00%
crdt | 1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
42 | 13.7 MB → 13.78 MB (+82.51 kB) | +0.59%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/sidebar/redesign/SideGroup.tsx` | 🆕 +5.03 kB | 0 B → 5.03 kB
`src/components/reports/graphs/MonteCarloCashflowGraphTooltip.tsx` | 🆕 +4.9 kB | 0 B → 4.9 kB
`src/components/reports/graphs/MonteCarloCashflowGraph.tsx` | 🆕 +4.52 kB | 0 B → 4.52 kB
`src/components/sidebar/redesign/AccountsSection.tsx` | 🆕 +4.09 kB | 0 B → 4.09 kB
`src/components/sidebar/redesign/AccountRow.tsx` | 🆕 +3.66 kB | 0 B → 3.66 kB
`src/components/sidebar/redesign/AccountsHeaderRow.tsx` | 🆕 +3.36 kB | 0 B → 3.36 kB
`src/components/reports/graphs/util/monteCarloCashflowChart.ts` | 🆕 +3.23 kB | 0 B → 3.23 kB
`src/components/sidebar/redesign/AccountGroupHeader.tsx` | 🆕 +2.87 kB | 0 B → 2.87 kB
`src/components/sidebar/redesign/ClosedSection.tsx` | 🆕 +2.65 kB | 0 B → 2.65 kB
`src/components/sidebar/redesign/useSidebarCollapseState.ts` | 🆕 +2.29 kB | 0 B → 2.29 kB
`src/components/sidebar/redesign/SidebarAccountGroup.tsx` | 🆕 +2.28 kB | 0 B → 2.28 kB
`src/components/sidebar/redesign/SyncDot.tsx` | 🆕 +2.12 kB | 0 B → 2.12 kB
`src/components/sidebar/redesign/SidebarIconButton.tsx` | 🆕 +2.04 kB | 0 B → 2.04 kB
`src/components/sidebar/redesign/SyncErrorRollup.tsx` | 🆕 +1.61 kB | 0 B → 1.61 kB
`src/components/reports/graphs/MonteCarloCashflowLegendGroup.tsx` | 🆕 +1.57 kB | 0 B → 1.57 kB
`src/components/sidebar/redesign/useSidebarAccountTree.ts` | 🆕 +1.41 kB | 0 B → 1.41 kB
`home/runner/work/actual/actual/packages/component-library/src/icons/v1/CheveronDownUp.tsx` | 🆕 +914 B | 0 B → 914 B
`home/runner/work/actual/actual/packages/component-library/src/icons/v1/CheveronUpDown.tsx` | 🆕 +913 B | 0 B → 913 B
`src/components/sidebar/redesign/SidebarBalance.tsx` | 🆕 +744 B | 0 B → 744 B
`src/components/sidebar/redesign/CountPill.tsx` | 🆕 +667 B | 0 B → 667 B
`src/components/reports/graphs/util/useMonteCarloTickFormatter.ts` | 🆕 +607 B | 0 B → 607 B
`src/components/sidebar/redesign/CollapseChevron.tsx` | 🆕 +338 B | 0 B → 338 B
`src/components/reports/graphs/MonteCarloCashflowSwatch.tsx` | 🆕 +310 B | 0 B → 310 B
`src/components/sidebar/redesign/styles.ts` | 🆕 +219 B | 0 B → 219 B
`home/runner/work/actual/actual/packages/loot-core/src/shared/errors.ts` | 📈 +293 B (+54.26%) | 540 B → 833 B
`src/components/reports/reports/SankeyCard.tsx` | 📈 +808 B (+17.88%) | 4.41 kB → 5.2 kB
`src/hooks/useMetaThemeColor.ts` | 📈 +511 B (+17.81%) | 2.8 kB → 3.3 kB
`src/components/reports/reportRanges.ts` | 📈 +710 B (+12.12%) | 5.72 kB → 6.41 kB
`src/components/reports/reports/monte-carlo/MonteCarlo.tsx` | 📈 +3.2 kB (+10.65%) | 30.07 kB → 33.28 kB
`src/sync-events.ts` | 📈 +833 B (+10.09%) | 8.06 kB → 8.88 kB
`src/components/reports/reports/monte-carlo/monteCarloSimulation.ts` | 📈 +2.99 kB (+8.53%) | 35.08 kB → 38.07 kB
`src/spreadsheet/bindings.ts` | 📈 +343 B (+7.11%) | 4.71 kB → 5.05 kB
`home/runner/work/actual/actual/packages/component-library/src/styles.ts` | 📈 +183 B (+5.80%) | 3.08 kB → 3.26 kB
`locale/en.json` | 📈 +12.99 kB (+5.28%) | 245.91 kB → 258.91 kB
`locale/uk.json` | 📈 +9.77 kB (+4.85%) | 201.42 kB → 211.2 kB
`package.json` | 📈 +260 B (+2.39%) | 10.61 kB → 10.86 kB
`src/components/formula/formulaCatalog.ts` | 📈 +761 B (+1.74%) | 42.76 kB → 43.5 kB
`src/components/formula/formulaBadgeRanges.ts` | 📈 +146 B (+1.35%) | 10.59 kB → 10.73 kB
`src/components/reports/reports/monte-carlo/MonteCarloRunDetailTable.tsx` | 📈 +181 B (+0.51%) | 34.82 kB → 34.99 kB
`src/style/customThemes.ts` | 📈 +60 B (+0.44%) | 13.29 kB → 13.35 kB
`src/components/reports/graphs/CashFlowGraph.tsx` | 📈 +6 B (+0.08%) | 7.75 kB → 7.75 kB
`src/components/reports/graphs/LineGraph.tsx` | 📈 +2 B (+0.02%) | 7.84 kB → 7.84 kB
`src/reports/mutations.ts` | 📈 +2 B (+0.02%) | 12.94 kB → 12.94 kB
`src/components/Notifications.tsx` | 📈 +2 B (+0.01%) | 14.73 kB → 14.73 kB
`src/components/reports/AccountSelector.tsx` | 📈 +2 B (+0.01%) | 15.54 kB → 15.54 kB
`src/components/reports/reports/monte-carlo/MonteCarloConfiguration.tsx` | 📉 -2 B (-0.01%) | 25.39 kB → 25.39 kB
`locale/ru.json` | 📉 -373 B (-0.17%) | 212.8 kB → 212.44 kB
`locale/fr.json` | 📉 -393 B (-0.21%) | 179.04 kB → 178.66 kB
`src/components/reports/reports/Sankey.tsx` | 📉 -73 B (-0.22%) | 32.54 kB → 32.47 kB
`src/style/theme.tsx` | 📉 -201 B (-2.50%) | 7.87 kB → 7.67 kB
`src/util/error.ts` | 📉 -293 B (-4.18%) | 6.85 kB → 6.56 kB
`src/components/reports/graphs/MonteCarloGraph.tsx` | 📉 -221 B (-7.07%) | 3.05 kB → 2.84 kB
`src/components/reports/reports/monte-carlo/MonteCarloRunsTable.tsx` | 📉 -1.13 kB (-8.37%) | 13.51 kB → 12.38 kB
`src/components/sidebar/redesign/SidebarRedesign.tsx` | 📉 -1.01 kB (-29.34%) | 3.43 kB → 2.42 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.64 MB → 1.68 MB (+35.89 kB) | +2.14%
static/js/ReportRouter.js | 1.46 MB → 1.48 MB (+21.56 kB) | +1.44%
static/js/en.js | 245.91 kB → 258.91 kB (+12.99 kB) | +5.28%
static/js/uk.js | 201.42 kB → 211.2 kB (+9.77 kB) | +4.85%
static/js/DateSelect.js | 2.37 MB → 2.38 MB (+1.65 kB) | +0.07%
static/js/FormulaEditor.js | 766.35 kB → 767.24 kB (+907 B) | +0.12%
static/js/Value.js | 1.79 MB → 1.79 MB (+343 B) | +0.02%
static/js/months.js | 574.92 kB → 575.1 kB (+183 B) | +0.03%

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/fr.js | 179.04 kB → 178.66 kB (-393 B) | -0.21%
static/js/ru.js | 212.8 kB → 212.44 kB (-373 B) | -0.17%

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/ManageRules.js | 71.66 kB | 0%
static/js/NotesTagFormatter.js | 25.94 kB | 0%
static/js/PayeeRuleCountLabel.js | 12.81 kB | 0%
static/js/ScheduleEditForm.js | 75.41 kB | 0%
static/js/SchedulesTable.js | 171.25 kB | 0%
static/js/TourHost.js | 169.22 kB | 0%
static/js/TourProvider.js | 1.54 kB | 0%
static/js/TransactionEdit.js | 219.59 kB | 0%
static/js/TransactionList.js | 166.98 kB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/ca.js | 170.64 kB | 0%
static/js/client.js | 452.05 kB | 0%
static/js/columns.js | 673.28 kB | 0%
static/js/de.js | 186.5 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/es.js | 164.81 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 151.67 kB | 0%
static/js/narrow.js | 290.52 kB | 0%
static/js/nb-NO.js | 135.46 kB | 0%
static/js/nl.js | 151.78 kB | 0%
static/js/pl.js | 136.39 kB | 0%
static/js/pt-BR.js | 178.2 kB | 0%
static/js/theme.js | 31.68 kB | 0%
static/js/useFormatList.js | 10.22 kB | 0%
static/js/useLocalPref.js | 97.2 kB | 0%
static/js/useReducedMotion.js | 594 B | 0%
static/js/wide.js | 274.53 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 106.8 kB | 0%
static/js/zh-Hant.js | 130.92 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.64 MB → 4.65 MB (+9.77 kB) | +0.21%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/sync/replay.ts` | 🆕 +2.99 kB | 0 B → 2.99 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/sync/serialization.ts` | 🆕 +973 B | 0 B → 973 B
`home/runner/work/actual/actual/packages/loot-core/src/server/sync/messages-pending.ts` | 🆕 +406 B | 0 B → 406 B
`home/runner/work/actual/actual/packages/loot-core/migrations/1788468782000_add_messages_pending.js` | 🆕 +167 B | 0 B → 167 B
`home/runner/work/actual/actual/packages/loot-core/src/server/sync/utils.ts` | 📈 +497 B (+394.44%) | 126 B → 623 B
`home/runner/work/actual/actual/packages/loot-core/src/server/migrate/migrations.ts` | 📈 +1.33 kB (+40.81%) | 3.27 kB → 4.6 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/transactions/import/ofx2json.ts` | 📈 +700 B (+24.46%) | 2.79 kB → 3.48 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/transactions/import/xmlcamt2json.ts` | 📈 +464 B (+16.59%) | 2.73 kB → 3.18 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/sync/reset.ts` | 📈 +212 B (+14.15%) | 1.46 kB → 1.67 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/rules/rule.ts` | 📈 +350 B (+7.65%) | 4.47 kB → 4.81 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/sync/index.ts` | 📈 +1.06 kB (+7.49%) | 14.13 kB → 15.18 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/errors.ts` | 📈 +145 B (+3.04%) | 4.66 kB → 4.8 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/rules/action.ts` | 📈 +98 B (+1.19%) | 8.06 kB → 8.16 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/transactions/transaction-rules.ts` | 📈 +238 B (+1.04%) | 22.36 kB → 22.6 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/budgetfiles/app.ts` | 📈 +97 B (+0.82%) | 11.51 kB → 11.6 kB
`node_modules/csv-parse/lib/api/index.js` | 📈 +130 B (+0.59%) | 21.37 kB → 21.5 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/transactions/import/parse-file.ts` | 📈 +20 B (+0.35%) | 5.6 kB → 5.62 kB
`home/runner/work/actual/actual/packages/loot-core/migrations/1765518577215_multiple_dashboards.js` | 📈 +2 B (+0.33%) | 614 B → 616 B
`node_modules/csv-parse/lib/utils/ResizeableBuffer.js` | 📉 -6 B (-0.41%) | 1.44 kB → 1.43 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.BASOiwtr.js | 0 B → 4.65 MB (+4.65 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.D1rKdvS-.js | 4.64 MB → 0 B (-4.64 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.85 MB → 3.86 MB (+9.65 kB) | +0.24%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/sync/replay.ts` | 🆕 +2.92 kB | 0 B → 2.92 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/sync/serialization.ts` | 🆕 +944 B | 0 B → 944 B
`home/runner/work/actual/actual/packages/loot-core/src/server/sync/messages-pending.ts` | 🆕 +405 B | 0 B → 405 B
`home/runner/work/actual/actual/packages/loot-core/migrations/1788468782000_add_messages_pending.js` | 🆕 +164 B | 0 B → 164 B
`home/runner/work/actual/actual/packages/loot-core/src/server/sync/utils.ts` | 📈 +481 B (+391.06%) | 123 B → 604 B
`home/runner/work/actual/actual/packages/loot-core/src/server/migrate/migrations.ts` | 📈 +1.31 kB (+41.05%) | 3.19 kB → 4.49 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/transactions/import/ofx2json.ts` | 📈 +689 B (+24.74%) | 2.72 kB → 3.39 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/transactions/import/xmlcamt2json.ts` | 📈 +456 B (+16.76%) | 2.66 kB → 3.1 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/sync/reset.ts` | 📈 +210 B (+14.36%) | 1.43 kB → 1.63 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/rules/rule.ts` | 📈 +346 B (+8.04%) | 4.2 kB → 4.54 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/sync/index.ts` | 📈 +1.04 kB (+7.60%) | 13.68 kB → 14.72 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/errors.ts` | 📈 +142 B (+3.02%) | 4.6 kB → 4.73 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/rules/action.ts` | 📈 +97 B (+1.25%) | 7.6 kB → 7.69 kB
`methods.ts` | 📈 +92 B (+1.22%) | 7.39 kB → 7.48 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/transactions/transaction-rules.ts` | 📈 +226 B (+0.98%) | 22.45 kB → 22.67 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/budgetfiles/app.ts` | 📈 +92 B (+0.81%) | 11.14 kB → 11.23 kB
`node_modules/csv-parse/lib/api/index.js` | 📈 +125 B (+0.59%) | 20.84 kB → 20.96 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/transactions/import/parse-file.ts` | 📈 +20 B (+0.35%) | 5.62 kB → 5.63 kB
`home/runner/work/actual/actual/packages/loot-core/migrations/1765518577215_multiple_dashboards.js` | 📈 +2 B (+0.33%) | 605 B → 607 B
`node_modules/csv-parse/lib/utils/ResizeableBuffer.js` | 📉 -6 B (-0.43%) | 1.36 kB → 1.36 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.85 MB → 3.86 MB (+9.65 kB) | +0.24%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB → 8.02 MB (+306 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/connection.ts` | 📈 +306 B (+9.01%) | 3.32 kB → 3.62 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB → 8.02 MB (+306 B) | +0.00%

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.16 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->