### PR TITLE
docker: copy missing workspace manifests

### DIFF
--- a/sync-server.Dockerfile
+++ b/sync-server.Dockerfile
@@ -9,14 +9,19 @@ WORKDIR /app
 COPY .yarn ./.yarn
 COPY yarn.lock package.json .yarnrc.yml tsconfig.json lage.config.js ./
 COPY packages/api/package.json packages/api/package.json
+COPY packages/ci-actions/package.json packages/ci-actions/package.json
+COPY packages/cli/package.json packages/cli/package.json
 COPY packages/component-library/package.json packages/component-library/package.json
 COPY packages/crdt/package.json packages/crdt/package.json
 COPY packages/desktop-client/package.json packages/desktop-client/package.json
 COPY packages/desktop-electron/package.json packages/desktop-electron/package.json
+COPY packages/docs/package.json packages/docs/package.json
 COPY packages/eslint-plugin-actual/package.json packages/eslint-plugin-actual/package.json
 COPY packages/loot-core/package.json packages/loot-core/package.json
+COPY packages/mobile-client/package.json packages/mobile-client/package.json
 COPY packages/sync-server/package.json packages/sync-server/package.json
 COPY packages/plugins-service/package.json packages/plugins-service/package.json
+COPY packages/vite-plugin-peggy/package.json packages/vite-plugin-peggy/package.json
 
 COPY ./bin/package-browser ./bin/package-browser
 

--- a/upcoming-release-notes/docker-workspace-manifests.md
+++ b/upcoming-release-notes/docker-workspace-manifests.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [hubermjonathan]
+---
+
+Copy every workspace manifest in `sync-server.Dockerfile` so the image builds


### PR DESCRIPTION
## Description

`sync-server.Dockerfile` copies a hand-listed set of `package.json` files into the `deps` stage before running `yarn install`. That list has fallen behind the workspace set: the repo has 14 workspaces under `packages/*` and the Dockerfile names 9.

Missing: `ci-actions`, `cli`, `docs`, `mobile-client`, `vite-plugin-peggy`.

The root `package.json` declares `workspaces: ["packages/*"]`, so yarn resolves the workspace set from what is actually in the build context. With five manifests absent, resolution fails outright:

```
Step 16/16 : RUN yarn install
➤ YN0000: · Yarn 4.17.1
➤ YN0000: ┌ Resolution step
➤ YN0001: │ Error: @actual-app/vite-plugin-peggy@workspace:*: Workspace not found (@actual-app/vite-plugin-peggy@workspace:*)
➤ YN0000: · Failed with errors in 0s 112ms
The command '/bin/sh -c yarn install' returned a non-zero code: 1
```

`vite-plugin-peggy` is the one that surfaces, because `api` and `loot-core` both depend on it directly.

**Why this went unnoticed:** this file is not on the release path. `docker-release.yml` and `docker-nightly.yml` build `packages/sync-server/docker/ubuntu.Dockerfile` after running `yarn build:server` on the runner, so the root `sync-server.Dockerfile` is never exercised by CI. It only breaks for people building it directly.

The fix adds the five missing `COPY` lines and nothing else, keeping the existing ordering.

*AI disclosure: this change was written with Claude Code (Claude Opus 5), per the AI usage policy.*

## Related issue(s)

None open that I could find — reporting it together with the fix.

## Testing

Reproduced against unmodified `master` (`12f4b6e22`), which fails with the error above:

```
docker build --target deps -f sync-server.Dockerfile .
```

With this branch the same command completes, and a full build succeeds:

```
docker build -f sync-server.Dockerfile -t actual-sync-server .
```

I have been running a personal sync server from an image built with these five lines since 2 September; it builds clean and the server starts, migrates and serves normally.

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed