### PR TITLE
[AI] Fix clearing the payee when editing a transaction on mobile

### DIFF
--- a/packages/desktop-client/e2e/transactions.mobile.test.ts
+++ b/packages/desktop-client/e2e/transactions.mobile.test.ts
@@ -79,6 +79,36 @@ test.describe('Mobile Transactions', () => {
 - textbox [disabled]: just a note`);
   });
 
+  test('removes the payee from a new transaction', async () => {
+    const accountsPage = await navigation.goToAccountsPage();
+    const accountPage = await accountsPage.openNthAccount(2);
+    const transactionEntryPage = await accountPage.clickCreateTransaction();
+
+    await transactionEntryPage.fillAmount('12.34');
+    // Click anywhere to cancel active edit.
+    await transactionEntryPage.header.click();
+    await transactionEntryPage.fillField(
+      page.getByTestId('payee-field'),
+      'Kroger',
+    );
+    await expect(page.getByTestId('payee-field')).toContainText('Kroger');
+
+    // Reopen the payee selector and clear it with the "No payee" option.
+    await page.getByTestId('payee-field').click();
+    await page.getByRole('button', { name: 'No payee' }).click();
+    await expect(page.getByTestId('payee-field')).not.toContainText('Kroger');
+
+    await transactionEntryPage.fillField(
+      page.getByTestId('category-field'),
+      'Clothing',
+    );
+    await transactionEntryPage.createTransaction();
+
+    await expect(accountPage.transactions.nth(0)).toHaveText(
+      '(No payee)Clothing-12.34',
+    );
+  });
+
   test('creates a transaction from `/accounts/:id` page', async () => {
     const accountsPage = await navigation.goToAccountsPage();
     const accountPage = await accountsPage.openNthAccount(2);

--- a/packages/desktop-client/src/components/mobile/transactions/TransactionEdit.tsx
+++ b/packages/desktop-client/src/components/mobile/transactions/TransactionEdit.tsx
@@ -994,6 +994,7 @@ const TransactionEditInner = memo<TransactionEditInnerProps>(
                   modal: {
                     name: 'payee-autocomplete',
                     options: {
+                      showNoneOption: !!transactionToEdit.payee,
                       onSelect: payeeId => {
                         void onUpdateInner(transactionToEdit, name, payeeId);
                       },

--- a/packages/desktop-client/src/components/modals/PayeeAutocompleteModal.tsx
+++ b/packages/desktop-client/src/components/modals/PayeeAutocompleteModal.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 
+import { Button } from '@actual-app/components/button';
 import { useResponsive } from '@actual-app/components/hooks/useResponsive';
 import { theme } from '@actual-app/components/theme';
+import { View } from '@actual-app/components/view';
 
 import { PayeeAutocomplete } from '#components/autocomplete/PayeeAutocomplete';
 import {
@@ -23,6 +25,7 @@ type PayeeAutocompleteModalProps = Extract<
 
 export function PayeeAutocompleteModal({
   onSelect,
+  showNoneOption,
   onClose,
 }: PayeeAutocompleteModalProps) {
   const { t } = useTranslation();
@@ -69,20 +72,37 @@ export function PayeeAutocompleteModal({
               }
             />
           )}
-          <PayeeAutocomplete
-            payees={payees}
-            accounts={accounts}
-            focused
-            embedded
-            closeOnBlur={false}
-            onClose={() => state.close()}
-            onManagePayees={onManagePayees}
-            showManagePayees={!isNarrowWidth}
-            showMakeTransfer={!isNarrowWidth}
-            {...defaultAutocompleteProps}
-            onSelect={onSelect}
-            value={null}
-          />
+          <View>
+            <View style={{ flex: 1 }}>
+              <PayeeAutocomplete
+                payees={payees}
+                accounts={accounts}
+                focused
+                embedded
+                closeOnBlur={false}
+                onClose={() => state.close()}
+                onManagePayees={onManagePayees}
+                showManagePayees={!isNarrowWidth}
+                showMakeTransfer={!isNarrowWidth}
+                {...defaultAutocompleteProps}
+                onSelect={onSelect}
+                value={null}
+              />
+            </View>
+            {showNoneOption && (
+              <View style={{ flexShrink: 0, padding: 5 }}>
+                <Button
+                  variant="menu"
+                  onPress={() => {
+                    onSelect(null);
+                    state.close();
+                  }}
+                >
+                  <Trans>No payee</Trans>
+                </Button>
+              </View>
+            )}
+          </View>
         </>
       )}
     </Modal>

--- a/packages/desktop-client/src/components/transactions/TransactionsTable.tsx
+++ b/packages/desktop-client/src/components/transactions/TransactionsTable.tsx
@@ -695,7 +695,7 @@ function PayeeCell({
               modal: {
                 name: 'payee-autocomplete',
                 options: {
-                  onSelect: (payeeId: PayeeEntity['id']) => {
+                  onSelect: (payeeId: PayeeEntity['id'] | null) => {
                     onUpdate('payee', payeeId);
                   },
                 },

--- a/packages/desktop-client/src/components/util/GenericInput.tsx
+++ b/packages/desktop-client/src/components/util/GenericInput.tsx
@@ -170,6 +170,9 @@ export const GenericInput = ({
                         name: 'payee-autocomplete',
                         options: {
                           onSelect: newValue => {
+                            if (newValue === null) {
+                              return;
+                            }
                             if (props.multi === true) {
                               props.onChange([...props.value, newValue]);
                               return;

--- a/packages/desktop-client/src/modals/modalsSlice.ts
+++ b/packages/desktop-client/src/modals/modalsSlice.ts
@@ -316,7 +316,8 @@ export type Modal =
   | {
       name: 'payee-autocomplete';
       options: {
-        onSelect: (payeeId: string) => void;
+        onSelect: (payeeId: string | null) => void;
+        showNoneOption?: boolean;
         onClose?: () => void;
       };
     }

--- a/upcoming-release-notes/fix-mobile-clear-payee.md
+++ b/upcoming-release-notes/fix-mobile-clear-payee.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [danielnieto]
+---
+
+Fix clearing the payee when editing a transaction on mobile


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

When creating a new transaction on mobile/pwa and selecting a Payee, there was no way to clear the selection. Following the same pattern to clear out a category I've added a "No Payee" (already translated) button at the bottom of the modal.

<img width="389" height="841" alt="image" src="https://github.com/user-attachments/assets/90b94390-4dca-4df0-92a4-51a810353a31" />

**AI Disclaimer:** I used Deepseek Harness and Pi with Deepseek 4.1 Flash, I verified the changes myself and manually tested the flow.

<!-- If AI tools wrote a significant part of this change, please disclose it here and name the tool you used. See https://actualbudget.org/docs/contributing/ai-usage-policy -->

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

## Testing

**Steps to reproduce:**
- Create a new transaction in "Mobile"
- Select a payee
- Try to remove the payee

**Expected result:**
- There is a way to remove the previously selected payee, since creating a transaction without a Payee is a valid use case.

**Actual result:**
- There is no way to remove the selected payee.

**What I tested:**
- Verify that the "No payee" button doesn't show up when you haven't selected a payee.
- Verify "No payee" button shows up after you have selected a payee


## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 42 | 13.77 MB → 13.77 MB (+665 B) | +0.00%
loot-core | 1 | 4.64 MB | 0%
api | 2 | 3.86 MB | 0%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
42 | 13.77 MB → 13.77 MB (+665 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/modals/PayeeAutocompleteModal.tsx` | 📈 +572 B (+34.35%) | 1.63 kB → 2.18 kB
`src/components/util/GenericInput.tsx` | 📈 +43 B (+0.54%) | 7.75 kB → 7.79 kB
`src/components/mobile/transactions/TransactionEdit.tsx` | 📈 +50 B (+0.09%) | 54.05 kB → 54.1 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.68 MB → 1.68 MB (+572 B) | +0.03%
static/js/TransactionEdit.js | 219.59 kB → 219.64 kB (+50 B) | +0.02%
static/js/Value.js | 1.79 MB → 1.79 MB (+43 B) | +0.00%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/DateSelect.js | 2.38 MB | 0%
static/js/FormulaEditor.js | 766.35 kB | 0%
static/js/ManageRules.js | 71.66 kB | 0%
static/js/NotesTagFormatter.js | 25.94 kB | 0%
static/js/PayeeRuleCountLabel.js | 12.81 kB | 0%
static/js/ReportRouter.js | 1.48 MB | 0%
static/js/ScheduleEditForm.js | 75.41 kB | 0%
static/js/SchedulesTable.js | 171.25 kB | 0%
static/js/TourHost.js | 169.22 kB | 0%
static/js/TourProvider.js | 1.54 kB | 0%
static/js/TransactionList.js | 166.98 kB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/ca.js | 170.64 kB | 0%
static/js/client.js | 452.05 kB | 0%
static/js/columns.js | 673.28 kB | 0%
static/js/de.js | 186.5 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/en.js | 258.91 kB | 0%
static/js/es.js | 164.81 kB | 0%
static/js/fr.js | 178.66 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 151.67 kB | 0%
static/js/months.js | 575.1 kB | 0%
static/js/narrow.js | 290.52 kB | 0%
static/js/nb-NO.js | 135.46 kB | 0%
static/js/nl.js | 151.78 kB | 0%
static/js/pl.js | 136.39 kB | 0%
static/js/pt-BR.js | 178.2 kB | 0%
static/js/ru.js | 212.44 kB | 0%
static/js/theme.js | 31.68 kB | 0%
static/js/uk.js | 201.7 kB | 0%
static/js/useFormatList.js | 10.22 kB | 0%
static/js/useLocalPref.js | 97.2 kB | 0%
static/js/useReducedMotion.js | 594 B | 0%
static/js/wide.js | 274.53 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 106.8 kB | 0%
static/js/zh-Hant.js | 130.92 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.64 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.CwcCF9J4.js | 4.64 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.86 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.86 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.16 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->