### PR TITLE
[AI] Document mobile bank sync refresh

### DIFF
--- a/packages/docs/docs/advanced/bank-sync.md
+++ b/packages/docs/docs/advanced/bank-sync.md
@@ -23,7 +23,16 @@ Here are a couple of considerations to know about before making the decision to 
 
 Actual does **not** sync bank data automatically. To fetch new transactions manually:
 
+#### On Desktop
+
 - To sync all accounts: click **All Accounts** in the sidebar, then click **Bank Sync**.
 - To sync a single account: open the account and click the Bank Sync button.
 
   ![](/img/connecting-your-bank/connecting-your-bank-simplefin-10.webp)
+
+#### On Mobile
+
+- To sync all linked accounts: open **Accounts**, scroll to the top of the account list, then pull down and release to refresh.
+- To sync a single account: open the account, scroll to the top of its transaction list, then pull down and release to refresh.
+
+Pulling down to refresh on the **Budget** screen syncs your budget with the server, but does **not** fetch new bank transactions.


### PR DESCRIPTION
## Description

I couldn’t find the bank-sync button on mobile, even though I’d used it on desktop. After digging into the code with Codex, I learned that pulling down on the accounts list triggers it. It worked once I knew how, so I’m adding those instructions to the docs to save the next person the same search.

I used Codex to find where to document it and to write the documentation.

## Related issue(s)

Relates to #5005, also raised the difficulty of discovering mobile bank sync

## Testing

- Verified app behavior against documentation
- Markdown formatting and `git diff --check` passed
- Type checking, lint, and the documentation build all passed

## Checklist

- [x] Release notes not required — documentation-only change
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->
