### PR TITLE
[AI] Fix upload-user-file network-failure by removing manual Content-Length

### DIFF
--- a/packages/loot-core/src/server/cloud-storage.test.ts
+++ b/packages/loot-core/src/server/cloud-storage.test.ts
@@ -1,7 +1,15 @@
-const { mockedFetch, mockedGetItem, mockedRemoveItem } = vi.hoisted(() => ({
+const {
+  mockedFetch,
+  mockedGetItem,
+  mockedRemoveItem,
+  mockedGetPrefs,
+  mockedSavePrefs,
+} = vi.hoisted(() => ({
   mockedFetch: vi.fn(),
   mockedGetItem: vi.fn(),
   mockedRemoveItem: vi.fn(),
+  mockedGetPrefs: vi.fn(),
+  mockedSavePrefs: vi.fn(),
 }));
 
 vi.unmock('#server/post');
@@ -14,6 +22,42 @@ vi.mock('#platform/server/fetch', () => ({
 vi.mock('#platform/server/asyncStorage', () => ({
   getItem: mockedGetItem,
   removeItem: mockedRemoveItem,
+}));
+
+vi.mock('#platform/server/fs', () => ({
+  getBudgetDir: () => '/budget',
+  join: (...parts: string[]) => parts.join('/'),
+  readFile: async (path: string) =>
+    path.endsWith('metadata.json')
+      ? JSON.stringify({ id: 'budget-id' })
+      : Buffer.from('db'),
+}));
+
+vi.mock('#platform/server/sqlite', () => ({
+  openDatabase: async () => ({}),
+  execQuery: vi.fn(),
+  exportDatabase: async () => Buffer.from('exported-db'),
+  closeDatabase: vi.fn(),
+}));
+
+vi.mock('#platform/server/memory', () => ({
+  getAvailableMemory: () => null,
+}));
+
+vi.mock('./mutators', () => ({
+  runMutator: (fn: () => unknown) => fn(),
+}));
+
+vi.mock('./prefs', () => ({
+  getPrefs: mockedGetPrefs,
+  savePrefs: mockedSavePrefs,
+}));
+
+vi.mock('./util/zip', () => ({
+  safeZip: () => new Uint8Array([1, 2, 3]),
+  safeUnzip: () => ({}),
+  exceedsSafeUnzipLimits: () => false,
+  UnsafeZipError: class UnsafeZipError extends Error {},
 }));
 
 describe('listRemoteFiles', () => {
@@ -69,5 +113,50 @@ describe('listRemoteFiles', () => {
     await listRemoteFiles();
 
     expect(mockedRemoveItem).toHaveBeenCalledWith('user-token');
+  });
+});
+
+describe('upload', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mockedFetch.mockReset();
+    mockedGetItem.mockReset().mockResolvedValue('token');
+    mockedRemoveItem.mockReset();
+    mockedSavePrefs.mockReset();
+    mockedGetPrefs.mockReset().mockReturnValue({
+      id: 'budget-id',
+      budgetName: 'My Budget',
+      cloudFileId: 'cloud-file-id',
+      groupId: 'group-id',
+      encryptKeyId: null,
+    });
+  });
+
+  // Setting Content-Length by hand is not just redundant, it is rejected: fetch appends its own
+  // content-length derived from the body, the Headers list combines the two into "N, N", and undici
+  // throws InvalidArgumentError('invalid content-length header') before the request leaves the
+  // process. Same defect #8195 fixed in postBinary; upload() sets the header via fetchJSON instead,
+  // so it was missed.
+  it('does not set Content-Length manually and lets fetch derive it', async () => {
+    mockedFetch.mockResolvedValue(
+      new Response(JSON.stringify({ status: 'ok', groupId: 'group-id' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const { setServer } = await import('./server-config');
+    setServer('https://test.env');
+    const { upload } = await import('./cloud-storage');
+    await upload();
+
+    expect(mockedFetch).toHaveBeenCalledOnce();
+    const options = mockedFetch.mock.calls[0][1];
+    expect(options?.headers).not.toHaveProperty('Content-Length');
+    expect(options?.headers).toMatchObject({
+      'Content-Type': 'application/encrypted-file',
+      'X-ACTUAL-TOKEN': 'token',
+      'X-ACTUAL-FILE-ID': 'cloud-file-id',
+    });
   });
 });

--- a/packages/loot-core/src/server/cloud-storage.ts
+++ b/packages/loot-core/src/server/cloud-storage.ts
@@ -334,7 +334,6 @@ export async function upload() {
     res = await fetchJSON(getServer().SYNC_SERVER + '/upload-user-file', {
       method: 'POST',
       headers: {
-        'Content-Length': String(uploadContent.length),
         'Content-Type': 'application/encrypted-file',
         'X-ACTUAL-TOKEN': userToken,
         'X-ACTUAL-FILE-ID': cloudFileId,

--- a/upcoming-release-notes/fix-upload-user-file-content-length.md
+++ b/upcoming-release-notes/fix-upload-user-file-content-length.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [sharpbiztech]
+---
+
+Fix budget file uploads failing with `invalid content-length header` by letting fetch derive Content-Length in `upload()`


### PR DESCRIPTION
## Description

`cloud-storage.upload()` hand-sets a `Content-Length` header on the `/upload-user-file` request. `fetch` then appends its **own** content-length derived from the body, the Headers list combines the two into `"N, N"`, and undici rejects that with `InvalidArgumentError: invalid content-length header` **before the request ever leaves the process**. Callers see it as `Upload failure TypeError: fetch failed` with an `UND_ERR_INVALID_ARG` cause.

This is the same defect #8195 fixed in `postBinary` for #8168, and the same remedy. It was missed here because `upload()` builds its request through `fetchJSON` rather than `postBinary` — it was the last hand-set `Content-Length` left in the codebase.

Browsers are unaffected: `Content-Length` is a forbidden header name, so `fetch` silently drops it there. Node is not, which makes this reproducible for every `@actual-app/api` consumer. It is also quiet in a way that hurts: `upload()` is the only writer of `prefs.lastUploaded`, so a failure leaves it pinned and every later sync retries and re-fails. CRDT message sync keeps working the whole time, so the sync server's base file just goes indefinitely stale with nothing surfacing in the UI.

Removing the header changes nothing on the wire — `fetch` sets an identical, correct content-length from the body itself.

Not size-dependent: it reproduces with a 5 KB body.

AI disclosure, per the [AI Usage Policy](https://actualbudget.org/docs/contributing/ai-usage-policy): the root-cause investigation, this patch, and the regression test were written with **Claude Code (Claude Opus 5)**. Every line was reviewed, and the behaviour was verified against a real self-hosted deployment before the PR was opened (see Testing).

## Related issue(s)

Relates to #8168 — follows #8195, which fixed the `postBinary` half of the same defect.

## Testing

**Reproduced in production**, self-hosted `actual-server`, `@actual-app/api` 26.7.0, Node 20.20.2, undici 7.29.0:

- 383 `Upload failure … invalid content-length header` occurrences across 8 days on two instances.
- `prefs.lastUploaded` pinned at `2026-07-05`, so every sync re-attempted and re-failed, and the sync server's stored base file went two months without a refresh.
- With the header removed, `POST 200 /upload-user-file` and the server-side blob refreshed — confirmed in the sync server's own request log, not just the client's.
- Also confirmed the inverse on a smaller budget: a request carrying the exact header set reached the server instead of throwing `UND_ERR_INVALID_ARG`.

**Regression test** (`cloud-storage.test.ts`), mirroring the `postBinary` one added in #8195 — verified in **both** directions: it fails with the header present and passes without it.

**Locally, before pushing:** `cloud-storage` + `post` suites 9/9 · `yarn typecheck` clean across 209 strict files · `oxlint --type-aware` and `oxfmt --check` clean. All CI checks on this PR are green.

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->
