### PR TITLE
[AI] Prevent custom CSS indicator overlap in theme settings (#8896)

### DIFF
--- a/packages/desktop-client/e2e/settings.test.ts
+++ b/packages/desktop-client/e2e/settings.test.ts
@@ -39,4 +39,83 @@ test.describe('Settings', () => {
 
     expect(download.suggestedFilename()).toMatch(/^\d{4}-\d{2}-\d{2}-.*.zip$/);
   });
+
+  test('keeps the global CSS override readable after switching themes', async () => {
+    await page.setViewportSize({ width: 1024, height: 900 });
+    await page.route('**/customThemeCatalog.json', route =>
+      route.fulfill({
+        json: [{ name: 'Test theme', repo: 'test/theme', mode: 'light' }],
+      }),
+    );
+    await page.route('**/test/theme/refs/heads/main/actual.css*', route =>
+      route.fulfill({ body: ':root { --color-pageBackground: #eeeeee; }' }),
+    );
+    await page.evaluate(() => window.Actual.setTheme('light'));
+    await page.getByRole('button', { name: 'Light', exact: true }).click();
+    await page
+      .getByRole('button', { name: 'Custom theme', exact: true })
+      .click();
+    await page.getByRole('button', { name: 'Test theme', exact: true }).click();
+    const css = ':root { --color-pageBackground: #abcdef; }';
+    await page.getByRole('textbox', { name: 'Custom Theme CSS' }).fill(css);
+    await page.getByRole('button', { name: 'Apply', exact: true }).click();
+    await page.getByRole('button', { name: 'Close', exact: true }).click();
+
+    const indicator = page.getByRole('button', {
+      name: 'Custom CSS override active — click to edit',
+    });
+    let currentTheme = 'Test theme';
+    for (const nextTheme of ['Dark', 'Midnight', 'Light', 'System default']) {
+      await page
+        .getByRole('button', { name: currentTheme, exact: true })
+        .click();
+      await page.getByRole('button', { name: nextTheme, exact: true }).click();
+      await expect(indicator).toBeVisible();
+      await expect
+        .poll(() =>
+          page.evaluate(() =>
+            getComputedStyle(document.documentElement)
+              .getPropertyValue('--color-pageBackground')
+              .trim(),
+          ),
+        )
+        .toBe('#abcdef');
+      currentTheme = nextTheme;
+    }
+
+    for (const width of [1024, 800, 375]) {
+      await page.setViewportSize({ width, height: 900 });
+      if (width === 375) {
+        await expect(page.getByRole('navigation')).toBeVisible();
+      }
+      await indicator.scrollIntoViewIfNeeded();
+      await page.screenshot({
+        path: test.info().outputPath(`system-default-${width}.png`),
+      });
+      const indicatorBounds = await indicator.boundingBox();
+      const lightBounds = await page
+        .getByRole('button', { name: 'Light', exact: true })
+        .boundingBox();
+      if (!indicatorBounds || !lightBounds) {
+        throw new Error('Missing theme controls');
+      }
+      const overlapsLightSelector =
+        indicatorBounds.x < lightBounds.x + lightBounds.width &&
+        indicatorBounds.x + indicatorBounds.width > lightBounds.x &&
+        indicatorBounds.y < lightBounds.y + lightBounds.height &&
+        indicatorBounds.y + indicatorBounds.height > lightBounds.y;
+      expect(overlapsLightSelector).toBe(false);
+      await expect(indicator).toBeInViewport();
+    }
+    await indicator.focus();
+    await page.keyboard.press('Enter');
+    await expect(
+      page.getByRole('textbox', { name: 'Custom Theme CSS' }),
+    ).toHaveValue(css);
+    await page.getByRole('textbox', { name: 'Custom Theme CSS' }).fill('');
+    await page.getByRole('button', { name: 'Apply', exact: true }).click();
+    await page.getByRole('button', { name: 'Close', exact: true }).click();
+    await expect(indicator).toBeHidden();
+    await expect(page.locator('#custom-theme-active')).toHaveCount(0);
+  });
 });

--- a/packages/desktop-client/src/components/settings/Themes.tsx
+++ b/packages/desktop-client/src/components/settings/Themes.tsx
@@ -218,41 +218,17 @@ export function ThemeSettings() {
               }}
             >
               <Column title={t('Theme')}>
