### PR TITLE
[AI] Only show stacked bar tooltip truncation indicator when categories are hidden

### DIFF
--- a/packages/desktop-client/src/components/reports/graphs/StackedBarGraph.test.tsx
+++ b/packages/desktop-client/src/components/reports/graphs/StackedBarGraph.test.tsx
@@ -1,0 +1,133 @@
+import React, { cloneElement } from 'react';
+import type { ReactElement, ReactNode } from 'react';
+import { MemoryRouter } from 'react-router';
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { TestProviders } from '#mocks';
+
+type TooltipEntry = {
+  name: string;
+  value: number;
+  color: string;
+  payload: { name: string; color: string };
+};
+
+// The tooltip is only reachable through recharts, which cannot measure or
+// hover a chart in jsdom. Stubbing the chart primitives renders the tooltip
+// content directly with the payload recharts would have handed it.
+let tooltipPayload: TooltipEntry[] = [];
+
+vi.mock('recharts', () => ({
+  Bar: () => null,
+  BarChart: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  CartesianGrid: () => null,
+  LabelList: () => null,
+  XAxis: () => null,
+  YAxis: () => null,
+  Tooltip: ({
+    content,
+  }: {
+    content: ReactElement<{
+      active?: boolean;
+      label?: string;
+      payload?: TooltipEntry[];
+    }>;
+  }) =>
+    cloneElement(content, {
+      active: true,
+      label: 'Jan 2024',
+      payload: tooltipPayload,
+    }),
+}));
+
+// jsdom does not implement matchMedia, which the animation hook uses for
+// reduced-motion detection
+window.matchMedia = (query: string): MediaQueryList => ({
+  matches: false,
+  media: query,
+  onchange: null,
+  addListener: vi.fn(),
+  removeListener: vi.fn(),
+  addEventListener: vi.fn(),
+  removeEventListener: vi.fn(),
+  dispatchEvent: vi.fn(() => false),
+});
+
+const { StackedBarGraph } = await import('./StackedBarGraph');
+
+function makeEntry(name: string, value: number): TooltipEntry {
+  return { name, value, color: 'red', payload: { name, color: 'red' } };
+}
+
+// recharts hands the payload over in reverse order, and the tooltip reverses
+// it back, so the payload here is written last-category-first
+function renderTooltip(entries: TooltipEntry[]) {
+  tooltipPayload = entries.slice(0).reverse();
+
+  render(
+    <TestProviders>
+      <MemoryRouter>
+        <StackedBarGraph
+          data={
+            {
+              intervalData: [{ date: 'Jan 2024' }],
+              legend: entries.map(entry => ({
+                name: entry.name,
+                dataKey: entry.name,
+                color: entry.color,
+              })),
+            } as never
+          }
+          filters={[]}
+          groupBy="Category"
+          compact
+          viewLabels={false}
+          balanceTypeOp="totalDebts"
+        />
+      </MemoryRouter>
+    </TestProviders>,
+  );
+}
+
+describe('StackedBarGraph tooltip', () => {
+  it('leaves out categories with no value for the interval', () => {
+    renderTooltip([
+      makeEntry('Food', 1000),
+      makeEntry('Bills', 0),
+      makeEntry('Fun', 2000),
+    ]);
+
+    expect(screen.getByText('Food')).toBeInTheDocument();
+    expect(screen.getByText('Fun')).toBeInTheDocument();
+    expect(screen.queryByText('Bills')).not.toBeInTheDocument();
+  });
+
+  it('does not show the truncation indicator when every non-zero category is visible', () => {
+    renderTooltip([
+      makeEntry('Food', 1000),
+      makeEntry('Bills', 0),
+      makeEntry('Fun', 2000),
+      makeEntry('Rent', 0),
+      makeEntry('Travel', 3000),
+      makeEntry('Gifts', 0),
+    ]);
+
+    expect(document.body).not.toHaveTextContent('...');
+  });
+
+  it('shows the truncation indicator when there are more non-zero categories than fit', () => {
+    renderTooltip([
+      makeEntry('Food', 1000),
+      makeEntry('Bills', 2000),
+      makeEntry('Fun', 3000),
+      makeEntry('Rent', 4000),
+      makeEntry('Travel', 5000),
+      makeEntry('Gifts', 6000),
+    ]);
+
+    expect(screen.queryByText('Gifts')).not.toBeInTheDocument();
+    expect(document.body).toHaveTextContent('...');
+  });
+});

