### PR TITLE
#7106 - Restore clock timestamp when message sync fails

### DIFF
--- a/packages/loot-core/src/server/sync/index.ts
+++ b/packages/loot-core/src/server/sync/index.ts
@@ -445,18 +445,34 @@ export const applyMessages = sequential(async (messages: Message[]) => {
 });
 
 export function receiveMessages(messages: Message[]): Promise<Message[]> {
+  // Timestamp.recv() mutates the shared clock immediately, but the
+  // messages might not be applied if the transaction fails.
+  // Restore the clock in that case so a failed batch can't bump it.
+  const timestamp = getClock().timestamp;
+  const savedMillis = timestamp.millis();
+  const savedCounter = timestamp.counter();
+
+  function restoreClock() {
+    timestamp.setMillis(savedMillis);
+    timestamp.setCounter(savedCounter);
+  }
+
   try {
     messages.forEach(msg => {
       Timestamp.recv(msg.timestamp);
     });
   } catch (e) {
+    restoreClock();
     if (e instanceof Timestamp.ClockDriftError) {
       throw new SyncError('clock-drift');
     }
     throw e;
   }
 
-  return runMutator(() => applyMessages(messages));
+  return runMutator(() => applyMessages(messages)).catch(e => {
+    restoreClock();
+    throw e;
+  });
 }
 
 async function errorHandler(e: Error) {

--- a/packages/loot-core/src/server/sync/index.ts
+++ b/packages/loot-core/src/server/sync/index.ts
@@ -445,33 +445,33 @@ export const applyMessages = sequential(async (messages: Message[]) => {
 });
 
 export function receiveMessages(messages: Message[]): Promise<Message[]> {
-  // Timestamp.recv() mutates the shared clock immediately, but the
-  // messages might not be applied if the transaction fails.
-  // Restore the clock in that case so a failed batch can't bump it.
-  const timestamp = getClock().timestamp;
-  const savedMillis = timestamp.millis();
-  const savedCounter = timestamp.counter();
+  return runMutator(async () => {
+    // Timestamp.recv() mutates the shared clock immediately, but the
+    // messages might not be applied if the transaction fails.
+    // Restore the clock in that case so a failed batch can't bump it.
+    const timestamp = getClock().timestamp;
+    const savedMillis = timestamp.millis();
+    const savedCounter = timestamp.counter();
 
-  function restoreClock() {
-    timestamp.setMillis(savedMillis);
-    timestamp.setCounter(savedCounter);
-  }
-
-  try {
-    messages.forEach(msg => {
-      Timestamp.recv(msg.timestamp);
-    });
-  } catch (e) {
-    restoreClock();
-    if (e instanceof Timestamp.ClockDriftError) {
-      throw new SyncError('clock-drift');
+    function restoreClock() {
+      timestamp.setMillis(savedMillis);
+      timestamp.setCounter(savedCounter);
     }
-    throw e;
-  }
 
-  return runMutator(() => applyMessages(messages)).catch(e => {
-    restoreClock();
-    throw e;
+    try {
+      messages.forEach(msg => {
+        Timestamp.recv(msg.timestamp);
+      });
+
+      return await applyMessages(messages);
+    } catch (e) {
+      restoreClock();
+
+      if (e instanceof Timestamp.ClockDriftError) {
+        throw new SyncError('clock-drift');
+      }
+      throw e;
+    }
   });
 }
 

--- a/packages/loot-core/src/server/sync/sync.test.ts
+++ b/packages/loot-core/src/server/sync/sync.test.ts
@@ -9,7 +9,13 @@ import * as mockSyncServer from '#server/tests/mockSyncServer';
 import * as encoder from './encoder';
 import { isError } from './utils';
 
-import { applyMessages, fullSync, sendMessages, setSyncingMode } from './index';
+import {
+  applyMessages,
+  fullSync,
+  receiveMessages,
+  sendMessages,
+  setSyncingMode,
+} from './index';
 
 beforeEach(() => {
   mockSyncServer.reset();
@@ -149,6 +155,44 @@ describe('Sync', () => {
     if (isError(result)) throw result.error;
     expect(result.messages.length).toBe(2);
     expect(mockSyncServer.getMessages().length).toBe(3);
+  });
+});
+
+describe('receiveMessages', () => {
+  it('restores the clock if a message in the batch triggers clock drift', async () => {
+    void prefs.loadPrefs();
+    void prefs.savePrefs({ groupId: 'group' });
+
+    const before = getClock().timestamp.toString();
+
+    const okMessage = {
+      dataset: 'transactions',
+      row: 'foo',
+      column: 'amount',
+      value: 3200,
+      timestamp: new Timestamp(Date.now(), 0, '0000000000000001'),
+    };
+    const driftedMessage = {
+      dataset: 'transactions',
+      row: 'foo',
+      column: 'amount',
+      value: 4200,
+      timestamp: new Timestamp(
+        Date.now() + 10 * 60 * 1000,
+        0,
+        '0000000000000002',
+      ),
+    };
+
+    let error;
+    try {
+      await receiveMessages([okMessage, driftedMessage]);
+    } catch (e) {
+      error = e;
+    }
+
+    expect(error).toBeTruthy();
+    expect(getClock().timestamp.toString()).toEqual(before);
   });
 });
 

--- a/packages/loot-core/src/server/sync/sync.test.ts
+++ b/packages/loot-core/src/server/sync/sync.test.ts
@@ -194,6 +194,51 @@ describe('receiveMessages', () => {
     expect(error).toBeTruthy();
     expect(getClock().timestamp.toString()).toEqual(before);
   });
+
+  it('safely handles concurrent batches where the first fails and the second succeeds', async () => {
+    void prefs.loadPrefs();
+    void prefs.savePrefs({ groupId: 'group' });
+
+    const now = Date.now();
+
+    // Batch 1: 1 valid message and 1 message with clock-drift
+    const batch1ValidMsg = {
+      dataset: 'transactions',
+      row: 'foo',
+      column: 'amount',
+      value: 1111,
+      timestamp: new Timestamp(now + 1000, 0, '0000000000000001'),
+    };
+    const batch1DriftedMsg = {
+      dataset: 'transactions',
+      row: 'foo',
+      column: 'amount',
+      value: 2222,
+      timestamp: new Timestamp(now + 10 * 60 * 1000, 0, '0000000000000002'),
+    };
+
+    // Batch 2: 1 valid message
+    const batch2ValidMsg = {
+      dataset: 'transactions',
+      row: 'bar',
+      column: 'amount',
+      value: 3333,
+      timestamp: new Timestamp(now + 2000, 0, '0000000000000003'),
+    };
+
+    const batch1Promise = receiveMessages([batch1ValidMsg, batch1DriftedMsg]);
+    const batch2Promise = receiveMessages([batch2ValidMsg]);
+
+    const results = await Promise.allSettled([batch1Promise, batch2Promise]);
+
+    expect(results[0].status).toBe('rejected');
+    expect(results[1].status).toBe('fulfilled');
+
+    // The final clock state timestamp should match only Batch 2's
+    expect(getClock().timestamp.millis()).toEqual(
+      batch2ValidMsg.timestamp.millis(),
+    );
+  });
 });
 
 function registerBudgetMonths(months) {

--- a/upcoming-release-notes/restore-clock-state-on-failed-received-messages-sync.md
+++ b/upcoming-release-notes/restore-clock-state-on-failed-received-messages-sync.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [jsoberg]
+---
+
+Restores the clock state when messages fail to be applied in a sync. Timestamp.recv would otherwise advance the clock without applying messages, permanently bumping the clock state potentially causing clock drift


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: g. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

<!-- If AI tools wrote a significant part of this change, please disclose it here and name the tool you used. See https://actualbudget.org/docs/contributing/ai-usage-policy -->

Attempting to guard against permanent clock drift issues from time mismatches across client/server.

`Timestamp.recv` sets the clock state in each message for a batch receive, but if a message fails later on in the batch none of the messages will get written, leaving the clock's state bumped forward without applied messages.

This change restores the clock on a failure to the original state to avoid clock drift issues.


**AI Usage**: Claude (Sonnet) was used to investigate potential time sync issues which is how this was identified.

## Related issue(s)

Relates to #7106 

<!-- e.g. Fixes #123, Relates to #456 -->

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

Added a test in `sync.test.ts` to verify a "bad" message in a batch doesn't bump the clock unnecessarily.

```
yarn test
lage - Version 2.15.17 - 2 Workers
[20:11:53] ✓ success  @actual-app/ci-actions - test (0.85s)
[20:11:54] ✓ success  @actual-app/cli - test (0.88s)
[20:11:58] ✓ success  @actual-app/components - test (3.46s)
[20:11:58] ✓ success  @actual-app/crdt - test (0.64s)
[20:13:05] ✓ success  @actual-app/web - test (1m 6.59s)
[20:13:06] ✓ success  eslint-plugin-actual - test (0.99s)
[20:13:09] ✓ success  @actual-app/api - test (1m 16.61s)
[20:13:45] ✓ success  @actual-app/sync-server - test (36.01s)
[20:14:11] ✓ success  @actual-app/core - test (1m 4.90s)

Summary
┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
success: 9, skipped: 0, pending: 0, aborted: 0, failed: 0
worker restarts: 0, max worker memory usage: 91.82 MB
┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
Took a total of 2m 18.30s to complete. 
```

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 42 | 13.7 MB → 13.62 MB (-87.13 kB) | -0.62%
loot-core | 1 | 4.64 MB → 4.64 MB (+301 B) | +0.01%
api | 2 | 3.85 MB → 3.85 MB (+291 B) | +0.01%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
42 | 13.7 MB → 13.62 MB (-87.13 kB) | -0.62%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`locale/ru.json` | 📈 +642 B (+0.29%) | 212.8 kB → 213.43 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/ru.js | 212.8 kB → 213.43 kB (+642 B) | +0.29%

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/TransactionList.js | 166.98 kB → 79.22 kB (-87.76 kB) | -52.56%

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.64 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/DateSelect.js | 2.37 MB | 0%
static/js/FormulaEditor.js | 766.35 kB | 0%
static/js/ManageRules.js | 71.66 kB | 0%
static/js/NotesTagFormatter.js | 25.94 kB | 0%
static/js/PayeeRuleCountLabel.js | 12.81 kB | 0%
static/js/ReportRouter.js | 1.46 MB | 0%
static/js/ScheduleEditForm.js | 75.41 kB | 0%
static/js/SchedulesTable.js | 171.25 kB | 0%
static/js/TourHost.js | 169.22 kB | 0%
static/js/TourProvider.js | 1.54 kB | 0%
static/js/TransactionEdit.js | 219.59 kB | 0%
static/js/Value.js | 1.79 MB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/ca.js | 170.64 kB | 0%
static/js/client.js | 452.05 kB | 0%
static/js/columns.js | 673.28 kB | 0%
static/js/de.js | 186.5 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/en.js | 245.91 kB | 0%
static/js/es.js | 164.81 kB | 0%
static/js/fr.js | 179.04 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 151.67 kB | 0%
static/js/months.js | 574.92 kB | 0%
static/js/narrow.js | 290.52 kB | 0%
static/js/nb-NO.js | 135.46 kB | 0%
static/js/nl.js | 151.78 kB | 0%
static/js/pl.js | 136.39 kB | 0%
static/js/pt-BR.js | 178.2 kB | 0%
static/js/theme.js | 31.68 kB | 0%
static/js/uk.js | 201.42 kB | 0%
static/js/useFormatList.js | 10.22 kB | 0%
static/js/useLocalPref.js | 97.2 kB | 0%
static/js/useReducedMotion.js | 594 B | 0%
static/js/wide.js | 274.53 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 106.8 kB | 0%
static/js/zh-Hant.js | 130.92 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.64 MB → 4.64 MB (+301 B) | +0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/sync/index.ts` | 📈 +301 B (+2.08%) | 14.13 kB → 14.42 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.B-Ffhahp.js | 0 B → 4.64 MB (+4.64 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.D1rKdvS-.js | 4.64 MB → 0 B (-4.64 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.85 MB → 3.85 MB (+291 B) | +0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/sync/index.ts` | 📈 +291 B (+2.08%) | 13.68 kB → 13.97 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.85 MB → 3.85 MB (+291 B) | +0.01%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.16 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->