### PR TITLE
[AI] Warn API users about deferred sync messages and fix stale docs row

### DIFF
--- a/packages/docs/docs/api/index.md
+++ b/packages/docs/docs/api/index.md
@@ -157,7 +157,7 @@ These are the codes for the common failures:
 | `missing-key`            | The budget file is end-to-end encrypted, and no encryption password was given.                       |
 | `decrypt-failure`        | The budget file could not be decrypted — the encryption password is wrong.                           |
 | `old-key-style`          | The budget file uses an old, unsupported encryption key style.                                       |
-| `out-of-sync-migrations` | The budget file needs a newer version of Actual — update the API package.                            |
+| `out-of-sync-migrations` | The budget file is damaged or from a version too old to open. Files from a newer Actual open fine.   |
 
 :::note
 `code` is present for the common connection and download failures listed above. Other errors may only carry a `message`, so always keep a fallback.

--- a/packages/loot-core/src/platform/server/connection/index.api.test.ts
+++ b/packages/loot-core/src/platform/server/connection/index.api.test.ts
@@ -1,0 +1,19 @@
+import { afterEach, expect, test, vi } from 'vitest';
+
+// oxlint-disable-next-line no-restricted-imports
+import { send } from './index.api';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+test('warns the script author about deferred and dropped sync messages only', () => {
+  const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+  send('sync-event', { type: 'success', tables: [] });
+  expect(warn).not.toHaveBeenCalled();
+
+  send('sync-event', { type: 'deferred-messages' });
+  send('sync-event', { type: 'dropped-messages' });
+  expect(warn).toHaveBeenCalledTimes(2);
+});

--- a/packages/loot-core/src/platform/server/connection/index.api.ts
+++ b/packages/loot-core/src/platform/server/connection/index.api.ts
@@ -1,11 +1,28 @@
+import { logger } from '#platform/server/log';
+import type { ServerEvents } from '#types/server-events';
+
 import type * as T from './index-types';
 
 export const init: T.Init = function () {
   // Nothing
 };
 
-export const send: T.Send = function () {
-  // Nothing
+// The API has no UI for server events; the two below mean synced data is
+// parked on (or lost from) this device, so surface them to the script author
+export const send: T.Send = function (type, args) {
+  if (type !== 'sync-event' || !args) {
+    return;
+  }
+  const event = args as ServerEvents['sync-event'];
+  if (event.type === 'deferred-messages') {
+    logger.warn(
+      'Some synced changes were made with a newer version of Actual and will apply once @actual-app/api is updated',
+    );
+  } else if (event.type === 'dropped-messages') {
+    logger.warn(
+      'Some changes made on another device could not be applied on this device, so your data may differ',
+    );
+  }
 };
 
 export const getNumClients: T.GetNumClients = function () {

--- a/upcoming-release-notes/api-warn-deferred-sync-changes.md
+++ b/upcoming-release-notes/api-warn-deferred-sync-changes.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [MatissJanis]
+---
+
+Warn API and CLI users when synced changes from a newer version of Actual are waiting for an update


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

Add warnings for cli/api users: when messages are deferred or dropped.

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

n/a

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

unit test added

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 42 | 13.77 MB | 0%
loot-core | 1 | 4.64 MB | 0%
api | 2 | 3.86 MB → 3.86 MB (+400 B) | +0.01%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
42 | 13.77 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.67 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/DateSelect.js | 2.38 MB | 0%
static/js/FormulaEditor.js | 766.35 kB | 0%
static/js/ManageRules.js | 71.66 kB | 0%
static/js/NotesTagFormatter.js | 25.94 kB | 0%
static/js/PayeeRuleCountLabel.js | 12.81 kB | 0%
static/js/ReportRouter.js | 1.48 MB | 0%
static/js/ScheduleEditForm.js | 75.41 kB | 0%
static/js/SchedulesTable.js | 171.25 kB | 0%
static/js/TourHost.js | 169.22 kB | 0%
static/js/TourProvider.js | 1.54 kB | 0%
static/js/TransactionEdit.js | 219.59 kB | 0%
static/js/TransactionList.js | 166.98 kB | 0%
static/js/Value.js | 1.79 MB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/ca.js | 170.64 kB | 0%
static/js/client.js | 452.05 kB | 0%
static/js/columns.js | 673.28 kB | 0%
static/js/de.js | 186.5 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/en.js | 258.91 kB | 0%
static/js/es.js | 164.81 kB | 0%
static/js/fr.js | 178.66 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 151.67 kB | 0%
static/js/months.js | 575.1 kB | 0%
static/js/narrow.js | 290.52 kB | 0%
static/js/nb-NO.js | 135.46 kB | 0%
static/js/nl.js | 151.78 kB | 0%
static/js/pl.js | 136.39 kB | 0%
static/js/pt-BR.js | 178.2 kB | 0%
static/js/ru.js | 212.44 kB | 0%
static/js/theme.js | 31.68 kB | 0%
static/js/uk.js | 201.7 kB | 0%
static/js/useFormatList.js | 10.22 kB | 0%
static/js/useLocalPref.js | 97.2 kB | 0%
static/js/useReducedMotion.js | 594 B | 0%
static/js/wide.js | 274.53 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 106.8 kB | 0%
static/js/zh-Hant.js | 130.92 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.64 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.CwcCF9J4.js | 4.64 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.86 MB → 3.86 MB (+400 B) | +0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/platform/server/connection/index.api.ts` | 📈 +400 B (+258.06%) | 155 B → 555 B
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.86 MB → 3.86 MB (+400 B) | +0.01%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.16 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->