### PR TITLE
Stop autofocusing search on mobile autocomplete pickers

### DIFF
--- a/packages/desktop-client/src/components/modals/AccountAutocompleteModal.tsx
+++ b/packages/desktop-client/src/components/modals/AccountAutocompleteModal.tsx
@@ -77,7 +77,7 @@ export function AccountAutocompleteModal({
             )}
             <View style={{ flex: 1 }}>
               <AccountAutocomplete
-                focused
+                focused={!isNarrowWidth}
                 embedded
                 closeOnBlur={false}
                 onClose={() => state.close()}

--- a/packages/desktop-client/src/components/modals/AutocompleteModals.focus.test.tsx
+++ b/packages/desktop-client/src/components/modals/AutocompleteModals.focus.test.tsx
@@ -1,0 +1,102 @@
+import type { ReactNode } from 'react';
+
+import { render } from '@testing-library/react';
+
+import { TestProviders } from '#mocks';
+
+import { AccountAutocompleteModal } from './AccountAutocompleteModal';
+import { CategoryAutocompleteModal } from './CategoryAutocompleteModal';
+import { PayeeAutocompleteModal } from './PayeeAutocompleteModal';
+
+const { useResponsiveMock } = vi.hoisted(() => ({
+  useResponsiveMock: vi.fn(),
+}));
+vi.mock('@actual-app/components/hooks/useResponsive', () => ({
+  useResponsive: useResponsiveMock,
+}));
+
+const { categoryAutocompleteSpy } = vi.hoisted(() => ({
+  categoryAutocompleteSpy: vi.fn(),
+}));
+vi.mock('#components/autocomplete/CategoryAutocomplete', () => ({
+  CategoryAutocomplete: (props: Record<string, unknown>) => {
+    categoryAutocompleteSpy(props);
+    return null;
+  },
+}));
+
+const { payeeAutocompleteSpy } = vi.hoisted(() => ({
+  payeeAutocompleteSpy: vi.fn(),
+}));
+vi.mock('#components/autocomplete/PayeeAutocomplete', () => ({
+  PayeeAutocomplete: (props: Record<string, unknown>) => {
+    payeeAutocompleteSpy(props);
+    return null;
+  },
+}));
+
+const { accountAutocompleteSpy } = vi.hoisted(() => ({
+  accountAutocompleteSpy: vi.fn(),
+}));
+vi.mock('#components/autocomplete/AccountAutocomplete', () => ({
+  AccountAutocomplete: (props: Record<string, unknown>) => {
+    accountAutocompleteSpy(props);
+    return null;
+  },
+}));
+
+vi.mock('#hooks/usePayees', () => ({ usePayees: () => ({ data: [] }) }));
+vi.mock('#hooks/useAccounts', () => ({ useAccounts: () => ({ data: [] }) }));
+vi.mock('#hooks/useNavigate', () => ({ useNavigate: () => vi.fn() }));
+
+function renderWithProviders(children: ReactNode) {
+  render(<TestProviders>{children}</TestProviders>);
+}
+
+describe.each([
+  { isNarrowWidth: true, expectedFocused: false, label: 'narrow (mobile)' },
+  {
+    isNarrowWidth: false,
+    expectedFocused: true,
+    label: 'not narrow (desktop)',
+  },
+])(
+  'autocomplete modal auto-focus - $label',
+  ({ isNarrowWidth, expectedFocused }) => {
+    beforeEach(() => {
+      useResponsiveMock.mockReturnValue({ isNarrowWidth });
+    });
+
+    it(`CategoryAutocompleteModal passes focused=${expectedFocused}`, () => {
+      renderWithProviders(
+        <CategoryAutocompleteModal
+          onSelect={vi.fn()}
+          categoryGroups={[]}
+          showHiddenCategories={false}
+          onClose={vi.fn()}
+        />,
+      );
+      expect(categoryAutocompleteSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ focused: expectedFocused }),
+      );
+    });
+
+    it(`PayeeAutocompleteModal passes focused=${expectedFocused}`, () => {
+      renderWithProviders(
+        <PayeeAutocompleteModal onSelect={vi.fn()} onClose={vi.fn()} />,
+      );
+      expect(payeeAutocompleteSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ focused: expectedFocused }),
+      );
+    });
+
+    it(`AccountAutocompleteModal passes focused=${expectedFocused}`, () => {
+      renderWithProviders(
+        <AccountAutocompleteModal onSelect={vi.fn()} onClose={vi.fn()} />,
+      );
+      expect(accountAutocompleteSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ focused: expectedFocused }),
+      );
+    });
+  },
+);

