### PR TITLE
#7106 - Reject sync messages too far in future to avoid clock drift

### DIFF
--- a/packages/sync-server/src/app-sync.test.ts
+++ b/packages/sync-server/src/app-sync.test.ts
@@ -2,7 +2,12 @@
 import crypto from 'node:crypto';
 import fs from 'node:fs';
 
-import { create, SyncRequestSchema, toBinary } from '@actual-app/crdt';
+import {
+  create,
+  MessageEnvelopeSchema,
+  SyncRequestSchema,
+  toBinary,
+} from '@actual-app/crdt';
 import request from 'supertest';
 
 import { getAccountDb } from './account-db';
@@ -1533,6 +1538,31 @@ describe('/sync', () => {
 
     expect(res.statusCode).toEqual(403);
     expect(res.text).toEqual('file-access-not-allowed');
+  });
+
+  it('returns 400 if a message timestamp is too far in the future', async () => {
+    const fileId = crypto.randomBytes(16).toString('hex');
+    const groupId = 'group-id';
+    const keyId = 'key-id';
+    const syncVersion = 2;
+    const encryptMeta = JSON.stringify({ keyId });
+
+    addMockFile(fileId, groupId, keyId, encryptMeta, syncVersion);
+
+    const syncRequest = createMinimalSyncRequest(fileId, groupId, keyId);
+    const farFutureMillis = Date.now() + 2 * 24 * 60 * 60 * 1000; // 2 days
+    syncRequest.messages = [
+      create(MessageEnvelopeSchema, {
+        timestamp: `${new Date(farFutureMillis).toISOString()}-0000-0000000000000000`,
+        isEncrypted: false,
+        content: new Uint8Array(),
+      }),
+    ];
+
+    const res = await sendSyncRequest(syncRequest);
+
+    expect(res.statusCode).toEqual(400);
+    expect(res.text).toEqual('clock-drift');
   });
 
   it("allows an admin to sync another user's file", async () => {

--- a/packages/sync-server/src/app-sync.ts
+++ b/packages/sync-server/src/app-sync.ts
@@ -188,7 +188,16 @@ app.post('/sync', async (req, res): Promise<void> => {
     return;
   }
 
-  const { trie, newMessages } = simpleSync.sync(messages, since, groupId);
+  let trie, newMessages;
+  try {
+    ({ trie, newMessages } = simpleSync.sync(messages, since, groupId));
+  } catch (e) {
+    if (e instanceof simpleSync.ClockDriftError) {
+      res.status(400).send('clock-drift');
+      return;
+    }
+    throw e;
+  }
 
   const responsePb = create(SyncResponseSchema, {
     merkle: JSON.stringify(trie),

--- a/packages/sync-server/src/app-sync.ts
+++ b/packages/sync-server/src/app-sync.ts
@@ -192,7 +192,7 @@ app.post('/sync', async (req, res): Promise<void> => {
   try {
     ({ trie, newMessages } = simpleSync.sync(messages, since, groupId));
   } catch (e) {
-    if (e instanceof simpleSync.ClockDriftError) {
+    if (e.code === simpleSync.CLOCK_DRIFT_ERROR_CODE) {
       res.status(400).send('clock-drift');
       return;
     }

--- a/packages/sync-server/src/sync-simple.js
+++ b/packages/sync-server/src/sync-simple.js
@@ -16,11 +16,15 @@ import { getPathForGroupFile } from './util/paths';
 // forever and break sync for every device in the group.
 const MAX_FUTURE_DRIFT_MS = 24 * 60 * 60 * 1000; // 1 day
 
-export class ClockDriftError extends Error {}
+export const CLOCK_DRIFT_ERROR_CODE = 'clock-drift';
+
+function createClockDriftError(message) {
+  return Object.assign(new Error(message), { code: CLOCK_DRIFT_ERROR_CODE });
+}
 
 function isTimestampTooFarInFuture(timestamp) {
   const parsed = Timestamp.parse(timestamp);
-  return !parsed || parsed.millis() - Date.now() > MAX_FUTURE_DRIFT_MS;
+  return !parsed || parsed.millis() - Date.now() >= MAX_FUTURE_DRIFT_MS;
 }
 
 function getGroupDb(groupId) {
@@ -44,7 +48,7 @@ function addMessages(db, messages) {
     if (messages.length > 0) {
       for (const msg of messages) {
         if (isTimestampTooFarInFuture(msg.timestamp)) {
-          throw new ClockDriftError(
+          throw createClockDriftError(
             'Rejecting sync message with timestamp too far in the future: ' +
               msg.timestamp,
           );

--- a/packages/sync-server/src/sync-simple.js
+++ b/packages/sync-server/src/sync-simple.js
@@ -11,6 +11,18 @@ import { openDatabase } from './db';
 import messagesSql from './sql/messages.sql?raw';
 import { getPathForGroupFile } from './util/paths';
 
+// A client with a badly drifted clock can send a timestamp far in the
+// future, which would otherwise get baked into the shared merkle trie
+// forever and break sync for every device in the group.
+const MAX_FUTURE_DRIFT_MS = 24 * 60 * 60 * 1000; // 1 day
+
+export class ClockDriftError extends Error {}
+
+function isTimestampTooFarInFuture(timestamp) {
+  const parsed = Timestamp.parse(timestamp);
+  return !parsed || parsed.millis() - Date.now() > MAX_FUTURE_DRIFT_MS;
+}
+
 function getGroupDb(groupId) {
   const path = getPathForGroupFile(groupId);
   const needsInit = !existsSync(path);
@@ -31,6 +43,13 @@ function addMessages(db, messages) {
 
     if (messages.length > 0) {
       for (const msg of messages) {
+        if (isTimestampTooFarInFuture(msg.timestamp)) {
+          throw new ClockDriftError(
+            'Rejecting sync message with timestamp too far in the future: ' +
+              msg.timestamp,
+          );
+        }
+
         const info = db.mutate(
           `INSERT OR IGNORE INTO messages_binary (timestamp, is_encrypted, content)
              VALUES (?, ?, ?)`,
@@ -70,25 +89,27 @@ function getMerkle(db) {
 
 export function sync(messages, since, groupId) {
   const db = getGroupDb(groupId);
-  const newMessages = db.all(
-    `SELECT * FROM messages_binary
-         WHERE timestamp > ?
-         ORDER BY timestamp`,
-    [since],
-  );
+  try {
+    const newMessages = db.all(
+      `SELECT * FROM messages_binary
+           WHERE timestamp > ?
+           ORDER BY timestamp`,
+      [since],
+    );
 
-  const trie = addMessages(db, messages);
+    const trie = addMessages(db, messages);
 
-  db.close();
-
-  return {
-    trie,
-    newMessages: newMessages.map(msg =>
-      create(MessageEnvelopeSchema, {
-        timestamp: msg.timestamp,
-        isEncrypted: msg.is_encrypted === 1,
-        content: msg.content,
-      }),
-    ),
-  };
+    return {
+      trie,
+      newMessages: newMessages.map(msg =>
+        create(MessageEnvelopeSchema, {
+          timestamp: msg.timestamp,
+          isEncrypted: msg.is_encrypted === 1,
+          content: msg.content,
+        }),
+      ),
+    };
+  } finally {
+    db.close();
+  }
 }

--- a/upcoming-release-notes/reject-sync-messages-too-far-in-future.md
+++ b/upcoming-release-notes/reject-sync-messages-too-far-in-future.md
@@ -3,4 +3,4 @@ category: Bugfixes
 authors: [jsoberg]
 ---
 
-Rejects incoming messages that have a timestamp too far in the future, since they would cause permanent clock drift issues. This isolates the problem to just the client trying to send the message, rather than all clients connected to the server.
+Fixed an issue where a device with an incorrect clock could permanently break syncing for everyone sharing the budget.

--- a/upcoming-release-notes/reject-sync-messages-too-far-in-future.md
+++ b/upcoming-release-notes/reject-sync-messages-too-far-in-future.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [jsoberg]
+---
+
+Rejects incoming messages that have a timestamp too far in the future, since they would cause permanent clock drift issues. This isolates the problem to just the client trying to send the message, rather than all clients connected to the server.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

<!-- If AI tools wrote a significant part of this change, please disclose it here and name the tool you used. See https://actualbudget.org/docs/contributing/ai-usage-policy -->

Attempting to add a more robust guard against clock drift issues, alongside https://github.com/actualbudget/actual/pull/8904

A client sending a message with a far off time can push a message that is timestamped incorrectly enough to cause permanent clock drift sync issues. This guard checks if an incoming message is too far off server time (1 day or more) and rejects it with an explicit 400 stating the issue. This would present the client with the timestamp problem with the error without causing a clock drift issue on the server that can only be fixed by resetting sync/affecting all clients.

Additionally, moves the DB closure of `sync` into a finally block to make sure it gets closed on error.

**AI Usage**: Used Claude (Sonnet) to investigate potential clock drift issues and self-review my code/syntax (typescript isn't my strong suit lol)

## Related issue(s)

Relates to #7106 

<!-- e.g. Fixes #123, Relates to #456 -->

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

Tested that a far drifted timestamp message returns with an explicitly marked 400 dealing with clock drift.

```
lage - Version 2.15.17 - 2 Workers
[20:45:28] - skipped  @actual-app/ci-actions - test (0.15s)
[20:45:28] - skipped  @actual-app/api - test (0.16s)
[20:45:28] - skipped  @actual-app/cli - test (0.01s)
[20:45:28] - skipped  @actual-app/crdt - test (0.00s)
[20:45:28] - skipped  @actual-app/components - test (0.07s)
[20:45:28] - skipped  @actual-app/web - test (0.12s)
[20:45:28] - skipped  eslint-plugin-actual - test (0.06s)
[20:46:04] ✓ success  @actual-app/sync-server - test (36.26s)
[20:46:33] ✓ success  @actual-app/core - test (1m 5.47s)

Summary
┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
success: 2, skipped: 7, pending: 0, aborted: 0, failed: 0
worker restarts: 0, max worker memory usage: 38.82 MB
┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
Took a total of 1m 5.76s to complete. 
```


## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->