-                <View
-                  style={{
-                    flexDirection: 'row',
-                    alignItems: 'center',
-                    gap: 8,
-                  }}
-                >
-                  <Select<string>
-                    onChange={handleThemeChange}
-                    value={getCurrentValue()}
-                    options={buildOptions()}
-                    className={css({
-                      '&[data-hovered]': {
-                        backgroundColor: themeStyle.buttonNormalBackgroundHover,
-                      },
-                      maxWidth: '100%',
-                    })}
-                  />
-                  {hasCustomCssOverride && (
-                    <Button
-                      variant="bare"
-                      aria-label={t(
-                        'Custom CSS override active — click to edit',
-                      )}
-                      onPress={handleEditOverride}
-                      style={{
-                        color: themeStyle.pageTextPositive,
-                        gap: 6,
-                      }}
-                    >
-                      <Trans>Custom CSS is active</Trans>
-                      <SvgCode style={{ width: 14, height: 14 }} />
-                    </Button>
-                  )}
-                </View>
+                <Select<string>
+                  onChange={handleThemeChange}
+                  value={getCurrentValue()}
+                  options={buildOptions()}
+                  className={css({
+                    '&[data-hovered]': {
+                      backgroundColor: themeStyle.buttonNormalBackgroundHover,
+                    },
+                    maxWidth: '100%',
+                  })}
+                />
               </Column>
               {theme === 'auto' && (
                 <>
@@ -295,6 +271,22 @@ export function ThemeSettings() {
                 </>
               )}
             </View>
+          )}
+
+          {!showInstaller && hasCustomCssOverride && (
+            <Button
+              variant="bare"
+              aria-label={t('Custom CSS override active — click to edit')}
+              onPress={handleEditOverride}
+              style={{
+                alignSelf: 'flex-start',
+                color: themeStyle.pageTextPositive,
+                gap: 6,
+              }}
+            >
+              <Trans>Custom CSS is active</Trans>
+              <SvgCode style={{ width: 14, height: 14 }} />
+            </Button>
           )}
 
           {showInstaller && (

--- a/packages/docs/docs/custom-themes.md
+++ b/packages/docs/docs/custom-themes.md
@@ -15,16 +15,20 @@ The easiest way to install a custom theme is to choose one from the catalog:
 
 Themes in the catalog are hosted on GitHub and are automatically fetched when you select them. Each theme shows a color palette preview (6 colors in a 3x2 grid) and includes a link to its source repository.
 
-### Installing a Theme by Pasting CSS
+### Applying Custom CSS Overrides
 
-You can also install a custom theme by pasting CSS directly:
+You can also customize your colors by pasting CSS directly:
 
 1. Go to **Settings** → **Themes** → **Custom theme**
-2. Scroll down to the "or paste CSS directly" section
+2. Scroll down to the **Additional CSS overrides** section
 3. Paste your theme CSS into the text area
 4. Click **Apply**
 
-The CSS will be validated before installation. If there are any errors, they will be displayed below the text area.
+The CSS will be validated before it is applied. If there are any errors, they will be displayed below the text area.
+
+These overrides apply on top of every theme, including **Light**, **Dark**, **Midnight**, and both modes of **System default**. Switching themes does not clear your overrides.
+
+The **Custom CSS is active** button below the theme selectors opens the editor with your saved CSS. To remove the overrides, clear the text area and click **Apply**.
 
 ## Publishing Custom Themes
 

--- a/upcoming-release-notes/fix-custom-css-indicator-layout.md
+++ b/upcoming-release-notes/fix-custom-css-indicator-layout.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [femedici]
+---
+
+Prevent the custom CSS indicator from overlapping theme selectors when using System default.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

<!-- If AI tools wrote a significant part of this change, please disclose it here and name the tool you used. See https://actualbudget.org/docs/contributing/ai-usage-policy -->

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

## Checklist

- [ ] Release notes added (see link above)
- [ ] No obvious regressions in affected areas
- [ ] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 42 | 13.76 MB → 13.76 MB (-95 B) | -0.00%
loot-core | 1 | 4.65 MB | 0%
api | 2 | 3.87 MB | 0%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
42 | 13.76 MB → 13.76 MB (-95 B) | -0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/settings/Themes.tsx` | 📉 -95 B (-1.22%) | 7.58 kB → 7.48 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.68 MB → 1.68 MB (-95 B) | -0.01%

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/DateSelect.js | 2.37 MB | 0%
static/js/FormulaEditor.js | 767.24 kB | 0%
static/js/ManageRules.js | 71.66 kB | 0%
static/js/NotesTagFormatter.js | 25.94 kB | 0%
static/js/PayeeRuleCountLabel.js | 12.81 kB | 0%
static/js/ReportRouter.js | 1.53 MB | 0%
static/js/ScheduleEditForm.js | 75.41 kB | 0%
static/js/SchedulesTable.js | 171.25 kB | 0%
static/js/TourHost.js | 169.22 kB | 0%
static/js/TourProvider.js | 1.54 kB | 0%
static/js/TransactionEdit.js | 219.59 kB | 0%
static/js/TransactionList.js | 79.22 kB | 0%
static/js/Value.js | 1.79 MB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/ca.js | 170.64 kB | 0%
static/js/client.js | 452.05 kB | 0%
static/js/columns.js | 673.28 kB | 0%
static/js/de.js | 186.5 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/en.js | 258.91 kB | 0%
static/js/es.js | 164.81 kB | 0%
static/js/fr.js | 178.66 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 151.79 kB | 0%
static/js/months.js | 590.14 kB | 0%
static/js/narrow.js | 290.52 kB | 0%
static/js/nb-NO.js | 135.46 kB | 0%
static/js/nl.js | 151.78 kB | 0%
static/js/pl.js | 136.51 kB | 0%
static/js/pt-BR.js | 178.74 kB | 0%
static/js/ru.js | 212.44 kB | 0%
static/js/theme.js | 31.68 kB | 0%
static/js/uk.js | 211.2 kB | 0%
static/js/useFormatList.js | 10.22 kB | 0%
static/js/useLocalPref.js | 97.2 kB | 0%
static/js/useReducedMotion.js | 594 B | 0%
static/js/wide.js | 274.53 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 106.8 kB | 0%
static/js/zh-Hant.js | 130.92 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.65 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.CqRg4sOw.js | 4.65 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.87 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.87 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.16 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->