### PR TITLE
sidebar pt. 5: account search

### DIFF
--- a/packages/desktop-client/src/components/sidebar/redesign/AccountSearchField.tsx
+++ b/packages/desktop-client/src/components/sidebar/redesign/AccountSearchField.tsx
@@ -1,0 +1,59 @@
+import { useTranslation } from 'react-i18next';
+
+import { Button } from '@actual-app/components/button';
+import { SvgRemove } from '@actual-app/components/icons/v2';
+import { InitialFocus } from '@actual-app/components/initial-focus';
+import { Input } from '@actual-app/components/input';
+import { theme } from '@actual-app/components/theme';
+import { spacing } from '@actual-app/components/tokens';
+import { View } from '@actual-app/components/view';
+
+type AccountSearchFieldProps = {
+  value: string;
+  onChange: (value: string) => void;
+  onClose: () => void;
+};
+
+export function AccountSearchField({
+  value,
+  onChange,
+  onClose,
+}: AccountSearchFieldProps) {
+  const { t } = useTranslation();
+
+  return (
+    <View
+      style={{
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: spacing.xs,
+        marginBottom: spacing.xs,
+      }}
+    >
+      <InitialFocus>
+        <Input
+          value={value}
+          aria-label={t('Find account')}
+          placeholder={t('Find account…')}
+          onChangeValue={onChange}
+          onEscape={onClose}
+          style={{
+            flex: 1,
+            fontSize: 12,
+            backgroundColor: theme.sidebarControlBackground,
+            border: '1px solid transparent',
+            color: theme.sidebarItemText,
+          }}
+        />
+      </InitialFocus>
+      <Button
+        variant="bare"
+        aria-label={t('Close search')}
+        onPress={onClose}
+        style={{ color: theme.sidebarTextSubdued, padding: spacing.xxs }}
+      >
+        <SvgRemove width={9} height={9} />
+      </Button>
+    </View>
+  );
+}

--- a/packages/desktop-client/src/components/sidebar/redesign/AccountsHeaderRow.tsx
+++ b/packages/desktop-client/src/components/sidebar/redesign/AccountsHeaderRow.tsx
@@ -5,6 +5,7 @@ import {
   SvgCheveronDownUp,
   SvgCheveronUpDown,
 } from '@actual-app/components/icons/v1';
+import { SvgSearchAlternate } from '@actual-app/components/icons/v2';
 import { theme } from '@actual-app/components/theme';
 import { spacing } from '@actual-app/components/tokens';
 import { View } from '@actual-app/components/view';