--- a/packages/desktop-client/src/components/modals/CategoryAutocompleteModal.tsx
+++ b/packages/desktop-client/src/components/modals/CategoryAutocompleteModal.tsx
@@ -89,7 +89,7 @@ export function CategoryAutocompleteModal({
                 name={month ? monthUtils.sheetForMonth(month) : ''}
               >
                 <CategoryAutocomplete
-                  focused
+                  focused={!isNarrowWidth}
                   embedded
                   closeOnBlur={false}
                   closeOnSelect={closeOnSelect}

--- a/packages/desktop-client/src/components/modals/PayeeAutocompleteModal.tsx
+++ b/packages/desktop-client/src/components/modals/PayeeAutocompleteModal.tsx
@@ -72,7 +72,7 @@ export function PayeeAutocompleteModal({
           <PayeeAutocomplete
             payees={payees}
             accounts={accounts}
-            focused
+            focused={!isNarrowWidth}
             embedded
             closeOnBlur={false}
             onClose={() => state.close()}

--- a/upcoming-release-notes/fix-mobile-autocomplete-keyboard-focus.md
+++ b/upcoming-release-notes/fix-mobile-autocomplete-keyboard-focus.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [roasted-oolong]
+---
+
+Stop autofocusing search on mobile autocomplete pickers


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

On certain mobile devices, opening Payee/Category/Account autofocuses on search and activates the phone's on-screen keyboard. The on-screen keyboard covers a large portion of the screen, and most of the list underneath is blocked (hidden) from view.
    
This fix disables autofocusing search on mobile devices, so that the full list shows first. The user can tap an item right away or choose to search/filter by typing.

Disclosure: Code drafted by Claude Code, Reviewed by roasted-oolong

## Related issue(s)

N/A

## Testing

Attempt to add a Category, Payee, or Account on a screen with a mobile width (reproduced on a Samsung Fold 8 and Motorola Razr+ closed) See attached screenshot.

<img height="600" alt="image" src="https://github.com/user-attachments/assets/8c63fff1-9bbd-4c8b-82ca-8a8cdb2d78f8" />


## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 42 | 13.62 MB → 13.62 MB (+30 B) | +0.00%
loot-core | 1 | 4.64 MB | 0%
api | 2 | 3.85 MB | 0%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
42 | 13.62 MB → 13.62 MB (+30 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/modals/PayeeAutocompleteModal.tsx` | 📈 +10 B (+0.60%) | 1.63 kB → 1.64 kB
`src/components/modals/AccountAutocompleteModal.tsx` | 📈 +10 B (+0.36%) | 2.72 kB → 2.73 kB
`src/components/modals/CategoryAutocompleteModal.tsx` | 📈 +10 B (+0.27%) | 3.67 kB → 3.68 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.64 MB → 1.64 MB (+30 B) | +0.00%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/DateSelect.js | 2.37 MB | 0%
static/js/FormulaEditor.js | 766.35 kB | 0%
static/js/ManageRules.js | 71.66 kB | 0%
static/js/NotesTagFormatter.js | 25.94 kB | 0%
static/js/PayeeRuleCountLabel.js | 12.81 kB | 0%
static/js/ReportRouter.js | 1.46 MB | 0%
static/js/ScheduleEditForm.js | 75.41 kB | 0%
static/js/SchedulesTable.js | 171.25 kB | 0%
static/js/TourHost.js | 169.22 kB | 0%
static/js/TourProvider.js | 1.54 kB | 0%
static/js/TransactionEdit.js | 219.59 kB | 0%
static/js/TransactionList.js | 79.22 kB | 0%
static/js/Value.js | 1.79 MB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/ca.js | 170.64 kB | 0%
static/js/client.js | 452.05 kB | 0%
static/js/columns.js | 673.28 kB | 0%
static/js/de.js | 186.5 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/en.js | 245.91 kB | 0%
static/js/es.js | 164.81 kB | 0%
static/js/fr.js | 179.04 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 151.67 kB | 0%
static/js/months.js | 574.92 kB | 0%
static/js/narrow.js | 290.52 kB | 0%
static/js/nb-NO.js | 135.46 kB | 0%
static/js/nl.js | 151.78 kB | 0%
static/js/pl.js | 136.39 kB | 0%
static/js/pt-BR.js | 178.2 kB | 0%
static/js/ru.js | 213.43 kB | 0%
static/js/theme.js | 31.68 kB | 0%
static/js/uk.js | 201.7 kB | 0%
static/js/useFormatList.js | 10.22 kB | 0%
static/js/useLocalPref.js | 97.2 kB | 0%
static/js/useReducedMotion.js | 594 B | 0%
static/js/wide.js | 274.53 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 106.8 kB | 0%
static/js/zh-Hant.js | 130.92 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.64 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.D1rKdvS-.js | 4.64 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.85 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.85 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.16 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->