### PR TITLE
[WIP] Discard repeated Enable Banking page instead of importing it twice

### DIFF
--- a/packages/sync-server/src/app-enablebanking/services/enablebanking-service.ts
+++ b/packages/sync-server/src/app-enablebanking/services/enablebanking-service.ts
@@ -437,8 +437,9 @@ export const enableBankingService = {
         continuationKey,
         psuHeaders,
       );
-      allTransactions.push(...result.transactions);
-
+      // Some ASPSPs (e.g. Trade Republic) return the same continuation_key
+      // together with the same page of transactions again. Detect the repeat
+      // before appending, otherwise the whole page is imported twice.
       if (
         result.continuation_key &&
         result.continuation_key === continuationKey
@@ -446,6 +447,7 @@ export const enableBankingService = {
         break;
       }
 
+      allTransactions.push(...result.transactions);
       continuationKey = result.continuation_key;
       iteration++;
     } while (continuationKey && iteration < maxIterations);

--- a/packages/sync-server/src/app-enablebanking/services/tests/enablebanking-service.spec.ts
+++ b/packages/sync-server/src/app-enablebanking/services/tests/enablebanking-service.spec.ts
@@ -490,13 +490,16 @@ describe('enableBankingService', () => {
       expect(result).toHaveLength(0);
     });
 
-    it('breaks out of pagination when continuation_key repeats', async () => {
+    it('discards the repeated page when continuation_key repeats', async () => {
+      // Some ASPSPs (e.g. Trade Republic) answer a continuation_key request
+      // with the exact same page and the exact same key again. The repeated
+      // page must not be appended, otherwise every transaction is duplicated.
       mockFetchResponse({
         transactions: [mockCreditTransaction],
         continuation_key: 'stuck-key',
       });
       mockFetchResponse({
-        transactions: [mockDebitTransaction],
+        transactions: [mockCreditTransaction],
         continuation_key: 'stuck-key',
       });
 
@@ -507,7 +510,7 @@ describe('enableBankingService', () => {
       );
 
       expect(mockFetch).toHaveBeenCalledTimes(2);
-      expect(result).toHaveLength(2);
+      expect(result).toHaveLength(1);
     });
   });
 

--- a/upcoming-release-notes/8927.md
+++ b/upcoming-release-notes/8927.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [tinyoverflow]
+---
+
+Fix Enable Banking sync duplicating every transaction when the bank repeats the pagination continuation key (e.g. Trade Republic)


### PR DESCRIPTION
Some ASPSPs — Trade Republic being the confirmed case, see the reports in #7799 — answer a `continuation_key` request with the exact same page of transactions and the exact same `continuation_key` again.

`getAllTransactions()` already guards against a repeated `continuation_key`, but the check runs *after* the page has been appended to `allTransactions`, so the whole repeated page is returned twice. Because Trade Republic also provides neither `entry_reference` nor `transaction_id` (so `imported_id` is empty and ID-based dedup can't catch it), every one of those transactions is imported as a duplicate on sync.

This PR moves the repeated-key check before the append, so the repeated page is discarded instead of imported. The existing pagination test asserted the old behavior (repeated page kept); it is updated to assert the page is discarded, and its fixture now mirrors the real-world case where the repeated page contains the same transactions.

Verified against a real Trade Republic account via Enable Banking: the raw payload carries the same page again with an identical `continuation_key`, producing exactly one duplicate per transaction per sync before this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)