--- a/packages/desktop-client/src/components/reports/graphs/StackedBarGraph.test.tsx
+++ b/packages/desktop-client/src/components/reports/graphs/StackedBarGraph.test.tsx
@@ -63,7 +63,7 @@ function makeEntry(name: string, value: number): TooltipEntry {
 
 // recharts hands the payload over in reverse order, and the tooltip reverses
 // it back, so the payload here is written last-category-first
-function renderTooltip(entries: TooltipEntry[]) {
+function renderTooltip(entries: TooltipEntry[], { compact = true } = {}) {
   tooltipPayload = entries.slice(0).reverse();
 
   render(
@@ -82,7 +82,7 @@ function renderTooltip(entries: TooltipEntry[]) {
           }
           filters={[]}
           groupBy="Category"
-          compact
+          compact={compact}
           viewLabels={false}
           balanceTypeOp="totalDebts"
         />
@@ -129,5 +129,22 @@ describe('StackedBarGraph tooltip', () => {
 
     expect(screen.queryByText('Gifts')).not.toBeInTheDocument();
     expect(document.body).toHaveTextContent('...');
+  });
+
+  it('never truncates outside compact mode', () => {
+    renderTooltip(
+      [
+        makeEntry('Food', 1000),
+        makeEntry('Bills', 2000),
+        makeEntry('Fun', 3000),
+        makeEntry('Rent', 4000),
+        makeEntry('Travel', 5000),
+        makeEntry('Gifts', 6000),
+      ],
+      { compact: false },
+    );
+
+    expect(screen.getByText('Gifts')).toBeInTheDocument();
+    expect(document.body).not.toHaveTextContent('...');
   });
 });

--- a/packages/desktop-client/src/components/reports/graphs/StackedBarGraph.tsx
+++ b/packages/desktop-client/src/components/reports/graphs/StackedBarGraph.tsx
@@ -91,16 +91,22 @@ const CustomTooltip = ({
 
   const maxTooltipItems = 5;
 
-  const visibleItems = useMemo(() => {
-    const nonZero = items.filter(p => p.value !== 0);
-    if (!compact || nonZero.length <= maxTooltipItems) return nonZero;
+  const nonZeroItems = useMemo(() => {
+    return items.filter(p => p.value !== 0);
+  }, [items]);
 
-    const hoveredIndex = nonZero.findIndex(p => tooltip === p.name);
+  const visibleItems = useMemo(() => {
+    if (!compact || nonZeroItems.length <= maxTooltipItems) return nonZeroItems;
+
+    const hoveredIndex = nonZeroItems.findIndex(p => tooltip === p.name);
     if (hoveredIndex >= maxTooltipItems) {
-      return [...nonZero.slice(0, maxTooltipItems - 1), nonZero[hoveredIndex]];
+      return [
+        ...nonZeroItems.slice(0, maxTooltipItems - 1),
+        nonZeroItems[hoveredIndex],
+      ];
     }
-    return nonZero.slice(0, maxTooltipItems);
-  }, [compact, items, tooltip]);
+    return nonZeroItems.slice(0, maxTooltipItems);
+  }, [compact, nonZeroItems, tooltip]);
 
   if (active && items.length) {
     return (
@@ -139,7 +145,7 @@ const CustomTooltip = ({
                 />
               );
             })}
-            {compact && items.length > visibleItems.length && '...'}
+            {compact && nonZeroItems.length > visibleItems.length && '...'}
             <AlignedText
               left={t('Total')}
               right={

--- a/upcoming-release-notes/stacked-bar-tooltip-truncation-indicator.md
+++ b/upcoming-release-notes/stacked-bar-tooltip-truncation-indicator.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [bean-1129]
+---
+
+Fix the stacked bar report widget showing a truncation indicator when no categories were hidden

--- a/upcoming-release-notes/stacked-bar-tooltip-truncation-indicator.md
+++ b/upcoming-release-notes/stacked-bar-tooltip-truncation-indicator.md
@@ -3,4 +3,4 @@ category: Bugfix
 authors: [bean-1129]
 ---
 
-Fix the stacked bar report widget showing a truncation indicator when no categories were hidden
+Fix the stacked bar report showing an unnecessary "..." when all spending categories were visible


### PR DESCRIPTION
## Description

The stacked bar report widget showed a `...` truncation indicator even when no
categories were hidden. `items` includes categories whose value is zero for the
hovered interval, while `visibleItems` filters them out, so comparing the two
lengths flagged truncation whenever any category was zero that month, which
varies month to month and matches the inconsistency reported in the issue.

This lifts the non-zero filter into its own `nonZeroItems` memo and compares
against that instead. Truncation behaviour itself is unchanged; `maxTooltipItems`
and the hovered-item swap logic are untouched.

The initial implementation was drafted with Claude Code and then reviewed,
tested, and edited by me.

## Related issue(s)

Fixes #7297

## Testing

Added `StackedBarGraph.test.tsx`. The tooltip is only reachable through recharts,
which cannot measure or hover a chart in jsdom, so the test stubs the chart
primitives and renders the tooltip with the payload recharts would have handed
it. No test-only export was needed, the real `StackedBarGraph` is rendered.

Verified red-then-green rather than only green:

- With the source reverted to `db1b0ea97` and the new test in place:
  1 failed | 2 passed. The failing one is
  `does not show the truncation indicator when every non-zero category is visible`.
- With the fix applied: 3 passed.

The two passing-either-way tests are deliberate guardrails, they confirm real
truncation still happens when more than `maxTooltipItems` categories are
non-zero, and that nothing truncates outside compact mode.

Also run locally on Node 24.18.1:

- `yarn typecheck` : passes (`@actual-app/web` typechecked, not cached)
- `yarn lint` : 0 errors
- `yarn test:debug` : 9/9 packages, cache disabled

To reproduce by hand: create a stacked bar custom report grouped by category with
"Show empty rows" enabled, add it to a dashboard, and hover a month where fewer
than 6 categories have spending but at least one is zero. Before this change the
`...` appears despite nothing being hidden.

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 42 | 13.65 MB → 13.65 MB (+259 B) | +0.00%
loot-core | 1 | 4.64 MB | 0%
api | 2 | 3.85 MB | 0%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
42 | 13.65 MB → 13.65 MB (+259 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/reports/graphs/StackedBarGraph.tsx` | 📈 +259 B (+2.97%) | 8.53 kB → 8.78 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/ReportRouter.js | 1.46 MB → 1.46 MB (+259 B) | +0.02%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.67 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/DateSelect.js | 2.38 MB | 0%
static/js/FormulaEditor.js | 766.35 kB | 0%
static/js/ManageRules.js | 71.66 kB | 0%
static/js/NotesTagFormatter.js | 25.94 kB | 0%
static/js/PayeeRuleCountLabel.js | 12.81 kB | 0%
static/js/ScheduleEditForm.js | 75.41 kB | 0%
static/js/SchedulesTable.js | 171.25 kB | 0%
static/js/TourHost.js | 169.22 kB | 0%
static/js/TourProvider.js | 1.54 kB | 0%
static/js/TransactionEdit.js | 219.59 kB | 0%
static/js/TransactionList.js | 79.22 kB | 0%
static/js/Value.js | 1.79 MB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/ca.js | 170.64 kB | 0%
static/js/client.js | 452.05 kB | 0%
static/js/columns.js | 673.28 kB | 0%
static/js/de.js | 186.5 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/en.js | 245.91 kB | 0%
static/js/es.js | 164.81 kB | 0%
static/js/fr.js | 179.04 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 151.67 kB | 0%
static/js/months.js | 575.1 kB | 0%
static/js/narrow.js | 290.52 kB | 0%
static/js/nb-NO.js | 135.46 kB | 0%
static/js/nl.js | 151.78 kB | 0%
static/js/pl.js | 136.39 kB | 0%
static/js/pt-BR.js | 178.2 kB | 0%
static/js/ru.js | 213.43 kB | 0%
static/js/theme.js | 31.68 kB | 0%
static/js/uk.js | 201.7 kB | 0%
static/js/useFormatList.js | 10.22 kB | 0%
static/js/useLocalPref.js | 97.2 kB | 0%
static/js/useReducedMotion.js | 594 B | 0%
static/js/wide.js | 274.53 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 106.8 kB | 0%
static/js/zh-Hant.js | 130.92 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.64 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.D1rKdvS-.js | 4.64 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.85 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.85 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.16 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->