### PR TITLE
 [AI] Keep custom report charts stable with long legends (#5394)

### DIFF
--- a/packages/desktop-client/e2e/reports.test.ts
+++ b/packages/desktop-client/e2e/reports.test.ts
@@ -166,6 +166,47 @@ test.describe('Reports', () => {
       await customReportPage.showLegendButton.click();
     });
 
+    for (const graph of ['Bar Graph', 'Line Graph']) {
+      test(`${graph} keeps its height when the legend needs scrolling`, async () => {
+        await page.setViewportSize({ width: 1280, height: 700 });
+        await customReportPage.selectMode('time');
+        await customReportPage.selectViz(graph);
+        await page
+          .getByRole('button', { name: 'Options', exact: true })
+          .click();
+        await page
+          .getByRole('button', { name: 'Show empty rows', exact: true })
+          .click();
+        await page.keyboard.press('Escape');
+
+        const content = page.locator('#custom-report-content');
+        const chart = content.locator('.recharts-wrapper');
+        await expect(chart).toBeVisible();
+        const originalHeight = await chart.evaluate(el => el.clientHeight);
+
+        await customReportPage.showSummaryButton.click();
+        await customReportPage.showLegendButton.click();
+
+        await expect
+          .poll(() => chart.evaluate(el => el.clientHeight))
+          .toBe(originalHeight);
+        const legend = content
+          .getByText('Category', { exact: true })
+          .locator('..');
+        await expect
+          .poll(() => legend.evaluate(el => el.scrollHeight > el.clientHeight))
+          .toBe(true);
+        await legend.hover();
+        await page.mouse.wheel(0, 500);
+        await expect
+          .poll(() => legend.evaluate(el => el.scrollTop))
+          .toBeGreaterThan(0);
+        await expect
+          .poll(() => chart.evaluate(el => el.clientHeight))
+          .toBe(originalHeight);
+      });
+    }
+
     test('Validates that "show summary" button shows the summary', async () => {
       await customReportPage.selectViz('Bar Graph');
       await customReportPage.showSummaryButton.click();

--- a/packages/desktop-client/src/components/reports/reports/CustomReport.tsx
+++ b/packages/desktop-client/src/components/reports/reports/CustomReport.tsx
@@ -1001,7 +1001,7 @@ function CustomReportInner({
             style={{
               backgroundColor: theme.tableBackground,
               flexDirection: 'row',
-              flex: '1 0 auto',
+              flex: 1,
             }}
           >
             <View

--- a/upcoming-release-notes/fix-custom-report-legend-scroll.md
+++ b/upcoming-release-notes/fix-custom-report-legend-scroll.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [femedici]
+---
+
+Keep custom report charts at a stable height when scrolling a long legend.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

<!-- If AI tools wrote a significant part of this change, please disclose it here and name the tool you used. See https://actualbudget.org/docs/contributing/ai-usage-policy -->

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

## Checklist

- [ ] Release notes added (see link above)
- [ ] No obvious regressions in affected areas
- [ ] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 42 | 13.76 MB → 13.76 MB (-9 B) | -0.00%
loot-core | 1 | 4.65 MB | 0%
api | 2 | 3.87 MB | 0%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
42 | 13.76 MB → 13.76 MB (-9 B) | -0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/reports/reports/CustomReport.tsx` | 📉 -9 B (-0.03%) | 25.71 kB → 25.7 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/ReportRouter.js | 1.53 MB → 1.53 MB (-9 B) | -0.00%

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.68 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/DateSelect.js | 2.37 MB | 0%
static/js/FormulaEditor.js | 767.24 kB | 0%
static/js/ManageRules.js | 71.66 kB | 0%
static/js/NotesTagFormatter.js | 25.94 kB | 0%
static/js/PayeeRuleCountLabel.js | 12.81 kB | 0%
static/js/ScheduleEditForm.js | 75.41 kB | 0%
static/js/SchedulesTable.js | 171.25 kB | 0%
static/js/TourHost.js | 169.22 kB | 0%
static/js/TourProvider.js | 1.54 kB | 0%
static/js/TransactionEdit.js | 219.59 kB | 0%
static/js/TransactionList.js | 79.22 kB | 0%
static/js/Value.js | 1.79 MB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/ca.js | 170.64 kB | 0%
static/js/client.js | 452.05 kB | 0%
static/js/columns.js | 673.28 kB | 0%
static/js/de.js | 186.5 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/en.js | 258.91 kB | 0%
static/js/es.js | 164.81 kB | 0%
static/js/fr.js | 178.66 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 151.79 kB | 0%
static/js/months.js | 590.14 kB | 0%
static/js/narrow.js | 290.52 kB | 0%
static/js/nb-NO.js | 135.46 kB | 0%
static/js/nl.js | 151.78 kB | 0%
static/js/pl.js | 136.51 kB | 0%
static/js/pt-BR.js | 178.74 kB | 0%
static/js/ru.js | 212.44 kB | 0%
static/js/theme.js | 31.68 kB | 0%
static/js/uk.js | 211.2 kB | 0%
static/js/useFormatList.js | 10.22 kB | 0%
static/js/useLocalPref.js | 97.2 kB | 0%
static/js/useReducedMotion.js | 594 B | 0%
static/js/wide.js | 274.53 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 106.8 kB | 0%
static/js/zh-Hant.js | 130.92 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.65 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.CqRg4sOw.js | 4.65 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.87 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.87 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.16 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->