@@ -20,11 +21,17 @@ import { SidebarIconButton } from './SidebarIconButton';
 type AccountsHeaderRowProps = {
   allOpen: boolean;
   onToggleAll: () => void;
+  isToggleAllDisabled: boolean;
+  isSearchOpen: boolean;
+  onToggleSearch: () => void;
 };
 
 export function AccountsHeaderRow({
   allOpen,
   onToggleAll,
+  isToggleAllDisabled,
+  isSearchOpen,
+  onToggleSearch,
 }: AccountsHeaderRowProps) {
   const { t } = useTranslation();
   const dispatch = useDispatch();
@@ -60,7 +67,14 @@ export function AccountsHeaderRow({
       <SidebarIconButton
         Icon={allOpen ? SvgCheveronDownUp : SvgCheveronUpDown}
         label={allOpen ? t('Collapse all groups') : t('Expand all groups')}
+        isDisabled={isToggleAllDisabled}
         onPress={onToggleAll}
+      />
+      <SidebarIconButton
+        Icon={SvgSearchAlternate}
+        label={t('Find account')}
+        isToggledOn={isSearchOpen}
+        onPress={onToggleSearch}
       />
       <SidebarIconButton
         Icon={SvgAdd}

--- a/packages/desktop-client/src/components/sidebar/redesign/AccountsSection.tsx
+++ b/packages/desktop-client/src/components/sidebar/redesign/AccountsSection.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { spacing } from '@actual-app/components/tokens';
@@ -5,16 +6,32 @@ import { View } from '@actual-app/components/view';
 
 import * as bindings from '#spreadsheet/bindings';
 
+import { AccountSearchField } from './AccountSearchField';
 import { AccountsHeaderRow } from './AccountsHeaderRow';
 import { ClosedSection } from './ClosedSection';
 import { SideGroup } from './SideGroup';
-import { useSidebarAccountTree } from './useSidebarAccountTree';
+import {
+  filterSidebarTree,
+  useSidebarAccountTree,
+} from './useSidebarAccountTree';
 import { bucketKey, useSidebarCollapseState } from './useSidebarCollapseState';
 
 export function AccountsSection() {
   const { t } = useTranslation();
   const tree = useSidebarAccountTree();
-  const collapse = useSidebarCollapseState({ tree, isSearching: false });
+  const [isSearchOpen, setIsSearchOpen] = useState(false);
+  const [query, setQuery] = useState('');
+  const trimmedQuery = query.trim().toLowerCase();
+  const isSearching = trimmedQuery !== '';
+
+  const collapse = useSidebarCollapseState({ tree, isSearching });
+
+  const onToggleSearch = () => {
+    setIsSearchOpen(!isSearchOpen);
+    setQuery('');
+  };
+
+  const visibleTree = filterSidebarTree(tree, trimmedQuery);
 
   const showSyncDot = [
     ...tree.onBudget.buckets.map(b => b.accounts).flat(),
@@ -34,13 +51,23 @@ export function AccountsSection() {
         <AccountsHeaderRow
           allOpen={collapse.allOpen}
           onToggleAll={collapse.toggleAll}
+          isToggleAllDisabled={isSearching}
+          isSearchOpen={isSearchOpen}
+          onToggleSearch={onToggleSearch}
         />
+        {isSearchOpen && (
+          <AccountSearchField
+            value={query}
+            onChange={setQuery}
+            onClose={onToggleSearch}
+          />
+        )}
         {tree.onBudget.buckets.length > 0 && (
           <SideGroup
             label={t('On budget')}
             side="on"
             showSyncDot={showSyncDot}
-            sideData={tree.onBudget}
+            sideData={visibleTree.onBudget}
             totalBinding={bindings.onBudgetAccountBalance()}
             balanceTestId="sidebar-on-budget-balance"
             isOpen={collapse.isOpen('onbudget')}
@@ -54,7 +81,7 @@ export function AccountsSection() {
             label={t('Off budget')}
             side="off"
             showSyncDot={showSyncDot}
-            sideData={tree.offBudget}
+            sideData={visibleTree.offBudget}
             totalBinding={bindings.offBudgetAccountBalance()}
             balanceTestId="sidebar-off-budget-balance"
             isOpen={collapse.isOpen('offbudget')}
@@ -64,7 +91,7 @@ export function AccountsSection() {
           />
         )}
         <ClosedSection
-          accounts={tree.closed}
+          accounts={visibleTree.closed}
           isOpen={collapse.isOpen('closed')}
           onToggle={() => collapse.toggle('closed')}
         />

--- a/packages/desktop-client/src/components/sidebar/redesign/useSidebarAccountTree.test.ts
+++ b/packages/desktop-client/src/components/sidebar/redesign/useSidebarAccountTree.test.ts
@@ -5,7 +5,12 @@ import type {
 } from '@actual-app/core/types/models';
 import { describe, expect, it } from 'vitest';
 
-import { buildAccountSide, getEffectiveGroupId } from './useSidebarAccountTree';
+import {
+  buildAccountSide,
+  filterSidebarTree,
+  getEffectiveGroupId,
+} from './useSidebarAccountTree';
+import type { SidebarAccountTree } from './useSidebarAccountTree';
 
 function makeAccount(
   name: string,
@@ -80,5 +85,44 @@ describe('buildAccountSide', () => {
     expect(side.buckets.map(bucket => bucket.group?.id)).toEqual(['g1']);
     expect(side.buckets[0].failedCount).toBe(1);
     expect(side.failedCount).toBe(1);
+  });
+});
+
+describe('filterSidebarTree', () => {
+  const groups = [makeGroup('g1', 'Savings')];
+  const tree: SidebarAccountTree = {
+    onBudget: buildAccountSide(
+      [
+        makeAccount('Checking'),
+        makeAccount('Premium Saver', { account_group_id: 'g1' }),
+      ],
+      groups,
+    ),
+    offBudget: buildAccountSide([makeAccount('House')], groups),
+    closed: [makeAccount('Old Checking', { closed: 1 })],
+  };
+
+  it('returns the tree unchanged for an empty query', () => {
+    expect(filterSidebarTree(tree, '')).toBe(tree);
+  });
+
+  it('filters rows but keeps side counts for the full side', () => {
+    const filtered = filterSidebarTree(tree, 'saver');
+
+    expect(
+      filtered.onBudget.buckets.flatMap(bucket =>
+        bucket.accounts.map(account => account.name),
+      ),
+    ).toEqual(['Premium Saver']);
+    expect(filtered.onBudget.accountCount).toBe(2);
+    expect(filtered.offBudget.buckets).toEqual([]);
+    expect(filtered.closed).toEqual([]);
+  });
+
+  it('matches closed accounts too', () => {
+    const filtered = filterSidebarTree(tree, 'old');
+    expect(filtered.closed.map(account => account.name)).toEqual([
+      'Old Checking',
+    ]);
   });
 });

--- a/packages/desktop-client/src/components/sidebar/redesign/useSidebarAccountTree.ts
+++ b/packages/desktop-client/src/components/sidebar/redesign/useSidebarAccountTree.ts
@@ -75,6 +75,36 @@ export function buildAccountSide(
   };
 }
 
+function filterAccounts(accounts: AccountEntity[], query: string) {
+  return accounts.filter(account => account.name.toLowerCase().includes(query));
+}
+
+function filterSide(side: SidebarAccountSide, query: string) {
+  return {
+    ...side,
+    buckets: side.buckets
+      .map(bucket => ({
+        ...bucket,
+        accounts: filterAccounts(bucket.accounts, query),
+      }))
+      .filter(bucket => bucket.accounts.length > 0),
+  };
+}
+
+export function filterSidebarTree(
+  tree: SidebarAccountTree,
+  query: string,
+): SidebarAccountTree {
+  if (!query) {
+    return tree;
+  }
+  return {
+    onBudget: filterSide(tree.onBudget, query),
+    offBudget: filterSide(tree.offBudget, query),
+    closed: filterAccounts(tree.closed, query),
+  };
+}
+
 export function useSidebarAccountTree(): SidebarAccountTree {
   const { data: groups = [] } = useAccountGroups();
   const { data: onBudgetAccounts = [] } = useOnBudgetAccounts();

--- a/upcoming-release-notes/add-new-sidebar-search.md
+++ b/upcoming-release-notes/add-new-sidebar-search.md
@@ -1,0 +1,6 @@
+---
+category: Features
+authors: [matt-fidd]
+---
+
+Add account search to the experimental new sidebar

--- a/upcoming-release-notes/add-new-sidebar-search.md
+++ b/upcoming-release-notes/add-new-sidebar-search.md
@@ -1,5 +1,5 @@
 ---
-category: Features
+category: Enhancements
 authors: [matt-fidd]
 ---
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

<!-- If AI tools wrote a significant part of this change, please disclose it here and name the tool you used. See https://actualbudget.org/docs/contributing/ai-usage-policy -->

Getting towards the end of the initial implementation now, the rest are small so that review is as easy as possible. Thanks to everyone for helping me to get this in so quickly! Hopefully we'll have it fully fledged in time for the next release.

- [x] pt 1. db models (https://github.com/actualbudget/actual/pull/8764)
- [x] pt 2. account group management modal (https://github.com/actualbudget/actual/pull/8832)
- [x] pt 3. sidebar shell (https://github.com/actualbudget/actual/pull/8882)
- [x] pt 4. accounts list (https://github.com/actualbudget/actual/pull/8892)
- [ ] pt 5. accounts search (https://github.com/actualbudget/actual/pull/8914)
- [ ] pt 6. accounts context meus/hover cards
- [ ] pt 7. accounts drag and drop

Claude wrote the tests and the boiler plate

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

https://github.com/user-attachments/assets/f352982e-457b-4d68-9c70-a8aba2f0653d


## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 42 | 13.65 MB → 13.79 MB (+145.44 kB) | +1.04%
loot-core | 1 | 4.64 MB → 4.65 MB (+10.87 kB) | +0.23%
api | 2 | 3.85 MB → 3.86 MB (+10.15 kB) | +0.26%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
42 | 13.65 MB → 13.79 MB (+145.44 kB) | +1.04%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/reports/graphs/MonteCarloCashflowGraphTooltip.tsx` | 🆕 +4.9 kB | 0 B → 4.9 kB
`src/components/reports/graphs/MonteCarloCashflowGraph.tsx` | 🆕 +4.52 kB | 0 B → 4.52 kB
`src/components/reports/graphs/util/monteCarloCashflowChart.ts` | 🆕 +3.23 kB | 0 B → 3.23 kB
`src/components/sidebar/redesign/AccountSearchField.tsx` | 🆕 +2.24 kB | 0 B → 2.24 kB
`src/components/reports/graphs/MonteCarloCashflowLegendGroup.tsx` | 🆕 +1.57 kB | 0 B → 1.57 kB
`src/components/common/DirectoryDisplay.tsx` | 🆕 +998 B | 0 B → 998 B
`src/components/reports/graphs/util/useMonteCarloTickFormatter.ts` | 🆕 +607 B | 0 B → 607 B
`src/components/reports/graphs/MonteCarloCashflowSwatch.tsx` | 🆕 +310 B | 0 B → 310 B
`src/components/FatalError.tsx` | 📈 +6.56 kB (+60.83%) | 10.79 kB → 17.36 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/errors.ts` | 📈 +293 B (+54.26%) | 540 B → 833 B
`src/components/sidebar/redesign/useSidebarAccountTree.ts` | 📈 +562 B (+38.92%) | 1.41 kB → 1.96 kB
`src/components/sidebar/redesign/AccountsSection.tsx` | 📈 +1.35 kB (+33.02%) | 4.09 kB → 5.44 kB
`src/components/sidebar/redesign/AccountsHeaderRow.tsx` | 📈 +663 B (+19.27%) | 3.36 kB → 4.01 kB
`src/components/reports/reports/SankeyCard.tsx` | 📈 +808 B (+17.88%) | 4.41 kB → 5.2 kB
`src/hooks/useMetaThemeColor.ts` | 📈 +511 B (+17.81%) | 2.8 kB → 3.3 kB
`src/components/reports/reportRanges.ts` | 📈 +710 B (+12.12%) | 5.72 kB → 6.41 kB
`src/components/reports/reports/monte-carlo/MonteCarlo.tsx` | 📈 +3.2 kB (+10.65%) | 30.07 kB → 33.28 kB
`src/sync-events.ts` | 📈 +833 B (+10.09%) | 8.06 kB → 8.88 kB
`src/components/reports/reports/monte-carlo/monteCarloSimulation.ts` | 📈 +2.99 kB (+8.53%) | 35.08 kB → 38.07 kB
`locale/en.json` | 📈 +12.99 kB (+5.28%) | 245.91 kB → 258.91 kB
`locale/uk.json` | 📈 +9.5 kB (+4.71%) | 201.7 kB → 211.2 kB
`src/components/App.tsx` | 📈 +287 B (+3.44%) | 8.14 kB → 8.42 kB
`src/browser-preload.js` | 📈 +119 B (+2.71%) | 4.28 kB → 4.4 kB
`package.json` | 📈 +259 B (+2.38%) | 10.61 kB → 10.86 kB
`src/components/formula/formulaCatalog.ts` | 📈 +761 B (+1.74%) | 42.76 kB → 43.5 kB
`src/components/formula/formulaBadgeRanges.ts` | 📈 +146 B (+1.35%) | 10.59 kB → 10.73 kB
`src/components/reports/reports/monte-carlo/MonteCarloRunDetailTable.tsx` | 📈 +181 B (+0.51%) | 34.82 kB → 34.99 kB
`src/style/customThemes.ts` | 📈 +60 B (+0.44%) | 13.29 kB → 13.35 kB
`src/components/autocomplete/PayeeAutocomplete.tsx` | 📈 +86 B (+0.37%) | 22.99 kB → 23.07 kB
`locale/pt-BR.json` | 📈 +555 B (+0.30%) | 178.2 kB → 178.74 kB
`locale/pl.json` | 📈 +128 B (+0.09%) | 136.39 kB → 136.51 kB
`locale/it.json` | 📈 +126 B (+0.08%) | 151.67 kB → 151.79 kB
`src/components/reports/graphs/CashFlowGraph.tsx` | 📈 +6 B (+0.08%) | 7.75 kB → 7.75 kB
`src/components/reports/graphs/LineGraph.tsx` | 📈 +2 B (+0.02%) | 7.84 kB → 7.84 kB
`src/reports/mutations.ts` | 📈 +2 B (+0.02%) | 12.94 kB → 12.94 kB
`src/components/reports/AccountSelector.tsx` | 📈 +2 B (+0.01%) | 15.54 kB → 15.54 kB
`src/components/reports/reports/monte-carlo/MonteCarloConfiguration.tsx` | 📉 -2 B (-0.01%) | 25.39 kB → 25.39 kB
`locale/fr.json` | 📉 -393 B (-0.21%) | 179.04 kB → 178.66 kB
`src/components/reports/reports/Sankey.tsx` | 📉 -73 B (-0.22%) | 32.54 kB → 32.47 kB
`locale/ru.json` | 📉 -1015 B (-0.46%) | 213.43 kB → 212.44 kB
`src/style/theme.tsx` | 📉 -201 B (-2.50%) | 7.87 kB → 7.67 kB
`src/util/error.ts` | 📉 -293 B (-4.18%) | 6.85 kB → 6.56 kB
`src/components/reports/graphs/MonteCarloGraph.tsx` | 📉 -221 B (-7.07%) | 3.05 kB → 2.84 kB
`src/components/reports/reports/monte-carlo/MonteCarloRunsTable.tsx` | 📉 -1.13 kB (-8.37%) | 13.51 kB → 12.38 kB
`src/components/modals/manager/ConfirmChangeDocumentDir.tsx` | 📉 -932 B (-16.07%) | 5.66 kB → 4.75 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/TransactionList.js | 79.22 kB → 166.98 kB (+87.76 kB) | +110.78%
static/js/ReportRouter.js | 1.46 MB → 1.48 MB (+21.56 kB) | +1.44%
static/js/index.js | 1.67 MB → 1.69 MB (+13.38 kB) | +0.78%
static/js/en.js | 245.91 kB → 258.91 kB (+12.99 kB) | +5.28%
static/js/uk.js | 201.7 kB → 211.2 kB (+9.5 kB) | +4.71%
static/js/FormulaEditor.js | 766.35 kB → 767.24 kB (+907 B) | +0.12%
static/js/pt-BR.js | 178.2 kB → 178.74 kB (+555 B) | +0.30%
static/js/pl.js | 136.39 kB → 136.51 kB (+128 B) | +0.09%
static/js/it.js | 151.67 kB → 151.79 kB (+126 B) | +0.08%
static/js/Value.js | 1.79 MB → 1.79 MB (+86 B) | +0.00%

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/ru.js | 213.43 kB → 212.44 kB (-1015 B) | -0.46%
static/js/fr.js | 179.04 kB → 178.66 kB (-393 B) | -0.21%
static/js/DateSelect.js | 2.38 MB → 2.38 MB (-141 B) | -0.01%

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/ManageRules.js | 71.66 kB | 0%
static/js/NotesTagFormatter.js | 25.94 kB | 0%
static/js/PayeeRuleCountLabel.js | 12.81 kB | 0%
static/js/ScheduleEditForm.js | 75.41 kB | 0%
static/js/SchedulesTable.js | 171.25 kB | 0%
static/js/TourHost.js | 169.22 kB | 0%
static/js/TourProvider.js | 1.54 kB | 0%
static/js/TransactionEdit.js | 219.59 kB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/ca.js | 170.64 kB | 0%
static/js/client.js | 452.05 kB | 0%
static/js/columns.js | 673.28 kB | 0%
static/js/de.js | 186.5 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/es.js | 164.81 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/months.js | 575.1 kB | 0%
static/js/narrow.js | 290.52 kB | 0%
static/js/nb-NO.js | 135.46 kB | 0%
static/js/nl.js | 151.78 kB | 0%
static/js/theme.js | 31.68 kB | 0%
static/js/useFormatList.js | 10.22 kB | 0%
static/js/useLocalPref.js | 97.2 kB | 0%
static/js/useReducedMotion.js | 594 B | 0%
static/js/wide.js | 274.53 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 106.8 kB | 0%
static/js/zh-Hant.js | 130.92 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.64 MB → 4.65 MB (+10.87 kB) | +0.23%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/sync/replay.ts` | 🆕 +2.99 kB | 0 B → 2.99 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/sync/serialization.ts` | 🆕 +973 B | 0 B → 973 B
`home/runner/work/actual/actual/packages/loot-core/src/server/sync/messages-pending.ts` | 🆕 +406 B | 0 B → 406 B
`home/runner/work/actual/actual/packages/loot-core/migrations/1788468782000_add_messages_pending.js` | 🆕 +167 B | 0 B → 167 B
`home/runner/work/actual/actual/packages/loot-core/src/server/sync/utils.ts` | 📈 +497 B (+394.44%) | 126 B → 623 B
`home/runner/work/actual/actual/packages/loot-core/src/server/migrate/migrations.ts` | 📈 +1.33 kB (+40.81%) | 3.27 kB → 4.6 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/errors.ts` | 📈 +552 B (+27.14%) | 1.99 kB → 2.53 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/transactions/import/ofx2json.ts` | 📈 +700 B (+24.46%) | 2.79 kB → 3.48 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/transactions/import/xmlcamt2json.ts` | 📈 +464 B (+16.59%) | 2.73 kB → 3.18 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/sync/reset.ts` | 📈 +212 B (+14.15%) | 1.46 kB → 1.67 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/sync/index.ts` | 📈 +1.26 kB (+8.89%) | 14.13 kB → 15.38 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/rules/rule.ts` | 📈 +350 B (+7.65%) | 4.47 kB → 4.81 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/main.ts` | 📈 +373 B (+7.61%) | 4.79 kB → 5.15 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/errors.ts` | 📈 +145 B (+3.04%) | 4.66 kB → 4.8 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/rules/action.ts` | 📈 +98 B (+1.19%) | 8.06 kB → 8.16 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/transactions/transaction-rules.ts` | 📈 +238 B (+1.04%) | 22.36 kB → 22.6 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/budgetfiles/app.ts` | 📈 +97 B (+0.82%) | 11.51 kB → 11.6 kB
`node_modules/csv-parse/lib/api/index.js` | 📈 +130 B (+0.59%) | 21.37 kB → 21.5 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/transactions/import/parse-file.ts` | 📈 +20 B (+0.35%) | 5.6 kB → 5.62 kB
`home/runner/work/actual/actual/packages/loot-core/migrations/1765518577215_multiple_dashboards.js` | 📈 +2 B (+0.33%) | 614 B → 616 B
`node_modules/csv-parse/lib/utils/ResizeableBuffer.js` | 📉 -6 B (-0.41%) | 1.44 kB → 1.43 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.CqHqoSL0.js | 0 B → 4.65 MB (+4.65 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.D1rKdvS-.js | 4.64 MB → 0 B (-4.64 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.85 MB → 3.86 MB (+10.15 kB) | +0.26%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/sync/replay.ts` | 🆕 +2.92 kB | 0 B → 2.92 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/sync/serialization.ts` | 🆕 +944 B | 0 B → 944 B
`home/runner/work/actual/actual/packages/loot-core/src/server/sync/messages-pending.ts` | 🆕 +405 B | 0 B → 405 B
`home/runner/work/actual/actual/packages/loot-core/migrations/1788468782000_add_messages_pending.js` | 🆕 +164 B | 0 B → 164 B
`home/runner/work/actual/actual/packages/loot-core/src/server/sync/utils.ts` | 📈 +481 B (+391.06%) | 123 B → 604 B
`home/runner/work/actual/actual/packages/loot-core/src/platform/server/connection/index.api.ts` | 📈 +400 B (+258.06%) | 155 B → 555 B
`home/runner/work/actual/actual/packages/loot-core/src/server/migrate/migrations.ts` | 📈 +1.31 kB (+41.05%) | 3.19 kB → 4.49 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/transactions/import/ofx2json.ts` | 📈 +689 B (+24.74%) | 2.72 kB → 3.39 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/transactions/import/xmlcamt2json.ts` | 📈 +456 B (+16.76%) | 2.66 kB → 3.1 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/sync/reset.ts` | 📈 +210 B (+14.36%) | 1.43 kB → 1.63 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/sync/index.ts` | 📈 +1.24 kB (+9.05%) | 13.68 kB → 14.92 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/rules/rule.ts` | 📈 +346 B (+8.04%) | 4.2 kB → 4.54 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/errors.ts` | 📈 +142 B (+3.02%) | 4.6 kB → 4.73 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/rules/action.ts` | 📈 +97 B (+1.25%) | 7.6 kB → 7.69 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/transactions/transaction-rules.ts` | 📈 +226 B (+0.98%) | 22.45 kB → 22.67 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/budgetfiles/app.ts` | 📈 +92 B (+0.81%) | 11.14 kB → 11.23 kB
`node_modules/csv-parse/lib/api/index.js` | 📈 +125 B (+0.59%) | 20.84 kB → 20.96 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/transactions/import/parse-file.ts` | 📈 +20 B (+0.35%) | 5.62 kB → 5.63 kB
`home/runner/work/actual/actual/packages/loot-core/migrations/1765518577215_multiple_dashboards.js` | 📈 +2 B (+0.33%) | 605 B → 607 B
`node_modules/csv-parse/lib/utils/ResizeableBuffer.js` | 📉 -6 B (-0.43%) | 1.36 kB → 1.36 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.85 MB → 3.86 MB (+10.15 kB) | +0.26%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.16 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->