### PR TITLE
[WIP] Fix API password login when OpenID is configured alongside password auth

### DIFF
--- a/packages/sync-server/src/account-db.js
+++ b/packages/sync-server/src/account-db.js
@@ -64,11 +64,7 @@ export function getLoginMethod(req) {
     (req.body || { loginMethod: null }).loginMethod &&
     config.get('allowedLoginMethods').includes(req.body.loginMethod)
   ) {
-    const accountDb = getAccountDb();
-    const row = accountDb.first('SELECT method FROM auth WHERE method = ?', [
-      req.body.loginMethod,
-    ]);
-    if (row) return req.body.loginMethod;
+    return req.body.loginMethod;
   }
 
   //BY-PASS ANY OTHER CONFIGURATION TO ENSURE HEADER AUTH

--- a/packages/sync-server/src/app-account.test.js
+++ b/packages/sync-server/src/app-account.test.js
@@ -206,10 +206,10 @@ describe('getLoginMethod()', () => {
     expect(getLoginMethod(req)).toBe('password');
   });
 
-  it('ignores a client-requested method that is not in DB', () => {
+  it('honors a client-requested allowed method even when it has no auth row', () => {
     insertAuthRow('openid', 1);
     const req = { body: { loginMethod: 'password' } };
-    expect(getLoginMethod(req)).toBe('openid');
+    expect(getLoginMethod(req)).toBe('password');
   });
 
   it('falls back to config default when auth table is empty and no req', () => {
@@ -253,6 +253,32 @@ describe('/login', () => {
 
     expect(res.statusCode).toEqual(400);
     expect(res.body).toHaveProperty('reason', 'invalid-password');
+  });
+
+  it('should route an explicit password login to the password handler when OpenID is the only configured method', async () => {
+    // Simulate an OpenID-only env bootstrap (app.ts run()): only an openid row exists.
+    insertAuthRow('openid', 1);
+
+    const res = await request(app)
+      .post('/login')
+      .send({ loginMethod: 'password', password: 'whatever' });
+
+    // The request must NOT be diverted into the OpenID redirect flow.
+    expect(res.statusCode).toEqual(400);
+    expect(res.body.reason).not.toEqual('Invalid redirect URL');
+    expect(res.body.reason).toEqual('invalid-password');
+  });
+
+  it('should not silently fall back to password when openid is explicitly requested but not configured', async () => {
+    await bootstrapPassword('testpassword');
+    // only a password row exists; no openid row
+
+    const res = await request(app)
+      .post('/login')
+      .send({ loginMethod: 'openid', returnUrl: 'http://localhost/callback' });
+
+    expect(res.statusCode).toEqual(400);
+    expect(res.body.reason).toEqual('Invalid redirect URL');
   });
 });
 

--- a/upcoming-release-notes/fix-password-login-openid.md
+++ b/upcoming-release-notes/fix-password-login-openid.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [lorenzozanee]
+---
+
+Route an explicit password login request to the password handler instead of the OpenID redirect flow when OpenID is configured via environment variables.


### PR DESCRIPTION
## Description

When linking a pluggy.ai account whose bank reports automatically invested balances, the account list computed the balance as a raw float sum of `automaticallyInvestedBalance + closingBalance`. With values like `55807.2 + 27903.6` this produces `83710.79999999999`, and rendering that balance in the link dialog goes through the number-formatting string path, which mangles the value into an integer that `safeNumber` rejects — so the balance shows wrong amounts and linking the account fails with an error.

This extracts the pluggy account mapping into `mapPluggyAiExternalAccounts` in `bankSyncUtils.ts` and computes balances in integer cents with `amountToInteger` — the same convention the sync server already uses for pluggy balances (`Math.round(balance * 100)`).

Note: the displayed balance for non-BANK pluggy accounts also becomes correct (previously single-decimal values displayed off by 10x). SimpleFin/Akahu still pass raw units through the same display path — left untouched here, could be a follow-up.

## Related issue(s)

Fixes #6345

## Testing

Added a regression test in `bankSyncUtils.test.ts` using a fixture payload with the values from the issue (`55807.2 + 27903.6`): the mapped balance must be `8371080` (integer cents). The test fails against the old float addition (produces `83710.79999999999`) and passes with the fix. All bank-sync-scoped desktop-client tests pass (8/8) and the strict typecheck passes.

## Checklist

- [ ] Release notes added (see link above)
- [ ] No obvious regressions in affected areas
- [ ] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 42 | 13.6 MB → 13.6 MB (+94 B) | +0.00%
loot-core | 1 | 4.64 MB | 0%
api | 2 | 3.85 MB | 0%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
42 | 13.6 MB → 13.6 MB (+94 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/banksync/bankSyncUtils.ts` | 📈 +493 B (+31.70%) | 1.52 kB → 2 kB
`src/components/banksync/useBuiltInBankSyncProviders.ts` | 📉 -399 B (-2.50%) | 15.61 kB → 15.22 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/ManageRules.js | 71.66 kB → 71.75 kB (+94 B) | +0.13%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.58 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/DateSelect.js | 2.37 MB | 0%
static/js/FormulaEditor.js | 766.35 kB | 0%
static/js/NotesTagFormatter.js | 25.94 kB | 0%
static/js/PayeeRuleCountLabel.js | 12.81 kB | 0%
static/js/ReportRouter.js | 1.43 MB | 0%
static/js/ScheduleEditForm.js | 75.41 kB | 0%
static/js/SchedulesTable.js | 171.25 kB | 0%
static/js/TourHost.js | 169.22 kB | 0%
static/js/TourProvider.js | 1.54 kB | 0%
static/js/TransactionEdit.js | 221.38 kB | 0%
static/js/TransactionList.js | 166.98 kB | 0%
static/js/Value.js | 1.79 MB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/ca.js | 170.64 kB | 0%
static/js/client.js | 452.05 kB | 0%
static/js/columns.js | 673.28 kB | 0%
static/js/de.js | 185 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/en.js | 245.91 kB | 0%
static/js/es.js | 164.81 kB | 0%
static/js/fr.js | 179.04 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 151.67 kB | 0%
static/js/months.js | 574.72 kB | 0%
static/js/narrow.js | 290.52 kB | 0%
static/js/nb-NO.js | 135.46 kB | 0%
static/js/nl.js | 151.78 kB | 0%
static/js/pl.js | 136.39 kB | 0%
static/js/pt-BR.js | 178.2 kB | 0%
static/js/ru.js | 209.56 kB | 0%
static/js/theme.js | 31.1 kB | 0%
static/js/uk.js | 199.25 kB | 0%
static/js/useFormatList.js | 10.22 kB | 0%
static/js/useLocalPref.js | 97.2 kB | 0%
static/js/useReducedMotion.js | 594 B | 0%
static/js/wide.js | 274.04 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 106.8 kB | 0%
static/js/zh-Hant.js | 130.92 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.64 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.CokRHpI5.js | 4.64 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.85 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.85 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.16 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->


Supercedes #8814（原PR分支已删，按原提交重建）
